### PR TITLE
FIX: Add support for Firefox with contenteditable

### DIFF
--- a/src/app/tasks/task-comment-composer/task-comment-composer.component.ts
+++ b/src/app/tasks/task-comment-composer/task-comment-composer.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, Inject, Input, ViewChildren, QueryList } from '@angular/core';
+import { Component, OnInit, Inject, Input, ViewChildren, QueryList, ViewChild, ElementRef } from '@angular/core';
 import { taskService, analyticsService, alertService } from 'src/app/ajs-upgraded-providers';
 import { PopoverDirective } from 'ngx-bootstrap';
 import { MatDialog, MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
@@ -26,6 +26,12 @@ export class TaskCommentComposerComponent implements OnInit {
 
   get isStaff() {
     return this.task.project().unit().my_role !== 'Student';
+  }
+
+  contentEditableValue() {
+    const UA = navigator.userAgent;
+    const isWebkit = /WebKit/.test(UA) && !/Edge/.test(UA);
+    return isWebkit ? 'plaintext-only' : 'true';
   }
 
   ngOnInit() {

--- a/src/app/tasks/task-comment-composer/task-comment-composer.html
+++ b/src/app/tasks/task-comment-composer/task-comment-composer.html
@@ -2,7 +2,7 @@
   <button class="btn-recorder" type="button" [popover]="audioDiscussionTemplate">
     <span class="fa fa-microphone"></span>
   </button>
-  <div id="textField" contenteditable="plaintext-only" (keydown.enter)="send($event)" [(ngModel)]="comment.text"
+  <div id="textField" [contenteditable]="contentEditableValue()" (keydown.enter)="send($event)" [(ngModel)]="comment.text"
     placeholder="Type a comment, or try dragging an image or pdf above" name="commentComposer">
   </div>
 </form>


### PR DESCRIPTION
Contenteditable does not support "plaintext-only" property value on non-webkit browsers, this PR ensures the value is set to true on non-webkit browsers to ensure they can use the contenteditable div.