### PR TITLE
Looks: Improve download button consistency

### DIFF
--- a/src/app/projects/states/dashboard/directives/task-dashboard/directives/task-description-card/task-description-card.tpl.html
+++ b/src/app/projects/states/dashboard/directives/task-dashboard/directives/task-description-card/task-description-card.tpl.html
@@ -32,7 +32,6 @@
       ng-show="taskDef.has_task_pdf"
       target="_blank"
       class="btn btn-primary">
-      <i class="fa fa-file-pdf-o"></i>
       <i class="fa fa-download"></i>
       Download Task Sheet
     </a>
@@ -42,7 +41,6 @@
       ng-show="taskDef.has_task_resources"
       target="_blank"
       class="btn btn-primary">
-      <i class="fa fa-file-zip-o"></i>
       <i class="fa fa-download"></i>
       Download Task Resources
     </a>

--- a/src/app/projects/states/dashboard/directives/task-dashboard/directives/task-status-card/task-status-card.tpl.html
+++ b/src/app/projects/states/dashboard/directives/task-dashboard/directives/task-status-card/task-status-card.tpl.html
@@ -43,7 +43,7 @@
   <div class="card-footer clearfix" ng-show="task.inFinalState() || task.status == 'ready_to_mark'">
     <a
       ng-click="updateFilesInSubmission()"
-      class="btn btn-primary pull-right"
+      class="btn btn-primary"
       tooltip="This allows you to update files for your portfolio, but does not update the task status."
       tooltip-popup-delay="250"
       tooltip-append-to-body="true">

--- a/src/app/projects/states/dashboard/directives/task-dashboard/directives/task-submission-card/task-submission-card.tpl.html
+++ b/src/app/projects/states/dashboard/directives/task-dashboard/directives/task-submission-card/task-submission-card.tpl.html
@@ -29,7 +29,6 @@
   <div class="card-footer clearfix" ng-show="submission.isUploaded || canReuploadEvidence || canRegeneratePdf">
     <div class="btn-group" ng-show="submission.isUploaded" dropdown>
       <a href="{{urls.pdf}}" target="_blank" class="btn btn-primary">
-        <i class="fa fa-file-pdf-o"></i>
         <i class="fa fa-download"></i>
         Download Submission
       </a>


### PR DESCRIPTION
This PR ensures that all task actions are pull-left, as apposed to the current state where most are pull-left but the recently added action button was pull-right. It also removes double icons from the action buttons. 