### PR TITLE
FIX: Remove periods for querySelector ids

### DIFF
--- a/src/app/common/services/task-service.coffee
+++ b/src/app/common/services/task-service.coffee
@@ -480,7 +480,7 @@ angular.module("doubtfire.common.services.tasks", [])
 
   taskService.taskKeyToIdString = (task) ->
     key = task.taskKey()
-    "task-key-#{key.studentId}-#{key.taskDefAbbr}"
+    "task-key-#{key.studentId}-#{key.taskDefAbbr}".replace(".", "")
 
   taskService.taskKey = (task) ->
     {


### PR DESCRIPTION
This PR will remove periods from task IDs which causes an error, as no period characters can be present in querySelector IDs.