### PR TITLE
Reduce calendar field width

### DIFF
--- a/src/app/tasks/partials/templates/task-admin.tpl.html
+++ b/src/app/tasks/partials/templates/task-admin.tpl.html
@@ -74,7 +74,7 @@
 
                 <div class="form-group" ng-required="isNew">
                   <label tooltip="Date students should aim to start this task." class="col-sm-3 control-label">Start Date</label>
-                  <div class="col-sm-8 input-group">
+                  <div class="col-sm-4 input-group">
                     <input datepicker-popup="yyyy-MM-dd" is-open="startPicker.open" type="text" class="form-control" ng-model="task.start_date" placeholder="yyyy-MM-dd" close-text="Close" />
                     <span class="input-group-btn">
                       <button class="btn btn-default" ng-click="open($event, startPicker)"><i class="glyphicon glyphicon-calendar"></i></button>
@@ -84,7 +84,7 @@
 
                 <div class="form-group" ng-required="isNew">
                   <label tooltip="Date students should aim to complete this task." class="col-sm-3 control-label">Target Date</label>
-                  <div class="col-sm-8 input-group">
+                  <div class="col-sm-4 input-group">
                     <input datepicker-popup="yyyy-MM-dd" is-open="targetPicker.open" type="text" class="form-control" ng-model="task.target_date" placeholder="yyyy-MM-dd" close-text="Close" />
                     <span class="input-group-btn">
                       <button class="btn btn-default" ng-click="open($event, targetPicker)"><i class="glyphicon glyphicon-calendar"></i></button>
@@ -94,7 +94,7 @@
 
                 <div class="form-group">
                   <label tooltip="Date after which task submissions will not appear for feedback. Can be empty." class="col-sm-3 control-label">Due Date</label>
-                  <div class="col-sm-8 input-group">
+                  <div class="col-sm-4 input-group">
                     <input datepicker-popup="yyyy-MM-dd" is-open="duePicker.open" type="text" class="form-control" ng-model="task.due_date" placeholder="yyyy-MM-dd" close-text="Close" />
                     <span class="input-group-btn">
                       <button class="btn btn-default" ng-click="open($event, duePicker)"><i class="glyphicon glyphicon-calendar"></i></button>

--- a/src/app/units/partials/templates/unit-admin-context.tpl.html
+++ b/src/app/units/partials/templates/unit-admin-context.tpl.html
@@ -27,7 +27,7 @@
 
         <div class="form-group">
           <label tooltip="Date for the start of teaching in the unit." class="col-sm-2 control-label" for="startdate">Start Date</label>
-          <div class="col-sm-9 input-group">
+          <div class="col-sm-4 input-group">
             <input datepicker-popup="yyyy-MM-dd" is-open="calOptions.startOpened" type="text" class="form-control" id="startdate" ng-model="unit.start_date" ng-required="true" placeholder="yyyy-MM-dd" close-text="Close" />
             <span class="input-group-btn">
               <button class="btn btn-default" type="button" ng-click="open($event,'start')"><i class="glyphicon glyphicon-calendar"></i></button>
@@ -37,7 +37,7 @@
 
         <div class="form-group">
           <label class="col-sm-2 control-label" for="enddate">End Date</label>
-          <div class="col-sm-9 input-group">
+          <div class="col-sm-4 input-group">
             <input datepicker-popup="{{format}}" id="enddate" type="text" class="form-control" ng-model="unit.end_date" is-open="calOptions.endOpened" ng-required="true" close-text="Close" />
             <span class="input-group-btn">
               <button class="btn btn-default" type="button" ng-click="open($event,'end')"><i class="glyphicon glyphicon-calendar"></i></button>


### PR DESCRIPTION
The calendar fields were too large and the icon for the calendar picker was too far away from the actual date in the field.

Resolves [trello card](https://trello.com/c/YvTgcoac/54-issue-7-calendar-icon-is-too-far-across-from-the-date-text) issue