### PR TITLE
NEW: Specify stream for unit tasks

### DIFF
--- a/src/app/common/services/unit-service.coffee
+++ b/src/app/common/services/unit-service.coffee
@@ -223,6 +223,10 @@ angular.module("doubtfire.common.services.units", [])
     unit.hasGroupwork = ->
       unit.group_sets?.length > 0
 
+    # Check if there are any streams
+    unit.hasStreams = ->
+      unit.tutorial_streams?.length > 0
+
     #
     # Push all of the tasks downloaded into the existing student projects
     #

--- a/src/app/tasks/task-definition-editor/task-definition-editor.coffee
+++ b/src/app/tasks/task-definition-editor/task-definition-editor.coffee
@@ -62,6 +62,12 @@ angular.module('doubtfire.tasks.task-definition-editor', [])
       $scope.task.has_task_sheet = true
       # $scope.filesUploaded = response
 
+    # Assign task the stream - this is called
+    # From the template as you can't ngModel
+    # With dropdown
+    $scope.changeTaskStream = (task, stream) ->
+      task.tutorial_stream = stream
+
     $scope.taskPDFUrl = ->
       "#{Task.getTaskPDFUrl($scope.unit, $scope.task)}&as_attachment=true"
 
@@ -164,6 +170,7 @@ angular.module('doubtfire.tasks.task-definition-editor', [])
       task.unit_id = $scope.unit.id
       task.upload_requirements = JSON.stringify $scope.task.upload_requirements
       task.plagiarism_checks = JSON.stringify $scope.task.plagiarism_checks
+      task.tutorial_stream_abbr = $scope.task.tutorial_stream
       if task.group_set
         task.group_set_id = task.group_set.id
       else

--- a/src/app/tasks/task-definition-editor/task-definition-editor.tpl.html
+++ b/src/app/tasks/task-definition-editor/task-definition-editor.tpl.html
@@ -45,6 +45,22 @@
                   </div>
                 </div><!--/abbr-->
 
+                <div class="form-group" ng-show="unit.hasStreams()" ng-required="isNew">
+                  <label class="col-sm-3 control-label">Stream</label>
+                  <div class="col-sm-8">
+                    <div class="btn-group dropdown" dropdown>
+                      <span>
+                        <button type="button" class="btn btn-default dropdown-toggle" dropdown-toggle>
+                          {{task.tutorial_stream ? task.tutorial_stream : 'None'}} <span class="caret"></span>
+                        </button>
+                      </span>
+                      <ul class="dropdown-menu">
+                        <li ng-repeat="stream in unit.tutorial_streams | orderBy:'abbreviation'"><a ng-click="changeTaskStream(task, stream.abbreviation)" ng-hide="stream.abbreviation == task.tutorial_stream">{{stream.abbreviation}}</a></li>
+                      </ul>
+                    </div>
+                  </div>
+                </div><!--/stream-->
+
                 <div class="form-group" ng-required="isNew">
                   <label class="col-sm-3 control-label">Grade</label>
                   <div class="col-sm-7">

--- a/src/app/units/states/edit/directives/unit-tasks-editor/unit-tasks-editor.tpl.html
+++ b/src/app/units/states/edit/directives/unit-tasks-editor/unit-tasks-editor.tpl.html
@@ -46,12 +46,17 @@
                     Deadline <i ng-show="taskAdminPager.sortOrder=='due_date'" class="fa fa-caret-{{taskAdminPager.reverse ? 'down' : 'up'}}"></i>
                   </a>
                 </th>
+                <th>
+                  <a ng-click="taskAdminPager.sortOrder='tutorial_stream'; taskAdminPager.reverse=!taskAdminPager.reverse">
+                    Stream <i ng-show="taskAdminPager.sortOrder=='tutorial_stream'" class="fa fa-caret-{{taskAdminPager.reverse ? 'down' : 'up'}}"></i>
+                  </a>
+                </th>
                 <th ng-show="unit.hasGroupwork()">
                   <a ng-click="taskAdminPager.sortOrder='group_set_id'; taskAdminPager.reverse=!taskAdminPager.reverse">
                     Group Set <i ng-show="taskAdminPager.sortOrder=='group_set_id'" class="fa fa-caret-{{taskAdminPager.reverse ? 'down' : 'up'}}"></i>
                   </a>
                 </th>
-                <th>
+                <th ng-show="unit.hasStreams()">
                   <a ng-click="taskAdminPager.sortOrder='upload_requirements.length'; taskAdminPager.reverse=!taskAdminPager.reverse">
                     <i class="fa fa-upload" tooltip="The number of files the student needs to submit."></i> <i ng-show="taskAdminPager.sortOrder=='upload_requirements.length'" class="fa fa-caret-{{taskAdminPager.reverse ? 'down' : 'up'}}"></i>
                   </a>
@@ -79,6 +84,7 @@
                 <td>{{taskDef.target_date | date : 'EEE d MMM' : '+0000'}}</td>
                 <td><span ng-show="taskDef.due_date">{{taskDef.due_date | date : 'EEE d MMM' : '+0000'}}</span><span ng-hide="taskDef.due_date">None</span></td>
                 <td ng-show="unit.hasGroupwork()">{{groupSetName(taskDef.group_set_id)}}</td>
+                <td ng-show="unit.hasStreams()">{{taskDef.tutorial_stream}}</td>
                 <td>{{taskDef.upload_requirements.length}}</td>
                 <td><i ng-show="taskDef.hasPlagiarismCheck()" class="fa fa-check"></i><i ng-hide="taskDef.hasPlagiarismCheck()" class="fa fa-times"></i></td>
                 <td><i ng-show="taskDef.restrict_status_updates" class="fa fa-check"></i><i ng-hide="taskDef.restrict_status_updates" class="fa fa-times"></i></td>


### PR DESCRIPTION
# Description

Note that the below  changes are only operational within units that have at least one stream

Add a stream column to the Unit Task List:
![image](https://user-images.githubusercontent.com/49075321/73708095-8a833880-4751-11ea-8cee-64c382d0c368.png)

When editing task, enable the ability to specify which stream the task belongs to:
![image](https://user-images.githubusercontent.com/49075321/73708185-cae2b680-4751-11ea-9299-d5118013dae9.png)

## Type of change
- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
