### PR TITLE
Enhance/add empty tutorial code message

### DIFF
--- a/src/app/admin/modals/user-settings-modal/user-settings-modal.tpl.html
+++ b/src/app/admin/modals/user-settings-modal/user-settings-modal.tpl.html
@@ -28,7 +28,7 @@
           <input type="input" class="form-control" placeholder="Surname" ng-model="user.last_name">
         </div>
       </div>
-      <div class="form-group">
+      <div class="form-group" ng-required="isNew">
         <label class="col-sm-3 control-label">Preferred Name</label>
         <div class="col-sm-7">
           <input type="input" class="form-control" placeholder="Name" ng-model="user.nickname">

--- a/src/app/common/alert-list/alert-list.tpl.html
+++ b/src/app/common/alert-list/alert-list.tpl.html
@@ -3,7 +3,6 @@
     <div class="alert-wrapper">
       <i class="fa fa-3x"></i>
       <div class="alert-content">
-        <h4>{{alert.type | ucfirst}}</h4>
         <div ng-bind-html="alert.msg"></div>
       </div>
     </div>

--- a/src/app/units/modals/unit-student-enrolment-modal/unit-student-enrolment-modal.coffee
+++ b/src/app/units/modals/unit-student-enrolment-modal/unit-student-enrolment-modal.coffee
@@ -19,6 +19,7 @@ angular.module('doubtfire.units.modals.unit-student-enrolment-modal', [])
 .controller('UnitStudentEnrolmentModalCtrl', ($scope, $modalInstance, Project, unit, alertService) ->
   $scope.unit = unit
   $scope.projects = unit.students
+  $scope.tutorial = ""
 
   $scope.enrolStudent = (student_id, tutorial) ->
     # get tutorial_id from tutorial_name

--- a/src/app/units/modals/unit-student-enrolment-modal/unit-student-enrolment-modal.tpl.html
+++ b/src/app/units/modals/unit-student-enrolment-modal/unit-student-enrolment-modal.tpl.html
@@ -16,6 +16,7 @@
           <input id="searchbar" class="form-control" placeholder="Tutorial Code" type="search" ng-model="tutorial" typeahead="tutorial as tutorial.abbreviation for tutorial in unit.tutorials" />
         </div>
       </div>
+      <p class="help-block" style="padding-left: 5em" ng-show="tutorial.trim().length == 0">Student will be enrolled without a tutorial assigned.</p>
     </form>
   </div>
   <div class="modal-footer text-right">


### PR DESCRIPTION
This PR will remove the type headings from all alerts in Doubtfire, as the "Danger" was causing confusion. Example of how alerts will appear:

<img width="619" alt="screen shot 2018-07-11 at 1 47 00 pm" src="https://user-images.githubusercontent.com/5138218/42549987-5b48e18a-8512-11e8-8901-794dea6a92d5.png">

Message will also be shown if student is enrolled with no tutorial code:
<img width="628" alt="screen shot 2018-07-11 at 11 39 32 am" src="https://user-images.githubusercontent.com/5138218/42549990-638f325e-8512-11e8-89ad-14c497a9011a.png">
