### PR TITLE
ENHANCE: Update task list inbox based on user tutorials

### DIFF
--- a/src/app/units/states/tasks/inbox/directives/staff-task-list/staff-task-list.coffee
+++ b/src/app/units/states/tasks/inbox/directives/staff-task-list/staff-task-list.coffee
@@ -22,11 +22,13 @@ angular.module('doubtfire.units.states.tasks.inbox.directives.staff-task-list', 
       throw Error "Invalid taskData.source provided for task list; supply one of Unit.tasksForTaskInbox, Unit.tasksRequiringFeedback, Unit.taskByTaskDefinition"
     # showDate from date-service
     $scope.showDate = dateService.showFullDate
+    # Does the current user have any tutorials?
+    $scope.userHasTutorials = $scope.unit.tutorialsForUserName(currentUser.profile.name)?.length > 0
     # Search option filters
     $scope.filteredTasks = []
     $scope.filters = _.extend({
       studentName: null
-      tutorialIdSelected: if $scope.unitRole.role == 'Tutor' then 'mine' else 'all'
+      tutorialIdSelected: if ($scope.unitRole.role == 'Tutor' || 'Convenor') && $scope.userHasTutorials then 'mine' else 'all'
       tutorials: []
       taskDefinitionIdSelected: null
       taskDefinition: null


### PR DESCRIPTION
This will make sure that a convenor can log in and view their task submissions based upon their own tutorials, if they have any. The same applies to tutors. Prior to this enhancement, a convenor would always be directed to a task inbox list that reflects all submissions from all tutorials, not just their own.