### PR TITLE
LOOKS: Move comment icons underneath text field

### DIFF
--- a/src/app/common/markdown-editor/markdown-editor.scss
+++ b/src/app/common/markdown-editor/markdown-editor.scss
@@ -7,20 +7,7 @@ $markdown-editor-height: 15px;
   }
 }
 
-.markdown-editor .markdown-editor-inner-context {
-  position: relative;
-  cursor: text;
-  padding: 6px 12px;
-  height: auto;
-  min-height: 30px;
-  border: 1px solid #cccccc;
-  box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
-  font-size: 1em;
-  border-radius: 4px;
-  background-color: #fff;
-
   .markdown-editor-actions {
-    position: absolute;
     bottom: 0.5em;
     right: 1em;
     z-index: 2;
@@ -34,6 +21,17 @@ $markdown-editor-height: 15px;
       color: $brand-primary;
     }
   }
+
+.markdown-editor .markdown-editor-inner-context {
+  position: relative;
+  cursor: text;
+  padding: 6px 12px;
+  height: auto;
+  min-height: 30px;
+  border: 1px solid #cccccc;
+  box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
+  font-size: 1em;
+  background-color: #fff;
 
   .markdown-editor-preview {
     display: relative;
@@ -51,6 +49,7 @@ $markdown-editor-height: 15px;
       color: grey;
       opacity: 0.3;
     }
+    width: 80%;
   }
 
   .CodeMirror-scroll {
@@ -75,7 +74,6 @@ $markdown-editor-height: 15px;
 
   &.bordered {
     border: 1px solid #ddd;
-    border-radius: 3px;
     padding: 10px 15px;
   }
 
@@ -101,7 +99,6 @@ $markdown-editor-height: 15px;
     word-wrap: break-word;
     background-color: #f5f5f5;
     border: 1px solid #ccc;
-    border-radius: 4px
   }
 
   code {
@@ -110,7 +107,6 @@ $markdown-editor-height: 15px;
     height: auto;
     color: #c7254e;
     background-color: #f9f2f4;
-    border-radius: 4px
   }
 
   pre code {
@@ -118,7 +114,6 @@ $markdown-editor-height: 15px;
     font-size: 1em;
     color: initial;
     background-color: initial;
-    border-radius: initial;
   }
 
   img {
@@ -129,6 +124,5 @@ $markdown-editor-height: 15px;
     line-height: 1.333;
     background-color: #fff;
     border: 1px solid #ddd;
-    border-radius: 4px;
   }
 }

--- a/src/app/common/markdown-editor/markdown-editor.tpl.html
+++ b/src/app/common/markdown-editor/markdown-editor.tpl.html
@@ -1,16 +1,18 @@
 <div class="markdown-editor">
   <div class="markdown-editor-inner-context">
-    <div ng-show="isEditing" ui-codemirror="{ onLoad : codemirrorLoaded }" ui-codemirror-opts="editorOpts" ui-refresh="true" ng-model="markdownText"></div>
+    <div ng-show="isEditing" ui-codemirror="{ onLoad : codemirrorLoaded }" ui-codemirror-opts="editorOpts" ui-refresh="true"
+      ng-model="markdownText"></div>
     <div style="{{heightStyle()}}" class="markdown-editor-preview markdown-to-html" ng-hide="isEditing">
       <div ng-bind-html="markdownText | markdown"></div>
     </div>
-    <div class="markdown-editor-actions">
-      <span ng-click="isEditing = !isEditing" class="markdown-editor-action fa-stack fa-lg" tooltip="{{isEditing ? 'View preview' : 'Continue editing'}}">
-        <i class="fa fa-{{isEditing ? 'eye' : 'pencil'}} fa-stack-1x"></i>
-      </span>
-      <a href="https://en.support.wordpress.com/markdown-quick-reference/" target="_blank" class="markdown-editor-action fa-stack fa-lg" tooltip="Markdown guide">
-        <i class="fa fa-question fa-stack-1x"></i>
-      </a>
-    </div>
+  </div>
+  <div class="markdown-editor-actions">
+    <span ng-click="isEditing = !isEditing" class="markdown-editor-action fa-stack fa-lg" tooltip="{{isEditing ? 'View preview' : 'Continue editing'}}">
+      <i class="fa fa-{{isEditing ? 'eye' : 'pencil'}} fa-stack-1x"></i>
+    </span>
+    <a href="https://en.support.wordpress.com/markdown-quick-reference/" target="_blank" class="markdown-editor-action fa-stack fa-lg"
+      tooltip="Markdown guide">
+      <i class="fa fa-question fa-stack-1x"></i>
+    </a>
   </div>
 </div>


### PR DESCRIPTION
This PR will create a small panel underneath the comment window, so that icons do not overlap the text window. This will also provide a space for upcoming audio comment feature.