### PR TITLE
ENHANCE: Remove automatic trigger of extension in favour of alert warning

### DIFF
--- a/src/app/common/services/project-service.coffee
+++ b/src/app/common/services/project-service.coffee
@@ -254,6 +254,8 @@ angular.module("doubtfire.common.services.projects", [])
       task.status in taskService.awaitingFeedbackStatuses
     task.inCompleteState = ->
       task.status == 'complete'
+    task.inTimeExceeded = ->
+      task.status == 'time_exceeded'
 
     task.triggerTransition = (status, unitRole) ->
       taskService.triggerTransition(task, status, unitRole)

--- a/src/app/common/services/task-service.coffee
+++ b/src/app/common/services/task-service.coffee
@@ -433,6 +433,9 @@ angular.module("doubtfire.common.services.tasks", [])
     if response.status == status
       project.updateBurndownChart?()
       alertService.add("success", "Status saved.", 2000)
+      if task.inTimeExceeded() && !task.isPastDeadline()
+        alertService.add('warning', "Request an extension, or wait for your extension request to be granted, to have this task assessed.")
+
       if response.other_projects?
         _.each response.other_projects, (details) ->
           proj = unit.findStudent(details.id) if unit.students?

--- a/src/app/projects/states/dashboard/directives/task-dashboard/directives/task-status-card/task-status-card.coffee
+++ b/src/app/projects/states/dashboard/directives/task-dashboard/directives/task-status-card/task-status-card.coffee
@@ -26,10 +26,7 @@ angular.module('doubtfire.projects.states.dashboard.directives.task-dashboard.di
 
     # Triggers a new task status
     $scope.triggerTransition = (trigger) ->
-      if trigger == 'ready_to_mark' && $scope.task.isPastDueDate() && !$scope.task.isOverdue()
-        ExtensionModal.show($scope.task, () -> $scope.task.triggerTransition(trigger, $scope.unitRole))
-      else
-        $scope.task.triggerTransition(trigger, $scope.unitRole)
+      $scope.task.triggerTransition(trigger, $scope.unitRole)
 
     # Allow upload of new files for an updated submission
     $scope.updateFilesInSubmission = ->


### PR DESCRIPTION
Auto trigger does not check for existing extension requests, and we should generally make the user responsible for this.