### PR TITLE
Responsive redesign for header.tpl.html to fit for mobile devices.

### DIFF
--- a/src/app/common/header/header.scss
+++ b/src/app/common/header/header.scss
@@ -5,7 +5,20 @@
   border-right: none;
   margin-bottom: 0;
 }
-
+#header-container,#breadcrumb-container {
+  width:100%;
+}
+#breadcrumb-col1 {
+  padding-left:0px;
+  padding-right:50px;
+}
+#breadcrumb-col2 {
+  margin-right:25px;
+  padding-left:0px;
+}
+#breadcrumb-col3 {
+  padding-left:0px;
+}
 .navbar ul.breadcrumb {
   margin: 0;
   padding-left: 0;

--- a/src/app/common/header/header.tpl.html
+++ b/src/app/common/header/header.tpl.html
@@ -10,21 +10,21 @@
   </div>
   <!-- Collect the nav links, forms, and other content for toggling -->
   <div class="collapse navbar-collapse" ng-class="!navCollapsed && 'in'" ng-show="!navCollapsed">
-    <div class="container" style="width:100%">
+    <div class="container" id="header-container">
       <div class="row">
         <div class="col-md-6">
     <ul class="nav navbar-nav navbar-left">
       <ul class="breadcrumb">
-        <div class="container" style="width:100%">
+        <div class="container" id="breadcrumb-container">
           <div class="row">
-            <div class="col-md-1" style="padding-left:0px;padding-right:50px;">
+            <div class="col-md-1" id="breadcrumb-col1">
         <li>
           <a class="home" ui-sref="home">
             <i class="logo"></i>
           </a>
         </li><!--/home-->
             </div>
-        <div class="col-md-6" style="padding-right:100px;padding-left:0px;">
+        <div class="col-md-6" id="breadcrumb-col2">
             <li>
           <div class="btn-group" dropdown>
             <button type="button" class="btn btn-default dropdown-toggle" dropdown-toggle>
@@ -39,7 +39,7 @@
           </div>
         </li><!--/selected-unit-->
             </div>
-            <div class="col-md-4" style="padding-left:0px;">
+            <div class="col-md-4" id="breadcrumb-col3">
         <li ng-if="task && tutor">
           <div class="btn-group" dropdown>
             <button type="button" class="btn btn-default dropdown-toggle" dropdown-toggle>

--- a/src/app/common/header/header.tpl.html
+++ b/src/app/common/header/header.tpl.html
@@ -10,14 +10,22 @@
   </div>
   <!-- Collect the nav links, forms, and other content for toggling -->
   <div class="collapse navbar-collapse" ng-class="!navCollapsed && 'in'" ng-show="!navCollapsed">
+    <div class="container" style="width:100%">
+      <div class="row">
+        <div class="col-md-6">
     <ul class="nav navbar-nav navbar-left">
       <ul class="breadcrumb">
+        <div class="container" style="width:100%">
+          <div class="row">
+            <div class="col-md-1" style="padding-left:0px;padding-right:50px;">
         <li>
           <a class="home" ui-sref="home">
             <i class="logo"></i>
           </a>
         </li><!--/home-->
-        <li>
+            </div>
+        <div class="col-md-6" style="padding-right:100px;padding-left:0px;">
+            <li>
           <div class="btn-group" dropdown>
             <button type="button" class="btn btn-default dropdown-toggle" dropdown-toggle>
               <label class="label label-unit" ng-if="unit">
@@ -30,6 +38,8 @@
             <unit-dropdown></unit-dropdown>
           </div>
         </li><!--/selected-unit-->
+            </div>
+            <div class="col-md-4" style="padding-left:0px;">
         <li ng-if="task && tutor">
           <div class="btn-group" dropdown>
             <button type="button" class="btn btn-default dropdown-toggle" dropdown-toggle>
@@ -136,8 +146,14 @@
             </ul><!--/teaching-tasks-->
           </div>
         </li><!--/task-dropdown-->
+          </div>
+            </div>
+          </div>
       </ul><!--breadcrumbs-->
     </ul><!--/nav-left-->
+      </div>
+          <div class="col-md-2"></div>
+          <div class="col-md-4">
     <ul class="nav navbar-nav navbar-right">
       <li class="dropdown" dropdown if-role="Admin Convenor">
         <a class="dropdown-toggle" dropdown-toggle><span class="glyphicon glyphicon-wrench"></span> Administration<b class="caret"></b></a>
@@ -163,5 +179,8 @@
         </ul>
       </li><!--/current-user-->
     </ul><!--/navbar-right-->
+          </div>
+        </div>
+      </div>
   </div><!--/navbar-collapse-->
 </nav>


### PR DESCRIPTION
Made changes to solve the overlapping issue in header for mobile device view and medium devices so that it is responsive.I have uploaded the screenshot of existing mobile view and the view after making changes. The ones in the laptop chrome browser is the view after making the changes and the mobile screenshot is existing mobile view.
<img width="1440" alt="Screen Shot 2019-08-23 at 4 48 22 pm" src="https://user-images.githubusercontent.com/48472135/63577099-7f8d7080-c542-11e9-8361-ffc9de67c50e.png"> 
![existing](https://user-images.githubusercontent.com/48472135/63577102-81573400-c542-11e9-9bbf-41192f971498.jpg)

<img width="1440" alt="Screen Shot 2019-08-23 at 4 45 58 pm" src="https://user-images.githubusercontent.com/48472135/63577081-756b7200-c542-11e9-9d13-69e677c239ca.png">
<img width="1440" alt="Screen Shot 2019-08-23 at 4 46 42 pm" src="https://user-images.githubusercontent.com/48472135/63577092-7b615300-c542-11e9-8384-c2b4483b1681.png">
<img width="1440" alt="Screen Shot 2019-08-23 at 4 47 36 pm" src="https://user-images.githubusercontent.com/48472135/63577094-7c928000-c542-11e9-9eb1-562f77ff7b3a.png">
<img width="1440" alt="Screen Shot 2019-08-23 at 4 47 08 pm" src="https://user-images.githubusercontent.com/48472135/63577098-7ef4da00-c542-11e9-89f2-a430b9cdabff.png">



.