### PR TITLE
Fix/remove all task definition option

### DIFF
--- a/src/app/common/header/header.tpl.html
+++ b/src/app/common/header/header.tpl.html
@@ -41,10 +41,10 @@
                 <a ui-sref="units/tasks/inbox({unitId: project.unit_id})">Task Inbox</a>
               </li>
               <li>
-                <a ui-sref="units/tasks/feedback({unitId: project.unit_id})">Give Student Feedback</a>
+                <a ui-sref="units/tasks/feedback({unitId: project.unit_id})">In-Class Feedback</a>
               </li>
               <li>
-                <a ui-sref="units/tasks/definition({unitId: project.unit_id})">Mark By Definition</a>
+                <a ui-sref="units/tasks/definition({unitId: project.unit_id})">Mark By Task Definition</a>
               </li>
               <li>
                 <a ui-sref="units/tasks/offline({unitId: project.unit_id})">Mark Tasks Offline</a>
@@ -102,10 +102,10 @@
                 <a ui-sref="units/tasks/inbox({unitId: unitRole.unit_id})" ng-if="unitRole.role != 'Admin'">Task Inbox</a>
               </li>
               <li>
-                <a ui-sref="units/tasks/feedback({unitId: unitRole.unit_id})" ng-if="unitRole.role != 'Admin'">Give Student Feedback</a>
+                <a ui-sref="units/tasks/feedback({unitId: unitRole.unit_id})" ng-if="unitRole.role != 'Admin'">In-Class Feedback</a>
               </li>
               <li>
-                <a ui-sref="units/tasks/definition({unitId: unitRole.unit_id})" ng-if="unitRole.role != 'Admin'">Mark By Definition</a>
+                <a ui-sref="units/tasks/definition({unitId: unitRole.unit_id})" ng-if="unitRole.role != 'Admin'">Mark By Task Definition</a>
               </li>
               <li>
                 <a ui-sref="units/tasks/offline({unitId: unitRole.unit_id})" ng-if="unitRole.role != 'Admin'">Mark Tasks Offline</a>

--- a/src/app/common/services/task-service.coffee
+++ b/src/app/common/services/task-service.coffee
@@ -231,7 +231,7 @@ angular.module("doubtfire.common.services.tasks", [])
       action: "You should discuss this with your tutor and/or the convenor."
     time_exceeded:
       detail: "Time limit exceeded"
-      reason: "This work was submitted after the deadline, having missed the target and deadline."
+      reason: "This work was submitted after the deadline, having missed both the target and deadline."
       action: "It is now your responsibility to ensure this task is at an adequate standard in your portfolio. This task will not be considered to be Complete, which may limit your maximum grade."
 
   # Statuses students/tutors can switch tasks to

--- a/src/app/common/services/task-service.coffee
+++ b/src/app/common/services/task-service.coffee
@@ -231,7 +231,7 @@ angular.module("doubtfire.common.services.tasks", [])
       action: "You should discuss this with your tutor and/or the convenor."
     time_exceeded:
       detail: "Time limit exceeded"
-      reason: "This work was submitted after the deadline, having missed the target and due dates."
+      reason: "This work was submitted after the deadline, having missed the target and deadline."
       action: "It is now your responsibility to ensure this task is at an adequate standard in your portfolio. This task will not be considered to be Complete, which may limit your maximum grade."
 
   # Statuses students/tutors can switch tasks to

--- a/src/app/projects/states/dashboard/directives/task-dashboard/directives/task-description-card/task-description-card.tpl.html
+++ b/src/app/projects/states/dashboard/directives/task-dashboard/directives/task-description-card/task-description-card.tpl.html
@@ -19,9 +19,9 @@
         You should aim to have this task completed by <strong>{{taskDef.target_date | humanizedDate}}</strong>.
       </li>
       <li ng-show="taskDef.due_date">
-        <strong>Due Date</strong>
+        <strong>Deadline</strong>
         &mdash;
-        You must complete this task by <strong>{{taskDef.due_date | humanizedDate}}</strong> or your tutor may not assess your work.
+        You must complete this task by <strong>{{taskDef.due_date | humanizedDate}}</strong>. Submitting after this date means your tutor will not provide feedback for your submission. It will be checked in your portfolio.
       </li>
     </ul>
   </div><!--/key-info-footer-->

--- a/src/app/projects/states/dashboard/directives/task-dashboard/directives/task-due-card/task-due-card.tpl.html
+++ b/src/app/projects/states/dashboard/directives/task-dashboard/directives/task-due-card/task-due-card.tpl.html
@@ -4,9 +4,8 @@
   </div>
   <div class="card-body">
     <p>
-      This task's due date is {{task.definition.due_date | date}}.
-      You must complete this task before then, otherwise your tutor may not assess
-      your work.
+      This task's deadline is {{task.definition.due_date | date}}.
+      Submitting after this date means your tutor will not provide feedback for your submission. It will be checked in your portfolio.
     </p>
     <p class="text-muted">
       Tasks are only considered <strong>Completed</strong> once your tutor has

--- a/src/app/tasks/task-definition-editor/task-definition-editor.tpl.html
+++ b/src/app/tasks/task-definition-editor/task-definition-editor.tpl.html
@@ -135,7 +135,7 @@
                 </div><!--/target-date-->
 
                 <div class="form-group">
-                  <label tooltip="Date after which task submissions will not appear for feedback. Can be empty." class="col-sm-3 control-label">Due Date</label>
+                  <label tooltip="Date after which task submissions will not appear for feedback. Can be empty." class="col-sm-3 control-label">Deadline</label>
                   <div class="col-sm-7">
                     <div class="col-sm-8 input-group">
                       <input datepicker-popup="yyyy-MM-dd" is-open="duePicker.open" type="text" class="form-control" ng-model="task.due_date" placeholder="yyyy-MM-dd" close-text="Close" />

--- a/src/app/units/states/edit/directives/unit-tasks-editor/unit-tasks-editor.tpl.html
+++ b/src/app/units/states/edit/directives/unit-tasks-editor/unit-tasks-editor.tpl.html
@@ -43,7 +43,7 @@
                 </th>
                 <th>
                   <a ng-click="taskAdminPager.sortOrder='due_date'; taskAdminPager.reverse=!taskAdminPager.reverse">
-                    Due Date <i ng-show="taskAdminPager.sortOrder=='due_date'" class="fa fa-caret-{{taskAdminPager.reverse ? 'down' : 'up'}}"></i>
+                    Deadline <i ng-show="taskAdminPager.sortOrder=='due_date'" class="fa fa-caret-{{taskAdminPager.reverse ? 'down' : 'up'}}"></i>
                   </a>
                 </th>
                 <th ng-show="unit.hasGroupwork()">

--- a/src/app/units/states/tasks/feedback/feedback.coffee
+++ b/src/app/units/states/tasks/feedback/feedback.coffee
@@ -13,7 +13,7 @@ angular.module('doubtfire.units.states.tasks.feedback', [
     templateUrl: "units/states/tasks/inbox/inbox.tpl.html"
     controller: "TaskFeedbackStateCtrl"
     data:
-      task: "Give Student Feedback"
+      task: "In-Class Feedback"
       pageTitle: "_Home_"
       roleWhitelist: ['Tutor', 'Convenor', 'Admin']
    }

--- a/src/app/units/states/tasks/inbox/directives/staff-task-list/staff-task-list.tpl.html
+++ b/src/app/units/states/tasks/inbox/directives/staff-task-list/staff-task-list.tpl.html
@@ -19,7 +19,7 @@
           ng-change="taskDefinitionIdChanged()"
           autofocus="{{autofocus.onTaskDefinitionSelect}}"
           class="form-control input-md">
-          <option value="" ng-hide="!isTaskDefMode">All task definitions</option>
+          <option disabled value="" ng-hide="!isTaskDefMode">Task Definitions</option>
         </select>
       </div>
       <p class="help-block">You can choose to display submissions of a specific task definition here.</p>


### PR DESCRIPTION
This PR will: Disable the All Task Definitions option which was causing a problem with trying to call an invalid endpoint as no taskDefId was provided.