### PR TITLE
New: add submission zip export

### DIFF
--- a/src/app/api/models/task-definition.coffee
+++ b/src/app/api/models/task-definition.coffee
@@ -1,10 +1,13 @@
 angular.module("doubtfire.api.models.task-definition", [])
 
-.factory("TaskDefinition", (resourcePlus) ->
+.factory("TaskDefinition", (resourcePlus, api, currentUser) ->
   TaskDefinition = resourcePlus "/task_definitions/:id", { id: "@id" }
 
   TaskDefinition.taskSheet = resourcePlus "/units/:unit_id/task_definitions/:task_def_id/task_sheet", { unit_id: "@unit_id", task_def_id: "@task_def_id" }
   TaskDefinition.taskResources = resourcePlus "/units/:unit_id/task_definitions/:task_def_id/task_resources", { unit_id: "@unit_id", task_def_id: "@task_def_id" }
+
+  TaskDefinition.getSubmissionsUrl = (unit_id, task_def_id) ->
+    "#{api}/submission/unit/#{unit_id}/task_definitions/#{task_def_id}/download_submissions?auth_token=#{currentUser.authenticationToken}"
 
   TaskDefinition
 )

--- a/src/app/api/models/task-definition.coffee
+++ b/src/app/api/models/task-definition.coffee
@@ -9,5 +9,8 @@ angular.module("doubtfire.api.models.task-definition", [])
   TaskDefinition.getSubmissionsUrl = (unit_id, task_def_id) ->
     "#{api}/submission/unit/#{unit_id}/task_definitions/#{task_def_id}/download_submissions?auth_token=#{currentUser.authenticationToken}"
 
+  TaskDefinition.getSubmissionsPdfsUrl = (unit_id, task_def_id) ->
+    "#{api}/submission/unit/#{unit_id}/task_definitions/#{task_def_id}/student_pdfs?auth_token=#{currentUser.authenticationToken}"
+
   TaskDefinition
 )

--- a/src/app/tasks/task-definition-editor/task-definition-editor.coffee
+++ b/src/app/tasks/task-definition-editor/task-definition-editor.coffee
@@ -72,7 +72,6 @@ angular.module('doubtfire.tasks.task-definition-editor', [])
           alertService.add("success", "Deleted task sheet", 2000)
         (error) ->
           alertService.add("danger", "Delete failed, #{error.data?.message}", 6000)
-      
 
     $scope.removeTaskResources = (task) ->
       TaskDefinition.taskResources.delete { unit_id: $scope.unit.id, task_def_id: task.id},
@@ -86,7 +85,7 @@ angular.module('doubtfire.tasks.task-definition-editor', [])
     #
     # The task resources uploader...
     #
-    $scope.taskResources = { file: { name: 'Task Resources', type: 'zip'  } }
+    $scope.taskResources = { file: { name: 'Task Resources', type: 'zip' } }
     $scope.taskResourcesUploadUrl = -> Unit.taskResourcesUploadUrl($scope.unit, $scope.task)
 
     $scope.onTaskResourcesSuccess = (response) ->

--- a/src/app/units/states/tasks/inbox/directives/staff-task-list/staff-task-list.coffee
+++ b/src/app/units/states/tasks/inbox/directives/staff-task-list/staff-task-list.coffee
@@ -12,7 +12,7 @@ angular.module('doubtfire.units.states.tasks.inbox.directives.staff-task-list', 
     unitRole: '='
     filters: '=?'
     showSearchOptions: '=?'
-  controller: ($scope, $timeout, $filter, Unit, taskService, alertService, currentUser, groupService, listenerService, dateService, projectService) ->
+  controller: ($scope, $timeout, $filter, $window, Unit, taskService, alertService, currentUser, groupService, listenerService, dateService, projectService, TaskDefinition) ->
     # Cleanup
     listeners = listenerService.listenTo($scope)
     # Check taskSource exists
@@ -41,6 +41,8 @@ angular.module('doubtfire.units.states.tasks.inbox.directives.staff-task-list', 
     # auto-selected with the search options open task def mode -- i.e., the mode
     # for selecting tasks by task definitions
     $scope.isTaskDefMode = $scope.taskData.source == Unit.tasksForDefinition && $scope.filters?.taskDefinitionIdSelected? && $scope.showSearchOptions?
+    if $scope.isTaskDefMode
+      $scope.submissionsUrl = TaskDefinition.getSubmissionsUrl($scope.unit.id, $scope.filters.taskDefinitionIdSelected)
     openTaskDefs = ->
       # Automatically "open" the task definition select element if in task def mode
       selectEl = document.querySelector('select[ng-model="filters.taskDefinitionIdSelected"]')
@@ -74,6 +76,7 @@ angular.module('doubtfire.units.states.tasks.inbox.directives.staff-task-list', 
     $scope.groupSetName = (id) ->
       groupService.groupSetName(id, $scope.unit) if $scope.unit.hasGroupwork()
     $scope.taskDefinitionIdChanged = ->
+      $scope.submissionsUrl = TaskDefinition.getSubmissionsUrl($scope.unit.id, $scope.filters.taskDefinitionIdSelected)
       taskDefId = $scope.filters.taskDefinitionIdSelected
       taskDef = $scope.unit.taskDef(taskDefId) if taskDefId?
       $scope.filters.taskDefinition = taskDef

--- a/src/app/units/states/tasks/inbox/directives/staff-task-list/staff-task-list.coffee
+++ b/src/app/units/states/tasks/inbox/directives/staff-task-list/staff-task-list.coffee
@@ -43,6 +43,7 @@ angular.module('doubtfire.units.states.tasks.inbox.directives.staff-task-list', 
     $scope.isTaskDefMode = $scope.taskData.source == Unit.tasksForDefinition && $scope.filters?.taskDefinitionIdSelected? && $scope.showSearchOptions?
     if $scope.isTaskDefMode
       $scope.submissionsUrl = TaskDefinition.getSubmissionsUrl($scope.unit.id, $scope.filters.taskDefinitionIdSelected)
+      $scope.submissionsPdfsUrl = TaskDefinition.getSubmissionsPdfsUrl($scope.unit.id, $scope.filters.taskDefinitionIdSelected)
     openTaskDefs = ->
       # Automatically "open" the task definition select element if in task def mode
       selectEl = document.querySelector('select[ng-model="filters.taskDefinitionIdSelected"]')
@@ -77,6 +78,7 @@ angular.module('doubtfire.units.states.tasks.inbox.directives.staff-task-list', 
       groupService.groupSetName(id, $scope.unit) if $scope.unit.hasGroupwork()
     $scope.taskDefinitionIdChanged = ->
       $scope.submissionsUrl = TaskDefinition.getSubmissionsUrl($scope.unit.id, $scope.filters.taskDefinitionIdSelected)
+      $scope.submissionsPdfsUrl = TaskDefinition.getSubmissionsPdfsUrl($scope.unit.id, $scope.filters.taskDefinitionIdSelected)
       taskDefId = $scope.filters.taskDefinitionIdSelected
       taskDef = $scope.unit.taskDef(taskDefId) if taskDefId?
       $scope.filters.taskDefinition = taskDef

--- a/src/app/units/states/tasks/inbox/directives/staff-task-list/staff-task-list.tpl.html
+++ b/src/app/units/states/tasks/inbox/directives/staff-task-list/staff-task-list.tpl.html
@@ -32,7 +32,7 @@
           ng-change="taskDefinitionIdChanged()"
           autofocus="{{autofocus.onTaskDefinitionSelect}}"
           class="form-control input-md">
-          <option value="" ng-hide="!isTaskDefMode">All task definitions</option>
+          <option value="" ng-hide="isTaskDefMode">All task definitions</option>
         </select>
       </div>
       <p class="help-block">You can choose to display submissions of a specific task definition here.</p>

--- a/src/app/units/states/tasks/inbox/directives/staff-task-list/staff-task-list.tpl.html
+++ b/src/app/units/states/tasks/inbox/directives/staff-task-list/staff-task-list.tpl.html
@@ -17,9 +17,9 @@
         <label>Task Definition</label>
         <i ng-if="isTaskDefMode" class="fa fa-download pull-right dropdown-toggle" style="cursor:pointer; padding-top: 8px; padding-right: 8px;" dropdown-toggle></i>
         <ul class="dropdown-menu pull-right">
-          <!-- <li>
-            <a ng-click="downloadPdfs()">Bulk Export Submission PDFs</a>
-          </li> -->
+          <li>
+            <a ng-href="{{submissionsPdfsUrl}}">Bulk Export Submission PDFs</a>
+          </li>
           <li>
             <a ng-href="{{submissionsUrl}}">Bulk Export Submission Files</a>
           </li>

--- a/src/app/units/states/tasks/inbox/directives/staff-task-list/staff-task-list.tpl.html
+++ b/src/app/units/states/tasks/inbox/directives/staff-task-list/staff-task-list.tpl.html
@@ -17,9 +17,9 @@
         <label>Task Definition</label>
         <i ng-if="isTaskDefMode" class="fa fa-download pull-right dropdown-toggle" style="cursor:pointer; padding-top: 8px; padding-right: 8px;" dropdown-toggle></i>
         <ul class="dropdown-menu pull-right">
-          <li>
+          <!-- <li>
             <a ng-click="downloadPdfs()">Bulk Export Submission PDFs</a>
-          </li>
+          </li> -->
           <li>
             <a ng-href="{{submissionsUrl}}">Bulk Export Submission Files</a>
           </li>

--- a/src/app/units/states/tasks/inbox/directives/staff-task-list/staff-task-list.tpl.html
+++ b/src/app/units/states/tasks/inbox/directives/staff-task-list/staff-task-list.tpl.html
@@ -6,12 +6,25 @@
         <button class="btn btn-default btn-search-opts-toggle" type="button" ng-model="showSearchOptions" btn-checkbox>
           <i class="fa fa-chevron-{{showSearchOptions ? 'up' : 'down'}}"></i>
         </button>
-      </span><!--/search-options-toggle-->
-    </div><!--/search-->
+      </span>
+      <!--/search-options-toggle-->
+    </div>
+    <!--/search-->
   </div>
   <form class="panel-body panel-collapseable search-options" ng-show="showSearchOptions">
     <div class="form-group task-definition">
-      <label>Task Definition</label>
+      <div class="dropdown" dropdown>
+        <label>Task Definition</label>
+        <i ng-if="isTaskDefMode" class="fa fa-download pull-right dropdown-toggle" style="cursor:pointer; padding-top: 8px; padding-right: 8px;" dropdown-toggle></i>
+        <ul class="dropdown-menu pull-right">
+          <li>
+            <a ng-click="downloadPdfs()">Bulk Export Submission PDFs</a>
+          </li>
+          <li>
+            <a ng-href="{{submissionsUrl}}">Bulk Export Submission Files</a>
+          </li>
+        </ul>
+      </div>
       <div class="input-group col-sm-12">
         <select
           ng-model="filters.taskDefinitionIdSelected"
@@ -23,30 +36,24 @@
         </select>
       </div>
       <p class="help-block">You can choose to display submissions of a specific task definition here.</p>
-    </div><!--/task-definition-->
+    </div>
+    <!--/task-definition-->
     <div class="form-group tutorial">
       <label>Tutorials</label>
       <div class="input-group col-sm-12">
-        <select
-          ng-model="filters.tutorialIdSelected"
-          ng-options="t.id as t.description for t in tutorials | orderBy:'abbreviation'"
-          ng-change="tutorialIdChanged()"
-          class="form-control input-md">
+        <select ng-model="filters.tutorialIdSelected" ng-options="t.id as t.description for t in tutorials | orderBy:'abbreviation'"
+          ng-change="tutorialIdChanged()" class="form-control input-md">
         </select>
       </div>
       <p class="help-block">You can choose to display submissions from all tutorials or just your tutorials.</p>
-    </div><!--/tutorial-->
-  </form><!--/search-options-->
+    </div>
+    <!--/tutorial-->
+  </form>
+  <!--/search-options-->
   <ul class="list-group">
-    <li class="list-group-item list-group-item-task clearfix {{task.statusClass()}}"
-      id="{{task.taskKeyToIdString()}}"
-      ng-click="setSelectedTask(task)"
-      ng-class="{selected: isSelectedTask(task)}"
-      ng-repeat="task in filteredTasks">
-      <user-icon
-        user="task.project()"
-        email="task.project().student_email"
-        size="50">
+    <li class="list-group-item list-group-item-task clearfix {{task.statusClass()}}" id="{{task.taskKeyToIdString()}}" ng-click="setSelectedTask(task)"
+      ng-class="{selected: isSelectedTask(task)}" ng-repeat="task in filteredTasks">
+      <user-icon user="task.project()" email="task.project().student_email" size="50">
       </user-icon>
       <div class="task-data">
         <h4 class="list-group-item-heading">
@@ -55,7 +62,7 @@
         <p class="list-group-item-text">
           {{task.definition.abbreviation}} - {{task.definition.name}}
         </p>
-        <div class="list-group-item-text-extended" ng-show="isSelectedTask(task)"> 
+        <div class="list-group-item-text-extended" ng-show="isSelectedTask(task)">
           <p>
             {{task.project().shortTutorialDescription()}}
           </p>
@@ -66,7 +73,8 @@
             Assessed {{task.times_assessed}} time{{task.times_assessed == 1 ? "" : "s"}}
           </p>
         </div>
-      </div><!--/task-data-->
+      </div>
+      <!--/task-data-->
       <div class="task-badges">
         <status-icon status="task.status"></status-icon>
         <div class="task-superscript-badges">
@@ -82,8 +90,10 @@
             {{task.gradeDesc()}}
           </span>
         </div>
-      </div><!--/badges-->
-    </li><!--/task-->
+      </div>
+      <!--/badges-->
+    </li>
+    <!--/task-->
     <li ng-show="filteredTasks.length == 0" class="list-group-item text-center text-muted">
       No tasks to display.
     </li>


### PR DESCRIPTION
This PR will allow staff to download all task submissions as a zip file for a task definition on the task definition marking view. It also fixes a bug with the "all task submission" entry being shown inappropriately on the task definition marking view, and not the inbox view.
<img width="460" alt="screen shot 2018-07-17 at 11 31 15 am" src="https://user-images.githubusercontent.com/5138218/42791637-f205c2f4-89b4-11e8-92b6-f6d50d183f7f.png">
