### PR TITLE
ENHANCE: Don't attempt send comment if text is empty

### DIFF
--- a/src/app/tasks/task-comment-composer/task-comment-composer.coffee
+++ b/src/app/tasks/task-comment-composer/task-comment-composer.coffee
@@ -26,7 +26,8 @@ angular.module("doubtfire.tasks.task-comment-composer", [])
     $scope.keyPress = (e) ->
       if (e.key.toLowerCase() == "enter" && !e.shiftKey)
         e.preventDefault()
-        $scope.addComment()
+        if $scope.comment.text.trim() != ""
+          $scope.addComment()
 
     $scope.formatImageName = (imageName) ->
       index = imageName.indexOf(".")


### PR DESCRIPTION
This PR will ensure that when the enter key is pressed while the comment field is not empty, it won't add the new line (as the previous behavior), but also will not attempt to add the comment. This will ensure an error message won't appear