### PR TITLE
Resolves issues with Marking by Task Definition.

### DIFF
--- a/src/app/common/filters/filters.coffee
+++ b/src/app/common/filters/filters.coffee
@@ -191,7 +191,14 @@ angular.module("doubtfire.common.filters", [])
   (tasks, tutorialIds) ->
     return tasks unless tasks?
     return [] if _.isEmpty tutorialIds
-    _.filter tasks, (task) -> _.includes(tutorialIds, task.project().tutorial_id)
+    # If task is group task, then use group tutorial, else use project tutorial
+    _.filter tasks, (task) ->
+      if task.isGroupTask()
+        if task.group()?
+          _.includes(tutorialIds, task.group().tutorial_id)
+      else
+        _.includes(tutorialIds, task.project().tutorial_id)
+
 )
 
 .filter('tasksWithStudentName', ->

--- a/src/app/common/services/project-service.coffee
+++ b/src/app/common/services/project-service.coffee
@@ -188,7 +188,8 @@ angular.module("doubtfire.common.services.projects", [])
         project.tasks.push(projectService.mapTask(newTask, unit, project))
         currentTask = newTask
       if currentTask.isGroupTask() and !currentTask.groups?
-        projectService.getGroup(currentTask.project(), callback)
+        projectService.updateGroups(currentTask.project(), callback, true)
+      callback?()
       currentTask
 
     project.refresh = (unit_obj) ->
@@ -216,15 +217,11 @@ angular.module("doubtfire.common.services.projects", [])
           onFailure?(failure)
       )
 
-  projectService.getGroup = (project, onSuccess) ->
-    Project.get { id: project.project_id }, (response) ->
-      project.groups = response.groups
-      onSuccess?(project)
-
-  projectService.updateGroups = (project) ->
-    if project.groups?
+  projectService.updateGroups = (project, onSuccess, force = false) ->
+    if project.groups? or force
       Project.get { id: project.project_id }, (response) ->
         project.groups = response.groups
+        onSuccess?(project)
 
   projectService.getGroupForTask = (project, task) ->
     return null unless task.definition.group_set

--- a/src/app/common/services/unit-service.coffee
+++ b/src/app/common/services/unit-service.coffee
@@ -213,7 +213,7 @@ angular.module("doubtfire.common.services.units", [])
           t = _.find p.tasks, (t) -> t.task_definition_id == taskDef.id
         # If a group task but group data not loaded, go fetch it
         if t.isGroupTask() and !t.group()?
-          projectService.getGroup(t.project())
+          projectService.updateGroups(t.project(), null, true)
         t
 
 

--- a/src/app/common/services/unit-service.coffee
+++ b/src/app/common/services/unit-service.coffee
@@ -190,15 +190,15 @@ angular.module("doubtfire.common.services.units", [])
     #
     # Push all of the tasks downloaded into the existing student projects
     #
-    unit.incorporateTasks = (tasks) ->
+    unit.incorporateTasks = (tasks, callback) ->
       _.map tasks, (t) ->
         project = unit.findStudent(t.project_id)
         if project?
           unless project.incorporateTask?
             projectService.mapTask t, unit, project
             projectService.addProjectMethods(project, unit)
+          project.incorporateTask(t, callback)
 
-          project.incorporateTask(t)
 
     #
     # Add any missing tasks and return the new collection
@@ -210,9 +210,11 @@ angular.module("doubtfire.common.services.units", [])
       _.map unit.students, (p) ->
         t = _.find tasks, (t) -> t.project_id == p.project_id && t.task_definition_id == taskDef.id
         unless t?
-          _.find p.tasks, (t) -> t.task_definition_id == taskDef.id
-        else
-          t
+          t = _.find p.tasks, (t) -> t.task_definition_id == taskDef.id
+        # If a group task but group data not loaded, go fetch it
+        if t.isGroupTask() and !t.group()?
+          projectService.getGroup(t.project())
+        t
 
 
     unit.staffAlignmentsForTaskDefinition = (td) ->

--- a/src/app/units/states/tasks/inbox/directives/staff-task-list/staff-task-list.coffee
+++ b/src/app/units/states/tasks/inbox/directives/staff-task-list/staff-task-list.coffee
@@ -53,7 +53,8 @@ angular.module('doubtfire.units.states.tasks.inbox.directives.staff-task-list', 
       { id: 'mine', description: 'Just my tutorials', abbreviation: '__mine' }
     ]), (tutorial) ->
       unless _.includes(['all', 'mine'], tutorial.id)
-        tutorial.description = tutorial.abbreviation + ' - ' + tutorial.description
+        if tutorial.description.indexOf(tutorial.abbreviation) == -1
+          tutorial.description = tutorial.abbreviation + ' - ' + tutorial.description
       tutorial
     )
     $scope.tutorialIdChanged = ->

--- a/src/app/units/states/tasks/inbox/directives/staff-task-list/staff-task-list.coffee
+++ b/src/app/units/states/tasks/inbox/directives/staff-task-list/staff-task-list.coffee
@@ -12,7 +12,7 @@ angular.module('doubtfire.units.states.tasks.inbox.directives.staff-task-list', 
     unitRole: '='
     filters: '=?'
     showSearchOptions: '=?'
-  controller: ($scope, $timeout, $filter, Unit, taskService, alertService, currentUser, groupService, listenerService, dateService) ->
+  controller: ($scope, $timeout, $filter, Unit, taskService, alertService, currentUser, groupService, listenerService, dateService, projectService) ->
     # Cleanup
     listeners = listenerService.listenTo($scope)
     # Check taskSource exists
@@ -97,7 +97,7 @@ angular.module('doubtfire.units.states.tasks.inbox.directives.staff-task-list', 
       # Tasks for feedback or tasks for task, depending on the data source
       $scope.taskData.source.query { id: $scope.unit.id, task_def_id: $scope.filters.taskDefinitionIdSelected },
         (response) ->
-          $scope.tasks = $scope.unit.incorporateTasks(response)
+          $scope.tasks = $scope.unit.incorporateTasks(response, applyFilters)
           # If loading via task definitions, fill
           if $scope.isTaskDefMode
             unstartedTasks = $scope.unit.fillWithUnStartedTasks($scope.tasks, $scope.filters.taskDefinitionIdSelected)


### PR DESCRIPTION
If I am a tutor and I have a group assigned to me, I should see all students from _any_ individual tutorial (i.e., not just my students in my tutorial).
    
E.g., Eda, Kattie and Michael are in a group. Eda is in Tutorial A, Katie is in Tutorial B, and Michael is in Tutorial C. I am a tutor for Tutorial C and a tutor for this group. I should therefore see Eda and Katie as well.

This PR resolves this issue, as previously I couldn’t see the other students.