### PR TITLE
Enhance/send comment on task change

### DIFF
--- a/src/app/projects/project-progress-dashboard/project-progress-dashboard.coffee
+++ b/src/app/projects/project-progress-dashboard/project-progress-dashboard.coffee
@@ -10,7 +10,7 @@ angular.module('doubtfire.projects.project-progress-dashboard',[])
 .directive('projectProgressDashboard', ->
   restrict: 'E'
   templateUrl: 'projects/project-progress-dashboard/project-progress-dashboard.tpl.html'
-  controller: ($scope, $state, $rootScope, $stateParams, Project, Unit, UnitRole, headerService, alertService, gradeService, taskService, projectService, analyticsService) ->
+  controller: ($scope, $state, $rootScope, $stateParams, Project, Unit, UnitRole, headerService, alertService, gradeService, taskService, projectService, analyticsService, listenerService) ->
     if $stateParams.projectId?
       $scope.studentProjectId = $stateParams.projectId
     else if $scope.project?

--- a/src/app/tasks/task-comments-viewer/task-comments-viewer.coffee
+++ b/src/app/tasks/task-comments-viewer/task-comments-viewer.coffee
@@ -65,4 +65,9 @@ angular.module("doubtfire.tasks.task-comments-viewer", [])
           analyticsService.event "View Task Comments", "Deleted existing comment"
         (response) ->
           alertService.add("danger", response.data.error, 2000)
+
+    # Watch for changes to the task status and if non-empty comment then add that comment
+    listeners.push $scope.$watch "task.status", ->
+      if $scope.comment.text.trim().length > 0
+        $scope.addComment()
 )


### PR DESCRIPTION
This PR will ensure that during the marking dashboard page, when there is text in the comment field, and a tutor assigns a task to a status, it will send the text in the field.