### PR TITLE
FIX: fix default selected task for tutors

### DIFF
--- a/src/app/units/states/tasks/inbox/directives/staff-task-list/staff-task-list.coffee
+++ b/src/app/units/states/tasks/inbox/directives/staff-task-list/staff-task-list.coffee
@@ -37,6 +37,13 @@ angular.module('doubtfire.units.states.tasks.inbox.directives.staff-task-list', 
       filteredTasks = $filter('tasksInTutorials')(filteredTasks, $scope.filters.tutorials)
       filteredTasks = $filter('tasksWithStudentName')(filteredTasks, $scope.filters.studentName)
       $scope.filteredTasks = filteredTasks
+
+      # Fix selected task.
+      if $scope.taskData.selectedTask && !_.includes(filteredTasks, $scope.taskData.selectedTask)
+        $scope.setSelectedTask(null)
+      if filteredTasks && filteredTasks.length && !$scope.taskData.selectedTask
+        $scope.setSelectedTask(filteredTasks[0])
+      
     # Let's call having a source of tasksForDefinition plus having a task definition
     # auto-selected with the search options open task def mode -- i.e., the mode
     # for selecting tasks by task definitions


### PR DESCRIPTION
Initially when the tutor opens the task box the first task is selected automatically. If the tutor adds some filters then the task still remains selected even if it is not in the filtered list. This PR fixes this bug. It will deselect the task if it is not in the new filtered list and automatically select the first task in the new list. If after applying the filter the task is still in the new filtered list then it will remain selected.

![Screenshot from 2019-05-03 11-44-09](https://user-images.githubusercontent.com/29236609/57121554-b5ec8780-6dbb-11e9-8235-c078eee6eb90.png)

![Screenshot from 2019-05-03 11-44-34](https://user-images.githubusercontent.com/29236609/57121563-c00e8600-6dbb-11e9-91c5-95d79a17e897.png)

![Screenshot from 2019-05-03 11-45-06](https://user-images.githubusercontent.com/29236609/57121569-c866c100-6dbb-11e9-932b-ea42247a6356.png)
