### PR TITLE
Resolve native PDF rendering using new as attachment parameter

### DIFF
--- a/src/app/api/models/portfolion-submission.coffee
+++ b/src/app/api/models/portfolion-submission.coffee
@@ -17,6 +17,9 @@ angular.module("doubtfire.api.models.portfolio-submission", [
     resource.portfolioUrl =
       "#{api}/submission/project/#{project.project_id}/portfolio?auth_token=#{currentUser.authenticationToken}"
 
+    resource.portfolioUrlAsAttachment =
+      resource.portfolioUrl + "&as_attachment=true"
+
     #
     # Object that defines file upload requirements of an LSR
     #
@@ -53,8 +56,10 @@ angular.module("doubtfire.api.models.portfolio-submission", [
 
     resource
 
-  PortfolioSubmission.getPortfolioUrl = (project) ->
-    "#{api}/submission/project/#{project.project_id}/portfolio?auth_token=#{currentUser.authenticationToken}"
+  PortfolioSubmission.getPortfolioUrl = (project, asAttachment = false) ->
+    url = "#{api}/submission/project/#{project.project_id}/portfolio?auth_token=#{currentUser.authenticationToken}"
+    url += "&as_attachment=true" if asAttachment
+    url
 
   PortfolioSubmission
 )

--- a/src/app/api/models/task-feedback.coffee
+++ b/src/app/api/models/task-feedback.coffee
@@ -3,8 +3,10 @@ angular.module("doubtfire.api.models.task-feedback", [])
 .factory("TaskFeedback", (api, currentUser, $window, resourcePlus) ->
   TaskFeedback = resourcePlus "/projects/:project_id/task_def_id/:task_definition_id/submission", { task_definition_id: "@task_definition_id", project_id: "@project_id" }
 
-  TaskFeedback.getTaskUrl = (task) ->
-    "#{api}/projects/#{task.project().project_id}/task_def_id/#{task.definition.id}/submission?auth_token=#{currentUser.authenticationToken}"
+  TaskFeedback.getTaskUrl = (task, asAttachment = false) ->
+    url = "#{api}/projects/#{task.project().project_id}/task_def_id/#{task.definition.id}/submission?auth_token=#{currentUser.authenticationToken}"
+    url += "&as_attachment=true"
+    url
 
   TaskFeedback.getTaskFilesUrl = (task) ->
     "#{api}/projects/#{task.project().project_id}/task_def_id/#{task.definition.id}/submission_files?auth_token=#{currentUser.authenticationToken}"

--- a/src/app/common/pdf-panel-viewer/pdf-panel-viewer.coffee
+++ b/src/app/common/pdf-panel-viewer/pdf-panel-viewer.coffee
@@ -9,19 +9,10 @@ angular.module("doubtfire.common.pdf-panel-viewer", [])
     resourcesUrl: '='
     hideFooter: '=?'
 
-  controller: ($scope, $sce, $timeout, analyticsService) ->
-    $scope.isSafari = navigator.userAgent.indexOf("Safari") > 0 && navigator.userAgent.indexOf("Chrome") == -1
+  controller: ($scope, analyticsService) ->
     $scope.downloadEvent = (type) ->
       analyticsService.event 'Task Sheet', "Downloaded #{type}"
-
-    $scope.shouldShowIframe = true
-
     # Watch the URL, and hide the view if it hasn't loaded
     $scope.$watch 'pdfUrl', (newUrl) ->
       return unless newUrl?
-      $scope.shouldShowIframe = false
-      # Add a timeout to reset the iframe
-      $timeout (nowLoading) ->
-        $scope.shouldShowIframe = true
-      $scope.googleDocsUrl = $sce.trustAsResourceUrl "https://docs.google.com/gview?url=#{newUrl}&embedded=true"
 )

--- a/src/app/common/pdf-panel-viewer/pdf-panel-viewer.scss
+++ b/src/app/common/pdf-panel-viewer/pdf-panel-viewer.scss
@@ -5,44 +5,11 @@
     overflow: inherit !important;
     background-color: #d1d1d1;
     height: 60vh;
-  }
-  .iframe-wrapper {
-    position: absolute;
-    top: 1px;
-    bottom: -1px;
-    left: 1px;
-    right: 0;
-  }
-  iframe {
-    position: absolute;
-    display: block;
-    height: 100%;
-    width: 100%;
-    border: none;
-    z-index: 1;
-  }
-  .loading-icon {
-    z-index: 0;
-    position: relative;
-    left: calc(50% - 300px /2);
-    top: 193px;
-    width: 300px;
 
-    p.loading-text {
-      font-size: 19px;
-      margin: 0.5em 0;
+    object {
+        width: 100%;
+        height: 100%;
     }
-
-    background-color: #4c494c;
-    -webkit-border-radius: 12px;
-    border-radius: 12px;
-
-    color: #fff;
-    margin-bottom: 40px;
-    padding: 20px;
-    text-align: center;
-    -webkit-box-shadow: 0 10px 12px 5px rgba(0, 0, 0, 0.2);
-    box-shadow: 0 10px 12px 5px rgba(0, 0, 0, 0.2)
   }
   .panel-footer {
     height: 60px;

--- a/src/app/common/pdf-panel-viewer/pdf-panel-viewer.tpl.html
+++ b/src/app/common/pdf-panel-viewer/pdf-panel-viewer.tpl.html
@@ -1,6 +1,6 @@
 <div class="pdf-panel-viewer">
     <div class="panel-body">
-        <object data="{{pdfUrl}}" type="application/pdf"></object>
+        <pdf-viewer pdf-url="pdfUrl"></pdf-viewer>
     </div>
 </div>
 <!--/panel-body-->

--- a/src/app/common/pdf-panel-viewer/pdf-panel-viewer.tpl.html
+++ b/src/app/common/pdf-panel-viewer/pdf-panel-viewer.tpl.html
@@ -12,7 +12,7 @@
         <a ng-click="downloadEvent('Resources')" ng-href="{{resourcesUrl}}" class="btn btn-primary" ng-if="resourcesUrl">
         <i class="fa fa-download"></i><span> Resources</span>
       </a>
-        <a ng-click="downloadEvent('PDF')" ng-href="{{pdfUrl}}" class="btn btn-success">
+        <a ng-click="downloadEvent('PDF')" ng-href="{{pdfUrl}}&as_attachment=true" class="btn btn-success">
         <i class="fa fa-download"></i><span ng-show="resourcesUrl"> PDF</span>
       </a>
     </div>

--- a/src/app/common/pdf-panel-viewer/pdf-panel-viewer.tpl.html
+++ b/src/app/common/pdf-panel-viewer/pdf-panel-viewer.tpl.html
@@ -1,30 +1,21 @@
 <div class="pdf-panel-viewer">
-  <div class="panel-body">
-    <div class="iframe-wrapper" ng-if="isSafari">
-      <object data="{{pdfUrl}}" type="application/pdf" width="100%" height="100%">
-      </object>
+    <div class="panel-body">
+        <object data="{{pdfUrl}}" type="application/pdf"></object>
     </div>
-    <div class="iframe-wrapper" ng-if="!isSafari">
-      <iframe ng-if="shouldShowIframe" ng-src="{{googleDocsUrl}}"></iframe>
-      <div class="loading-icon">
-        <i class="fa fa-spinner fa-pulse fa-2x"></i>
-        <p class="loading-text">
-          Loading PDF
-        </p>
-      </div>
-    </div>
-  </div><!--/panel-body-->
-  <div class="panel-footer" ng-if="!hideFooter">
+</div>
+<!--/panel-body-->
+<div class="panel-footer" ng-if="!hideFooter">
     <div class="pull-left text-muted" ng-show="footerText">
-      <strong>Note:</strong> {{footerText}}
+        <strong>Note:</strong> {{footerText}}
     </div>
     <div class="pull-right btn-group">
-      <a ng-click="downloadEvent('Resources')" ng-href="{{resourcesUrl}}" class="btn btn-primary" ng-if="resourcesUrl">
+        <a ng-click="downloadEvent('Resources')" ng-href="{{resourcesUrl}}" class="btn btn-primary" ng-if="resourcesUrl">
         <i class="fa fa-download"></i><span> Resources</span>
       </a>
-      <a ng-click="downloadEvent('PDF')" ng-href="{{pdfUrl}}" class="btn btn-success">
+        <a ng-click="downloadEvent('PDF')" ng-href="{{pdfUrl}}" class="btn btn-success">
         <i class="fa fa-download"></i><span ng-show="resourcesUrl"> PDF</span>
       </a>
     </div>
-  </div><!--/panel-footer-->
+</div>
+<!--/panel-footer-->
 </div>

--- a/src/app/common/pdf-viewer/pdf-viewer.coffee
+++ b/src/app/common/pdf-viewer/pdf-viewer.coffee
@@ -7,14 +7,8 @@ angular.module("doubtfire.common.pdf-viewer", [])
   templateUrl: 'common/pdf-viewer/pdf-viewer.tpl.html'
   scope:
     pdfUrl: '='
-  controller: ($scope, $sce, $timeout) ->
-    $scope.isSafari = navigator.userAgent.indexOf("Safari") > 0 && navigator.userAgent.indexOf("Chrome") == -1
+  controller: ($scope) ->
     # Watch the URL, and hide the view if it hasn't loaded
     $scope.$watch 'pdfUrl', (newUrl) ->
       return unless newUrl?
-      $scope.shouldShowIframe = false
-      # Add a timeout to reset the iframe
-      $timeout (nowLoading) ->
-        $scope.shouldShowIframe = true
-      $scope.googleDocsUrl = $sce.trustAsResourceUrl "https://docs.google.com/gview?url=#{newUrl}&embedded=true"
 )

--- a/src/app/common/pdf-viewer/pdf-viewer.coffee
+++ b/src/app/common/pdf-viewer/pdf-viewer.coffee
@@ -7,4 +7,8 @@ angular.module("doubtfire.common.pdf-viewer", [])
   link: (scope, element, attrs) ->
     url = scope.$eval(attrs.pdfUrl)
     element.replaceWith("<object type='application/pdf' data='#{url}'></object>")
+  controller: ($scope, $element) ->
+    # Watch the URL, and hide the view if it hasn't loaded
+    $scope.$watch 'pdfUrl', (newUrl) ->
+      $element.replaceWith("<object type='application/pdf' data='#{newUrl}'></object>")
 )

--- a/src/app/common/pdf-viewer/pdf-viewer.coffee
+++ b/src/app/common/pdf-viewer/pdf-viewer.coffee
@@ -4,11 +4,7 @@ angular.module("doubtfire.common.pdf-viewer", [])
 #
 .directive('pdfViewer', ->
   restrict: 'E'
-  templateUrl: 'common/pdf-viewer/pdf-viewer.tpl.html'
-  scope:
-    pdfUrl: '='
-  controller: ($scope) ->
-    # Watch the URL, and hide the view if it hasn't loaded
-    $scope.$watch 'pdfUrl', (newUrl) ->
-      return unless newUrl?
+  link: (scope, element, attrs) ->
+    url = scope.$eval(attrs.pdfUrl)
+    element.replaceWith("<object type='application/pdf' data='#{url}'></object>")
 )

--- a/src/app/common/pdf-viewer/pdf-viewer.scss
+++ b/src/app/common/pdf-viewer/pdf-viewer.scss
@@ -1,46 +1,5 @@
-pdf-viewer {
-  position: absolute;
-  top: 0;
-  right: -1px;
-  bottom: 0;
-  left: 0;
-  .iframe-wrapper {
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    background-color: #d1d1d1;
-  }
-  iframe {
-    position: absolute;
-    display: block;
-    height: 100%;
+object {
     width: 100%;
-    border: none;
-    z-index: 1;
-  }
-  .loading-icon {
-    z-index: 0;
-    position: relative;
-    left: calc(50% - 300px /2);
-    top: 193px;
-    width: 300px;
-
-    p.loading-text {
-      font-size: 19px;
-      margin: 0.5em 0;
-    }
-
-    background-color: #4c494c;
-    -webkit-border-radius: 12px;
-    border-radius: 12px;
-
-    color: #fff;
-    margin-bottom: 40px;
-    padding: 20px;
-    text-align: center;
-    -webkit-box-shadow: 0 10px 12px 5px rgba(0, 0, 0, 0.2);
-    box-shadow: 0 10px 12px 5px rgba(0, 0, 0, 0.2)
-  }
+    height: 100%;
+    position: absolute;
 }

--- a/src/app/common/pdf-viewer/pdf-viewer.tpl.html
+++ b/src/app/common/pdf-viewer/pdf-viewer.tpl.html
@@ -1,10 +1,1 @@
-<object ng-if="isSafari" data="{{pdfUrl}}" type="application/pdf" width="100%" height="100%"></object>
-<div class="iframe-wrapper" ng-if="!isSafari">
-  <iframe ng-if="shouldShowIframe" ng-src="{{googleDocsUrl}}"></iframe>
-  <div class="loading-icon">
-    <i class="fa fa-spinner fa-pulse fa-2x"></i>
-    <p class="loading-text">
-      Loading PDF...
-    </p>
-  </div>
-</div>
+<object data="{{pdfUrl}}" type="application/pdf"></object>

--- a/src/app/common/pdf-viewer/pdf-viewer.tpl.html
+++ b/src/app/common/pdf-viewer/pdf-viewer.tpl.html
@@ -1,1 +1,0 @@
-<object data="{{pdfUrl}}" type="application/pdf"></object>

--- a/src/app/common/services/unit-service.coffee
+++ b/src/app/common/services/unit-service.coffee
@@ -214,7 +214,7 @@ angular.module("doubtfire.common.services.units", [])
         else
           t
 
-    
+
     unit.staffAlignmentsForTaskDefinition = (td) ->
       return if ! td?
       filteredAlignments = $filter('taskDefinitionFilter')(unit.task_outcome_alignments, td.id)
@@ -358,6 +358,9 @@ angular.module("doubtfire.common.services.units", [])
     # Returns the student's portfolio submission URL
     student.portfolioUrl = ->
       PortfolioSubmission.getPortfolioUrl(student)
+
+    student.portfolioUrlAsAttachment = ->
+      PortfolioSubmission.getPortfolioUrl(student, true)
 
     # Assigns a grade to a student
     student.assignGrade = (score, rationale) ->

--- a/src/app/projects/states/dashboard/dashboard.tpl.html
+++ b/src/app/projects/states/dashboard/dashboard.tpl.html
@@ -3,17 +3,17 @@
     task-data="taskData"
     project="project"
     refresh-tasks="targetGradeUpdated"
-    class="col-xs-12 col-md-2"><!--/panel-1-->
+    class="col-xs-12 col-md-3"><!--/panel-1-->
   </student-task-list>
   <progress-dashboard
     project="project"
     on-update-target-grade="targetGradeUpdated"
-    class="col-xs-12 col-md-10"
+    class="col-xs-12 col-md-9"
     ng-if="!taskData.selectedTask">
   </progress-dashboard><!--/panel-2-->
   <task-dashboard
     task="taskData.selectedTask"
-    class="col-xs-12 col-md-7"
+    class="col-xs-12 col-md-6"
     ng-if="taskData.selectedTask">
   </task-dashboard><!--/panel-2-->
   <task-comments-viewer

--- a/src/app/projects/states/dashboard/directives/task-dashboard/directives/task-submission-card/task-submission-card.coffee
+++ b/src/app/projects/states/dashboard/directives/task-dashboard/directives/task-submission-card/task-submission-card.coffee
@@ -20,7 +20,7 @@ angular.module('doubtfire.projects.states.dashboard.directives.task-dashboard.di
           isUploaded: $scope.task.has_pdf
         }
         $scope.urls = {
-          pdf: TaskFeedback.getTaskUrl($scope.task)
+          pdf: TaskFeedback.getTaskUrl($scope.task, true)
           files: TaskFeedback.getTaskFilesUrl($scope.task)
         }
       )

--- a/src/app/projects/states/dashboard/directives/task-dashboard/task-dashboard.coffee
+++ b/src/app/projects/states/dashboard/directives/task-dashboard/task-dashboard.coffee
@@ -16,14 +16,14 @@ angular.module('doubtfire.projects.states.dashboard.directives.task-dashboard', 
     $scope.tutor = $stateParams.tutor
     # the ways in which the dashboard can be viewed
     $scope.dashboardViews = ["details", "submission", "task"]
-    
+
     # set the current dashboard view to details by default
     updateCurrentView = ->
       if $scope.showSubmission
         $scope.currentView = $scope.dashboardViews[1]
       else
         $scope.currentView = $scope.dashboardViews[0]
-    
+
     updateCurrentView()
 
     # Cleanup
@@ -35,11 +35,12 @@ angular.module('doubtfire.projects.states.dashboard.directives.task-dashboard', 
       $scope.urls = {
         taskSheetPdfUrl: Task.getTaskPDFUrl($scope.task.unit(), $scope.task.definition)
         taskSubmissionPdfUrl: TaskFeedback.getTaskUrl($scope.task)
+        taskSubmissionPdfAttachmentUrl: TaskFeedback.getTaskUrl($scope.task, true)
         taskFilesUrl: TaskFeedback.getTaskFilesUrl($scope.task)
       }
       updateCurrentView()
     )
-    
+
     # Set the selected dashboard view
     $scope.setSelectedDashboardView = (view) ->
       if view in $scope.dashboardViews

--- a/src/app/projects/states/dashboard/directives/task-dashboard/task-dashboard.tpl.html
+++ b/src/app/projects/states/dashboard/directives/task-dashboard/task-dashboard.tpl.html
@@ -20,7 +20,7 @@
           </li>
           <li class="divider" ng-show="task.has_pdf"></li>
           <li ng-show="task.has_pdf">
-            <a href="{{urls.taskSubmissionPdfUrl}}">Download Submission PDF</a>
+            <a href="{{urls.taskSubmissionPdfAttachmentUrl}}">Download Submission PDF</a>
           </li>
           <li ng-show="task.has_pdf">
             <a href="{{urls.taskFilesUrl}}">Download Submitted Files</a>

--- a/src/app/projects/states/portfolio/directives/portfolio-review-step/portfolio-review-step.tpl.html
+++ b/src/app/projects/states/portfolio/directives/portfolio-review-step/portfolio-review-step.tpl.html
@@ -109,7 +109,7 @@
         <button class="btn btn-danger" ng-click="deletePortfolio()">
           <i class="fa fa-trash-o"></i> Delete Portfolio
         </button>
-        <a href="{{project.portfolioUrl()}}" target="_blank" class="btn btn-success">
+        <a href="{{project.portfolioUrlAsAttachment()}}" target="_blank" class="btn btn-success">
           <i class="fa fa-download"></i> Download Portfolio
         </a>
       </div>

--- a/src/app/tasks/task-definition-editor/task-definition-editor.coffee
+++ b/src/app/tasks/task-definition-editor/task-definition-editor.coffee
@@ -63,7 +63,7 @@ angular.module('doubtfire.tasks.task-definition-editor', [])
       # $scope.filesUploaded = response
 
     $scope.taskPDFUrl = ->
-      Task.getTaskPDFUrl($scope.unit, $scope.task)
+      Task.getTaskPDFUrl($scope.unit, $scope.task, true)
 
     #
     # The task resources uploader...


### PR DESCRIPTION
This PR resolves #81.

As shown in https://github.com/doubtfire-lms/doubtfire-api/pull/70, the `Content-Disposition` header must not be sent when rendering PDF in an `object` element for Chrome and Firefox.

This PR ensures the PDF viewer and PDF panel viewer both use the PDF viewer, using the `as_attachment` query proposed in https://github.com/doubtfire-lms/doubtfire-api/pull/70.