### PR TITLE
FIX: Remove text appearing on index when loading

### DIFF
--- a/src/app/common/alert-list/alert-list.coffee
+++ b/src/app/common/alert-list/alert-list.coffee
@@ -1,0 +1,8 @@
+angular.module("doubtfire.common.alert-list", [])
+.directive('alertList', ->
+  restrict: 'E'
+  templateUrl: 'common/alert-list/alert-list.tpl.html'
+  replace: true
+
+  controller: ($scope) ->
+)

--- a/src/app/common/alert-list/alert-list.tpl.html
+++ b/src/app/common/alert-list/alert-list.tpl.html
@@ -1,0 +1,11 @@
+<div class="alert-top">
+  <alert ng-repeat="alert in alerts" class="col-xs-12 col-md-4 col-md-push-8" type="{{alert.type}}" close="alert.close()">
+    <div class="alert-wrapper">
+      <i class="fa fa-3x"></i>
+      <div class="alert-content">
+        <h4>{{alert.type | ucfirst}}</h4>
+        <div ng-bind-html="alert.msg"></div>
+      </div>
+    </div>
+  </alert>
+</div>

--- a/src/app/common/common.coffee
+++ b/src/app/common/common.coffee
@@ -8,4 +8,5 @@ angular.module("doubtfire.common", [
   'doubtfire.common.grade-icon'
   'doubtfire.common.status-icon'
   'doubtfire.common.markdown-editor'
+  'doubtfire.common.alert-list'
 ])

--- a/src/index.html
+++ b/src/index.html
@@ -56,7 +56,6 @@
         <div class="alert-wrapper">
           <i class="fa fa-3x"></i>
           <div class="alert-content">
-            <h4>{{alert.type | ucfirst}}</h4>
             <div ng-bind-html="alert.msg"></div>
           </div>
         </div>

--- a/src/index.html
+++ b/src/index.html
@@ -51,16 +51,7 @@
       <div ui-view="main" class="container-fluid container-fixed-lg"></div>
     </div>
 
-    <div class="alert-top">
-      <alert ng-repeat="alert in alerts" class="col-xs-12 col-md-4 col-md-push-8" type="{{alert.type}}" close="alert.close()">
-        <div class="alert-wrapper">
-          <i class="fa fa-3x"></i>
-          <div class="alert-content">
-            <div ng-bind-html="alert.msg"></div>
-          </div>
-        </div>
-      </alert>
-    </div>
+    <alert-list> </alert-list>
 
     <!-- compiled JS --><% scripts.forEach( function ( file ) { %>
     <script type="text/javascript" src="<%= file %>"></script><% }); %>


### PR DESCRIPTION
Stop H4 "alert.type | ucfirst" from displaying in index.html when loading

<img width="1440" alt="screenshot 2016-04-21 09 28 14" src="https://cloud.githubusercontent.com/assets/5138218/14707539/a775fb76-0808-11e6-9b07-00a4a1df5aeb.png">