### PR TITLE
Add graded tasks to feedback and admin

### DIFF
--- a/src/app/common/partials/directives/grade-icon.coffee
+++ b/src/app/common/partials/directives/grade-icon.coffee
@@ -7,8 +7,10 @@ angular.module('doubtfire.common.grade-icon', [])
   scope:
     inputGrade: '=?grade'
   controller: ($scope, gradeService) ->
-    $scope.grade = if _.isString($scope.inputGrade) then gradeService.grades.indexOf($scope.inputGrade) else $scope.inputGrade
-    $scope.gradeText = (grade) ->
-      if $scope.grade? then gradeService.grades[$scope.grade] or "Grade"
-    $scope.gradeLetter = (grade) ->
-      gradeService.gradeAcronyms[$scope.gradeText(grade)] or 'G'
+    $scope.$watch 'inputGrade', (newGrade) ->
+      return unless newGrade?
+      $scope.grade = if _.isString($scope.inputGrade) then gradeService.grades.indexOf($scope.inputGrade) else $scope.inputGrade
+      $scope.gradeText = (grade) ->
+        if $scope.grade? then gradeService.grades[$scope.grade] or "Grade"
+      $scope.gradeLetter = (grade) ->
+        gradeService.gradeAcronyms[$scope.gradeText(grade)] or 'G'

--- a/src/app/common/services/task-service.coffee
+++ b/src/app/common/services/task-service.coffee
@@ -297,5 +297,8 @@ angular.module("doubtfire.services.tasks", [])
         alertService.add("danger", "Request failed, cannot recreate PDF at this time.", 2000)
         analyticsService.event 'Task Service', 'Failed to Recreate PDF'
 
+  taskService.taskIsGraded = (task) ->
+    task.definition.is_graded and task.grade?
+
   taskService
 )

--- a/src/app/common/services/task-service.coffee
+++ b/src/app/common/services/task-service.coffee
@@ -262,7 +262,7 @@ angular.module("doubtfire.services.tasks", [])
       if project.updateBurndownChart?
         project.updateBurndownChart()
       alertService.add("success", "Status saved.", 2000)
-      $rootScope.$broadcast('TaskStatusUpdated')
+      $rootScope.$broadcast('TaskStatusUpdated', { status: response.status })
       if response.other_projects?
         _.each response.other_projects, (details) ->
           proj = unit.findStudent(details.id)

--- a/src/app/common/services/task-service.coffee
+++ b/src/app/common/services/task-service.coffee
@@ -287,7 +287,7 @@ angular.module("doubtfire.services.tasks", [])
           alertService.add("danger", value.data.error, 6000)
           analyticsService.event 'Task Service', 'Failed to Update Task Status', status
     # Must provide grade if graded and in a final complete state
-    if task.definition.is_graded and status in ['complete', 'discuss', 'demonstrate']
+    if task.definition.is_graded and status in taskService.gradeableStatuses
       GradeTaskModal.show(task).result.then(
         # Grade was selected (modal closed with result)
         (selectedGrade) ->

--- a/src/app/tasks/partials/directives/grade-task-modal.coffee
+++ b/src/app/tasks/partials/directives/grade-task-modal.coffee
@@ -1,0 +1,24 @@
+angular.module('doubtfire.tasks.partials.modals.grade-task-modal', [])
+.factory('GradeTaskModal', ($modal) ->
+  GradeTaskModal = {}
+
+  #
+  # Open a grade task modal with the provided task
+  #
+  GradeTaskModal.show = (task) ->
+    $modal.open
+      templateUrl: 'tasks/partials/templates/grade-task-modal.tpl.html'
+      controller: 'GradeTaskModal'
+      resolve:
+        task: -> task
+
+  GradeTaskModal
+)
+.controller('GradeTaskModal', ($scope, $modalInstance, gradeService, task) ->
+  $scope.task = task
+  $scope.data = { desiredGrade: null }
+  $scope.grades = gradeService.grades
+  $scope.dismiss = $modalInstance.dismiss
+  $scope.close = ->
+    $modalInstance.close $scope.data.desiredGrade
+)

--- a/src/app/tasks/partials/directives/provide-task-feedback.coffee
+++ b/src/app/tasks/partials/directives/provide-task-feedback.coffee
@@ -15,6 +15,8 @@ angular.module('doubtfire.tasks.partials.provide-task-feedback',[])
 
     $scope.triggerTransition = (status) ->
       taskService.updateTaskStatus($scope.unit, $scope.task.project(), $scope.task, status)
-      if $scope.onStatusUpdate? && _.isFunction($scope.onStatusUpdate)
-        $scope.onStatusUpdate(status)
+
+    if $scope.onStatusUpdate? && _.isFunction($scope.onStatusUpdate)
+      $scope.$on 'TaskStatusUpdated', (event, args) ->
+        $scope.onStatusUpdate(args.status)
 )

--- a/src/app/tasks/partials/directives/task-feedback-directive.coffee
+++ b/src/app/tasks/partials/directives/task-feedback-directive.coffee
@@ -86,6 +86,12 @@ angular.module('doubtfire.tasks.partials.task-feedback-directive', [])
       $scope.taskIsGraded = taskService.taskIsGraded newTask
 
     #
+    # Watch grade for changes
+    #
+    $scope.$watch 'project.selectedTask.grade', ->
+      $scope.taskIsGraded = taskService.taskIsGraded $scope.project.selectedTask
+
+    #
     # Loading the active task
     #
     $scope.setSelectedTask = (task) ->

--- a/src/app/tasks/partials/directives/task-feedback-directive.coffee
+++ b/src/app/tasks/partials/directives/task-feedback-directive.coffee
@@ -82,6 +82,8 @@ angular.module('doubtfire.tasks.partials.task-feedback-directive', [])
               $scope.setActiveTab($scope.tabs.taskSheet)
       else
         $scope.setActiveTab($scope.tabs.taskSheet)
+      # Update the task grade if applicable
+      $scope.taskIsGraded = taskService.taskIsGraded newTask
 
     #
     # Loading the active task

--- a/src/app/tasks/partials/directives/task-modals.coffee
+++ b/src/app/tasks/partials/directives/task-modals.coffee
@@ -1,1 +1,3 @@
-angular.module('doubtfire.tasks.partials.modals', [])
+angular.module('doubtfire.tasks.partials.modals', [
+  'doubtfire.tasks.partials.modals.grade-task-modal'
+])

--- a/src/app/tasks/partials/templates/grade-task-modal.tpl.html
+++ b/src/app/tasks/partials/templates/grade-task-modal.tpl.html
@@ -1,0 +1,21 @@
+<div>
+  <div class="modal-header">
+    <h3>Provide Grade</h3>
+  </div>
+  <div class="modal-body text-center">
+    <p>Please provide a grade to change the student's status for task <label class="label label-info">{{task.abbreviation}}</label>.</p>
+    <p class="btn-group">
+      <label ng-repeat="grade in grades" class="btn btn-default col-sm-3 text-center" ng-model="data.desiredGrade" btn-radio="{{$index}}">
+        <grade-icon grade="grade" tooltip="This student completed the task to a {{grade}} standard" tooltip-append-to-body="true"></grade-icon>
+      </label>
+    </p>
+  </div>
+  <div class="modal-footer">
+    <button class="btn btn-default" ng-click="dismiss()">
+      <i class="fa fa-times"></i>
+    </button>
+    <button class="btn btn-primary" ng-click="close()" ng-disabled="data.desiredGrade == null">
+      <i class="fa fa-check"></i>
+    </button>
+  </div>
+</div>

--- a/src/app/tasks/partials/templates/task-admin.tpl.html
+++ b/src/app/tasks/partials/templates/task-admin.tpl.html
@@ -73,6 +73,16 @@
                 </div><!--/restricted-->
 
                 <div class="form-group" ng-required="isNew">
+                  <label class="col-sm-3 control-label">Graded</label>
+                  <button type="button" class="btn btn-default col-sm-1" ng-model="task.is_graded" btn-checkbox btn-checkbox-true="1" btn-checkbox-false="0">
+                    <i class="fa fa-{{task.is_graded ? 'check' : 'times'}}"></i>
+                  </button>
+                  <span class="help-block col-sm-6">
+                    If true, the task will be assessed with a grade to a specific standard. For example, <em>the task was completed to a HD standard</em>.
+                  </span>
+                </div><!--/graded-task-->
+
+                <div class="form-group" ng-required="isNew">
                   <label tooltip="Date students should aim to start this task." class="col-sm-3 control-label">Start Date</label>
                   <div class="col-sm-8 input-group">
                     <input datepicker-popup="yyyy-MM-dd" is-open="startPicker.open" type="text" class="form-control" ng-model="task.start_date" placeholder="yyyy-MM-dd" close-text="Close" />

--- a/src/app/tasks/partials/templates/task-feedback.tpl.html
+++ b/src/app/tasks/partials/templates/task-feedback.tpl.html
@@ -22,7 +22,7 @@
         <h3>{{project.selectedTask.definition.name}}</h3>
         <p class="help-block">{{activeStatusData().helpText}}</p>
         <div class="graded-task-mark text-danger" ng-if="taskIsGraded">
-          Your tutor has marked you on this task to a <grade-icon grade="{{project.selectedTask.grade}}"></grade-icon> standard.
+          Your tutor has marked you on this task to a <grade-icon grade="project.selectedTask.grade"></grade-icon> standard.
         </div>
       </div>
       <div class="col-sm-4 date-info">

--- a/src/app/tasks/partials/templates/task-feedback.tpl.html
+++ b/src/app/tasks/partials/templates/task-feedback.tpl.html
@@ -18,16 +18,18 @@
         </ul>
     </div><!--/active-task-switcher-->
     <div class="task-header-info col-sm-10">
-      <div class="col-sm-7 task-description">
+      <div class="col-sm-8 task-status-summary">
         <h3>{{project.selectedTask.definition.name}}</h3>
         <p class="help-block">{{activeStatusData().helpText}}</p>
+        <div class="graded-task-mark text-danger" ng-if="taskIsGraded">
+          Your tutor has marked you on this task to a <grade-icon grade="{{project.selectedTask.grade}}"></grade-icon> standard.
+        </div>
       </div>
       <div class="col-sm-4 date-info">
         <div class="overdue label label-{{daysOverdue(project.selectedTask) > 5 ? 'danger' : 'warning'}}" ng-hide="daysOverdue(project.selectedTask) === false" tooltip="Tasks are overdue until they are discussed with your tutor." tooltip-placement="right">
           <i class="fa fa-exclamation-triangle"></i>
           Past Target By <br/> {{daysOverdue(project.selectedTask)}} day{{daysOverdue(project.selectedTask) > 1 ? 's' : ''}}
         </div>
-
         <p class="due-date" tooltip="You should aim to complete the task by this date" tooltip-placement="right">
           <label>Target:</label> {{project.selectedTask.definition.target_date | date:'EEE MMM d'}}
         </p>

--- a/src/less/common.less
+++ b/src/less/common.less
@@ -25,8 +25,12 @@ ul.nav.nav-tabs {
   margin-bottom: 20px;
 }
 
-a {
+a, .pointer {
   cursor: pointer;
+}
+
+.strong {
+  font-weight: bold;
 }
 
 .row {
@@ -60,10 +64,6 @@ a {
 .ui-select-bootstrap .ui-select-choices-row.active > a {
   color: #333;
   background-color: inherit;
-}
-
-.pointer {
-  cursor: pointer;
 }
 
 .large-notice-block {

--- a/src/less/modules/task-feedback.less
+++ b/src/less/modules/task-feedback.less
@@ -8,10 +8,20 @@
 }
 
 .task-feedback .task-header-info {
-  .task-description {
+  margin-bottom: 1em;
+  .task-status-summary {
     float: left;
     h3 {
       margin: 0;
+    }
+    .graded-task-mark {
+      font-weight: bold;
+      .grade-icon {
+        display: inline-block;
+        text-align: center;
+        line-height: 2.25em;
+        margin: 0 0.5ex;
+      }
     }
   }
   .overdue.label {
@@ -29,7 +39,6 @@
     display: inline-block;
   }
   .date-info {
-    float: right;
     text-align: right;
     .due-date {
       margin: 0;


### PR DESCRIPTION
This pull request adds graded task functionality to the app.

- Tasks can now be marked as graded tasks in the unit's task admin panel.
- Tasks that are marked by tutors in either a `complete`, `discuss` or `demonstrate` state for tasks that are graded tasks will be prompted by tutors select the desired grade for that task
- Graded task feedback is displayed underneath the task status in the task feedback panel