### PR TITLE
ENHANCE: Sort student task inbox by task priority

### DIFF
--- a/src/app/common/services/project-service.coffee
+++ b/src/app/common/services/project-service.coffee
@@ -150,6 +150,8 @@ angular.module("doubtfire.common.services.projects", [])
       taskService.daysUntilDueDate(task)
     task.daysUntilTargetDate = ->
       taskService.daysUntilTargetDate(task)
+    task.isValidTopTask = ->
+      _.includes taskService.validTopTask, task.status
     
     # Start date helpers
     task.timeUntilStartDate = ->

--- a/src/app/common/services/task-service.coffee
+++ b/src/app/common/services/task-service.coffee
@@ -589,6 +589,7 @@ angular.module("doubtfire.common.services.tasks", [])
       task.due_date = response.data.due_date
       task.extensions = response.data.extensions
       task.project().updateBurndownChart()
+      task.project().calcTopTasks() # Sort the task list again
       onSuccess(response)
 
     Task.applyForExtension(task, interceptSuccess, onError)

--- a/src/app/common/services/unit-service.coffee
+++ b/src/app/common/services/unit-service.coffee
@@ -341,7 +341,7 @@ angular.module("doubtfire.common.services.units", [])
 
         _.forEach overdueGradeTasks, (task) ->
           task.topWeight = currentWeight
-          task.topReason = "Complete this #{gradeService.grades[task.definition.target_grade]} task to get back on track."
+          task.topReason = "Complete this overdue #{gradeService.grades[task.definition.target_grade]} task as soon as possible."
           currentWeight++
 
       #
@@ -354,7 +354,7 @@ angular.module("doubtfire.common.services.units", [])
       toAdd = _.orderBy(toAdd,[(task)-> task.daysUntilTargetDate()])
       _.forEach toAdd, (task) ->
         task.topWeight = currentWeight
-        task.topReason = "Complete this #{gradeService.grades[task.definition.target_grade]} task to get ahead."
+        task.topReason = if task.daysUntilTargetDate() >= 14 then "Complete this #{gradeService.grades[task.definition.target_grade]} task to get ahead."
         currentWeight++
 
     # Switch's the student's current tutorial to a new tutorial, either specified

--- a/src/app/common/services/unit-service.coffee
+++ b/src/app/common/services/unit-service.coffee
@@ -322,12 +322,12 @@ angular.module("doubtfire.common.services.units", [])
       #
       # sort tasks by start date
       #
-      sortedTasks = _.sortBy(_.sortBy(_.filter(student.tasks, (task) -> _.includes taskService.validTopTask, task.status), 'definition.seq'), 'definition.start_date')
+      sortedTasks = _.sortBy(_.sortBy(_.filter(student.tasks, (task) -> task.isValidTopTask()), 'definition.seq'), 'definition.start_date')
 
       currentWeight = 0
 
       overdueTasks = _.filter sortedTasks, (task) ->
-        taskService.daysPastTargetDate(task) > 0
+        task.daysPastTargetDate() > 0
     
       #
       # Step 2: select tasks not complete that are overdue. Pass tasks are done first.
@@ -337,24 +337,24 @@ angular.module("doubtfire.common.services.units", [])
           task.definition.target_grade == grade
 
         # Sorting needs to be done here according to the days past the target date.
-        overdueGradeTasks = _.orderBy(overdueGradeTasks, [(task)-> taskService.daysPastTargetDate(task)], ['desc'])
+        overdueGradeTasks = _.orderBy(overdueGradeTasks, [(task)-> task.daysPastTargetDate()], ['desc'])
 
         _.forEach overdueGradeTasks, (task) ->
           task.topWeight = currentWeight
-          task.topReason = "Complete this #{gradeService.grades[grade]} task to get back on track."
+          task.topReason = "Complete this #{gradeService.grades[task.definition.target_grade]} task to get back on track."
           currentWeight++
 
       #
       # Step 3: ... up to date, so look forward
       #
-      toAdd = _.filter sortedTasks, (task) -> taskService.daysUntilTargetDate(task) >= 0
+      toAdd = _.filter sortedTasks, (task) -> task.daysUntilTargetDate() >= 0
       # Sort by the target_grade. Pass task are done first if same due date as others.
       toAdd = _.sortBy(toAdd, 'definition.target_grade')
       # Sort by the upcoming deadline.
-      toAdd = _.orderBy(toAdd,[(task)-> taskService.daysUntilTargetDate(task)])
+      toAdd = _.orderBy(toAdd,[(task)-> task.daysUntilTargetDate()])
       _.forEach toAdd, (task) ->
         task.topWeight = currentWeight
-        task.topReason = "Complete this #{gradeService.grades[grade]} task to get back on track."
+        task.topReason = "Complete this #{gradeService.grades[task.definition.target_grade]} task to get ahead."
         currentWeight++
 
     # Switch's the student's current tutorial to a new tutorial, either specified

--- a/src/app/projects/states/dashboard/directives/student-task-list/student-task-list.coffee
+++ b/src/app/projects/states/dashboard/directives/student-task-list/student-task-list.coffee
@@ -24,10 +24,11 @@ angular.module('doubtfire.projects.states.dashboard.directives.student-task-list
     # Sets new filteredTasks variable
     applyFilters = ->
       filteredTasks = $filter('tasksWithName')($scope.project.activeTasks(), $scope.filters.taskName)
-      filteredTasks = $filter('orderBy')(filteredTasks, 'definition.seq')
       $scope.filteredTasks = filteredTasks
     # Apply filters first-time
     applyFilters()
+    # Sort the tasks according to priority.
+    $scope.project.calcTopTasks()
     # When refreshing tasks, we are just reloading the active tasks
     $scope.refreshTasks = applyFilters
     # Expose grade service names

--- a/src/app/projects/states/dashboard/directives/student-task-list/student-task-list.tpl.html
+++ b/src/app/projects/states/dashboard/directives/student-task-list/student-task-list.tpl.html
@@ -7,7 +7,7 @@
       id="{{task.taskKeyToIdString()}}"
       ng-click="setSelectedTask(task)"
       ng-class="{selected: isSelectedTask(task)}"
-      ng-repeat="task in filteredTasks">
+      ng-repeat="task in filteredTasks | orderBy: 'topWeight'">
       <div class="task-data">
         <h4 class="list-group-item-heading">
           {{task.definition.name}}

--- a/src/app/projects/states/dashboard/directives/task-dashboard/directives/task-status-card/task-status-card.tpl.html
+++ b/src/app/projects/states/dashboard/directives/task-dashboard/directives/task-status-card/task-status-card.tpl.html
@@ -39,6 +39,9 @@
   </div><!--/static-status-label-->
   <div class="card-body">
     <p>{{task.statusHelp().reason}} {{task.statusHelp().action}}</p>
+    <div class="alert {{task.daysUntilTargetDate() >= 0 ? (task.daysUntilTargetDate() >= 14 ? 'alert-info' : '') : 'alert-danger'}}" role="alert" ng-show="task.isValidTopTask() && task.topReason">
+      {{task.topReason}}
+    </div>
   </div><!--/status-body-->
   <div class="card-footer clearfix" ng-show="task.inSubmittedState() && task.requiresFileUpload()">
     <a

--- a/src/app/projects/states/dashboard/directives/task-dashboard/directives/task-status-card/task-status-card.tpl.html
+++ b/src/app/projects/states/dashboard/directives/task-dashboard/directives/task-status-card/task-status-card.tpl.html
@@ -39,9 +39,6 @@
   </div><!--/static-status-label-->
   <div class="card-body">
     <p>{{task.statusHelp().reason}} {{task.statusHelp().action}}</p>
-    <div class="alert {{task.daysUntilTargetDate() >= 0 ? (task.daysUntilTargetDate() >= 14 ? 'alert-info' : '') : 'alert-danger'}}" role="alert" ng-show="task.isValidTopTask() && task.topReason">
-      {{task.topReason}}
-    </div>
   </div><!--/status-body-->
   <div class="card-footer clearfix" ng-show="task.inSubmittedState() && task.requiresFileUpload()">
     <a


### PR DESCRIPTION
By default, student task inbox is sorted according to the sequence number. (1.1, 1.2....).

The changes in this PR includes sorting the student task inbox according to the priority.

1. If the student has missed the target date of few tasks then those tasks will appear on the top of the inbox. All the tasks will be sorted according to the priority. Pass tasks are more important than credit so the pass tasks will appear on the top irrespective of the due date. So, if a pass task was due yesterday and a credit task was due 1 week ago then also pass task will be on the top of the inbox.

2. If there are no overdue tasks then tasks will be sorted according to the due date. So if a distinction task is due in 5 days and pass task is due in 2 weeks then the distinction task will be shown on top. If few tasks have the same deadline then it will be sorted according to priority. (P, C, D, HD).

3. After a student is granted an extension, the task inbox will be sorted again automatically.

4. All the tasks that are marked as "ready for feedback" and "completed" will be moved to the bottom after refreshing the page.
 
![Screenshot from 2019-04-17 15-54-44](https://user-images.githubusercontent.com/29236609/56345129-5a8a9900-6202-11e9-8c52-4716f6b44243.png)

![Screenshot from 2019-04-18 17-29-23](https://user-images.githubusercontent.com/29236609/56345147-64140100-6202-11e9-975f-0a5c012427c3.png)

![Screenshot from 2019-04-18 17-29-46](https://user-images.githubusercontent.com/29236609/56345156-69714b80-6202-11e9-9ee4-84d76aab46da.png)

