### PR TITLE
Doubtfire-web Installation Updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,21 @@ If you will be using [Docker](https://github.com/doubtfire-lms/doubtfire-api/#ge
 
 Before you get started, make sure you have the [Doubtfire API](https://github.com/doubtfire-lms/doubtfire-api) up and running. You will need to do this before continuing.
 
+First, clone the web repository, and change to the root directory:
+
+```
+$ git clone https://github.com/doubtfire-lms/doubtfire-web.git
+$ cd ./doubtfire-web
+```
+
+You can automate the installation process by running the automated setup script:
+
+```
+$ ./setup.sh
+```
+
+Or, you can continue following the below steps to manually install `doubtfire-web`.
+
 Install [Node.js](http://nodejs.org/) either by [downloading it](http://nodejs.org/download/) and installing it manually, or via [Homebrew](http://brew.sh) on OS X:
 
 ```
@@ -261,15 +276,8 @@ $ brew install node
 _or_ by using `apt-get` on Linux:
 
 ```
-$ curl -sL https://deb.nodesource.com/setup_5.x | sudo -E bash -
-$ sudo apt-get install nodejs nodejs-legacy
-```
-
-Clone the web repository, and change to the root directory:
-
-```
-$ git clone https://github.com/doubtfire-lms/doubtfire-web.git
-$ cd ./doubtfire-web
+$ curl -sL https://deb.nodesource.com/setup_10.x | sudo -E bash -
+$ sudo apt-get install nodejs
 ```
 
 Install [overcommit](https://github.com/brigade/overcommit) and Ruby [SASS](http://sass-lang.com):
@@ -301,13 +309,13 @@ $ npm install
 
 **Note:** You may need to install `grunt-cli` globally in Linux using `sudo`.
 
-Lastly, to compile and run a watch server and web server, use `npm install`:
+Lastly, to compile and run a watch server and web server, use `npm start`:
 
 ```
-$ npm install
+$ npm start
 ```
 
-This will automaticall run the angular 1 `grunt watch`, and the angular 7 `ng serve`.
+This will automatically run the angular 1 `grunt watch`, and the angular 7 `ng serve`.
 
 You can then navigate to the Doubtfire web interface at **http://localhost:8000**.
 

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+
+#!/bin/bash
+
+#
+# Detects if system is macOS
+#
+is_mac() {
+    if [[ `uname` == "Darwin" ]]; then
+        return 0
+    else
+        return 1
+    fi
+}
+
+#
+# Detects if system is Linux
+#
+is_linux() {
+    if [[ `uname` == "Linux" ]]; then
+        return 0
+    else
+        return 1
+    fi
+}
+
+#
+# Detects if environment is ZSH
+#
+is_zsh() {
+    if [ -n "$ZSH_VERSION" ]; then
+        return 0
+    elif [ -n "$BASH_VERSION" ]; then
+        return 1
+    fi
+}
+
+#
+# Resets the color
+#
+msg_reset () {
+  RESET='\033[0m'
+  printf "${RESET}\n"
+}
+
+#
+# Log an error
+#
+error () {
+  RED_FORE='\033[0;31m'
+  printf "${RED_FORE}ERROR: $1"
+  msg_reset
+}
+
+#
+# Log verbose message
+#
+verbose () {
+  CYAN_FORE='\033[0;36m'
+  printf "${CYAN_FORE}INFO: $1"
+  msg_reset
+}
+
+#
+# Log message
+#
+msg () {
+  printf "$1\n"
+}
+
+install_web() {
+	msg "Install Web Interface..."
+	curl -sL https://deb.nodesource.com/setup_10.x | sudo -E bash -
+	sudo apt-get install -y nodejs
+	gem install sass
+	rbenv rehash
+	overcommit --install
+	overcommit --sign
+	npm install
+}
+
+install_web
+msg "You should now be able to launch the doubtfire web interface using 'npm start'"
+


### PR DESCRIPTION
This PR seeks to merge updates to the Doubtfire-web installation in Ubuntu. Specifically, it creates an installation script, and updates the corresponding information in the readme.md.

# How Has This Been Tested?

The installation process described in the updated documentation has been tested from scratch, resulting in a functional instance of Doubtfire-web. Similarly, the ./setup.sh script has been tested from scratch (n.b. only using Ubuntu 18.04 LTS), also resulting in a functional instance of Doubtfire-web.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works

If you have any questions, please contact @macite or @jakerenzella.
