### PR TITLE
FIX: Only allow plaintext in the comment editor

### DIFF
--- a/src/app/tasks/task-comment-composer/task-comment-composer.tpl.html
+++ b/src/app/tasks/task-comment-composer/task-comment-composer.tpl.html
@@ -12,7 +12,7 @@
     ngf-change="modelChanged($files, upload)" ngf-accept="{{upload.accept}}" ngf-drag-over-class="{accept:'file-over', reject:'file-over', delay:100}"
     ngf-drop-available="dropSupported">
 
-    <div id="textField" contenteditable ng-keypress="keyPress($event)" ng-model="comment.text" placeholder="Type a comment, or try dragging an image, audio or pdf..."></div>
+    <div id="textField" contenteditable="plaintext-only" ng-keypress="keyPress($event)" ng-model="comment.text" placeholder="Type a comment, or try dragging an image, audio or pdf..."></div>
 
     <p ng-show="upload.display.error">
       Invalid file type!


### PR DESCRIPTION
This PR will ensure only plaintext will be allowed in the comment text editor. Previously, pasting style-rich text into the editor would render the styles. For example:

<img width="457" alt="Screen Shot 2019-04-15 at 12 54 06 pm" src="https://user-images.githubusercontent.com/5138218/56104997-95c86600-5f7d-11e9-8d62-6af6d1619dbc.png">

Would now be: 
<img width="474" alt="Screen Shot 2019-04-15 at 12 54 35 pm" src="https://user-images.githubusercontent.com/5138218/56105011-a7117280-5f7d-11e9-8642-b3c2267a19e6.png">

This can be merged safely at any time 👍