### PR TITLE
NEW: Add tab to upload task assessment resources

### DIFF
--- a/src/app/tasks/task-definition-editor/task-definition-editor.tpl.html
+++ b/src/app/tasks/task-definition-editor/task-definition-editor.tpl.html
@@ -254,7 +254,7 @@
               <div ng-show="activeTab == taskAdmin.tabsData.taskAssessmentResources">
                   <div class="panel-body large-notice-block" ng-hide="task && task.id">
                   </div>
-                  <!-- <task-assessor [task]="task"> -->
+                  <task-assessor [task]="task">
                       <div ng-if="task && task.id">
                           <file-uploader
                             files="taskAssessmentResources"
@@ -268,7 +268,7 @@
                             <i class="fa fa-trash-o"></i> Delete Assessment Resources
                           </a>
                         </div>
-                  <!-- </task-assessor> -->
+                  </task-assessor>
               </div> <!--/ upload task assessment resources-->
             </div><!--/panel-body-area-->
             <div class="panel-footer text-right" ng-show="activeTab == taskAdmin.tabsData.fileUpload">


### PR DESCRIPTION


# Description
This PR adds a new task assessment resources tab that lets the unit chair upload task assessment resources per task.
Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

I tested it manually. I uploaded a file through this tab and it appaered where it should be in doubt fire-api.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

If you have any questions, please contact @macite or @jakerenzella.

<img width="684" alt="Screen Shot 2019-11-14 at 5 11 13 pm" src="https://user-images.githubusercontent.com/53207655/68831207-d77ee200-0701-11ea-9b48-03717013f9f4.png">