### PR TITLE
FIX: Replace weeks with days

### DIFF
--- a/src/app/common/services/project-service.coffee
+++ b/src/app/common/services/project-service.coffee
@@ -29,10 +29,16 @@ angular.module("doubtfire.common.services.projects", [])
     ]
 
     for t in times
-      diff = laterTime.diff(earlyTime, t)
-      if diff > 1
+      #exactDiff is floating point
+      exactDiff = laterTime.diff(earlyTime, t, true).toFixed(2)
+      diff = Math.floor(exactDiff)
+      # if days are more than 14 then show in week
+      if(exactDiff > 2 && t == "weeks")
         return "#{diff} #{t.charAt(0).toUpperCase() + t.substr(1)}"
-      else if diff == 1
+      # Always show in days, Hours, Minutes and Seconds.
+      else if diff > 1 && t != "weeks"
+        return "#{diff} #{t.charAt(0).toUpperCase() + t.substr(1)}"
+      else if diff == 1 && t != "weeks"
         return "1 #{t.charAt(0).toUpperCase() + t.substr(1, t.length - 2)}"
     return laterTime.diff(earlyTime, "seconds")
 

--- a/src/app/projects/states/dashboard/directives/task-dashboard/directives/task-due-card/task-due-card.tpl.html
+++ b/src/app/projects/states/dashboard/directives/task-dashboard/directives/task-due-card/task-due-card.tpl.html
@@ -88,7 +88,7 @@
 </div><!--/past-target-card pre-discuss-->
 <div class="card card-danger card-sm" ng-show="task.isOverdue() && !task.inDiscussState() ">
   <div class="card-heading">
-    <h4>Missed Deadline By {{task.timePastDeadlineDescription()}}</h4>
+    <h4>Passed Deadline By {{task.timePastDeadlineDescription()}}</h4>
   </div>
   <div class="card-body">
     <p>


### PR DESCRIPTION
Fixed the dates and weeks shown in the task-cards. If the number of days is less than 14 then it will be shown as days else it will be shown in weeks.

![Screenshot from 2019-05-06 15-57-28](https://user-images.githubusercontent.com/29236609/57211128-7ffd0c80-7022-11e9-943c-a0f4e4d79da6.png)

![Screenshot from 2019-05-06 15-57-44](https://user-images.githubusercontent.com/29236609/57211129-8095a300-7022-11e9-8613-c0861f022c7b.png)
