### PR TITLE
FIX: fix task due card display

### DIFF
--- a/src/app/projects/states/dashboard/directives/task-dashboard/directives/task-due-card/task-due-card.tpl.html
+++ b/src/app/projects/states/dashboard/directives/task-dashboard/directives/task-due-card/task-due-card.tpl.html
@@ -71,7 +71,7 @@
     </p>
   </div>
 </div><!--/past-target-card pre-discuss-->
-<div class="card card-warning card-sm" ng-show="task.isPastTargetDate() && !task.isOverdue() && !task.inDiscussState() ">
+<div class="card card-warning card-sm" ng-show="task.isPastTargetDate() && !task.isOverdue() && task.inDiscussState() ">
   <div class="card-heading">
     <h4>Past Due Date By {{task.timePastTargetDescription()}}</h4>
   </div>


### PR DESCRIPTION
There was a bug which displayed 2 due date cards. This PR fixes that problem. One due card with the request extension button is shown when the task is not submitted yet. The other due card will be shown if the task is in discuss or demonstrate state (Note: since the extension is requested this card will not be shown until the task is past the new due date)

Before the fix

![Screenshot from 2019-05-15 12-41-08](https://user-images.githubusercontent.com/29236609/57745020-c9c6b080-770e-11e9-9f85-baacd2492f03.png)

After the fix

![Screenshot from 2019-05-15 12-38-39](https://user-images.githubusercontent.com/29236609/57744914-6fc5eb00-770e-11e9-9aa3-660ca6e99eb6.png)
