### PR TITLE
FEATURE: Specify main convenor

### DIFF
--- a/src/app/units/states/edit/directives/unit-staff-editor/unit-staff-editor.coffee
+++ b/src/app/units/states/edit/directives/unit-staff-editor/unit-staff-editor.coffee
@@ -20,6 +20,14 @@ angular.module('doubtfire.units.states.edit.directives.unit-staff-editor', [])
         (response) ->
           alertService.add("danger", response.data.error, 6000)
 
+    $scope.changeMainConvenor = (staff) ->
+      Unit.update {id: $scope.unit.id, unit: {main_convenor_id: staff.id}},
+        (response) ->
+          alertService.add("success", "Main convenor changed", 2000)
+          $scope.unit.main_convenor_id = staff.id
+        (response) ->
+          alertService.add("danger", response.data.error, 6000)
+
     $scope.addSelectedStaff = ->
       staff = $scope.selectedStaff
       $scope.selectedStaff = null

--- a/src/app/units/states/edit/directives/unit-staff-editor/unit-staff-editor.tpl.html
+++ b/src/app/units/states/edit/directives/unit-staff-editor/unit-staff-editor.tpl.html
@@ -27,9 +27,9 @@
                   </div>
                 </td>
                 <td>
-                  <label ng-show="staff.role == 'Convenor'" class="btn btn-default" ng-model="" btn-radio="true">
-                    <i class="fa fa-check"></i>
-                  </label>
+                  <button ng-show="staff.role == 'Convenor'" type="button" class="btn btn-default" ng-model="unit.main_convenor_id" ng-click="changeMainConvenor(staff)" btn-checkbox btn-checkbox-true="1" btn-checkbox-false="0">
+                    <i class="fa fa-{{staff.id == unit.main_convenor_id ? 'check' : 'times'}}"></i>
+                  </button>
                 </td>
                 <td>
                   <button class="btn btn-danger" ng-click="removeStaff(staff)">

--- a/src/app/units/states/edit/directives/unit-staff-editor/unit-staff-editor.tpl.html
+++ b/src/app/units/states/edit/directives/unit-staff-editor/unit-staff-editor.tpl.html
@@ -1,4 +1,10 @@
 <div class="unit-staff-editor">
+  <script type="text/ng-template" id="customTemplate.html">
+  <a>
+    <user-icon></user-icon>
+    <span bind-html-unsafe="match.label | typeaheadHighlight:query"></span>
+  </a>
+</script>
   <div class="panel panel-primary">
     <div class="panel-heading">
       <h3 class="panel-title">Modify Unit Staff</h3>
@@ -22,7 +28,7 @@
                 <td> {{staff.name}} </td>
                 <td>
                   <div class="btn-group">
-                    <label class="btn btn-default" ng-model="staff.role" btn-radio="'Tutor'" ng-click="changeRole(staff,2)">Tutor</label>
+                    <label class="btn btn-default" data-toggle="tooltip" data-placement="top" title="Hooray!" ng-model="staff.role" btn-radio="'Tutor'" ng-click="changeRole(staff,2)">Tutor</label>
                     <label class="btn btn-default" ng-model="staff.role" btn-radio="'Convenor'" ng-click="changeRole(staff,3)">Convenor</label>
                   </div>
                 </td>
@@ -50,6 +56,7 @@
           placeholder="Staff Name"
           ng-model="selectedStaff"
           typeahead="staff as staff.full_name for staff in staff | filter: $viewValue | filter: filterStaff"
+          typeahead-template-url="customTemplate.html"
           autocomplete="off"
           typeahead-editable="false"
           typeahead-wait-ms="200"

--- a/src/app/units/states/edit/directives/unit-staff-editor/unit-staff-editor.tpl.html
+++ b/src/app/units/states/edit/directives/unit-staff-editor/unit-staff-editor.tpl.html
@@ -1,4 +1,10 @@
 <div class="unit-staff-editor">
+  <script type="text/ng-template" id="staffAvatar.html">
+    <a>
+      <!-- This is where a user icon can go -->
+      <span bind-html-unsafe="match.label | typeaheadHighlight:query"></span>
+    </a>
+  </script>
   <div class="panel panel-primary">
     <div class="panel-heading">
       <h3 class="panel-title">Modify Unit Staff</h3>
@@ -11,7 +17,7 @@
           <table class="table table-condensed table-hover">
             <thead>
               <tr>
-                <th> Name </th>
+                <th colspan="2"> Name </th>
                 <th> Role </th>
                 <th> Main Convenor </th>
                 <th> Actions </th>
@@ -19,7 +25,12 @@
             </thead>
             <tbody>
               <tr ng-repeat="staff in unit.staff">
-                <td> {{staff.name}} </td>
+                <td style="width: 35px;">
+                    <user-icon size="50" user="staff" email="staff.email" style="max-width: 35px; max-height: 35px; font-size: 14px;"></user-icon>
+                </td>
+                <td>
+                    {{staff.name}}
+                </td>
                 <td>
                   <div class="btn-group">
                     <label class="btn btn-default" tooltip="Tutors deliver unit content." ng-model="staff.role" btn-radio="'Tutor'" ng-click="changeRole(staff,2)">Tutor</label>
@@ -53,6 +64,7 @@
           autocomplete="off"
           typeahead-editable="false"
           typeahead-wait-ms="200"
+          typeahead-template-url="staffAvatar.html"
           typeahead-select-on-exact="true"
           typeahead-on-select="addSelectedStaff()">
 

--- a/src/app/units/states/edit/directives/unit-staff-editor/unit-staff-editor.tpl.html
+++ b/src/app/units/states/edit/directives/unit-staff-editor/unit-staff-editor.tpl.html
@@ -13,6 +13,7 @@
               <tr>
                 <th> Name </th>
                 <th> Role </th>
+                <th> Main Convenor </th>
                 <th> Actions </th>
               </tr>
             </thead>
@@ -24,6 +25,11 @@
                     <label class="btn btn-default" ng-model="staff.role" btn-radio="'Tutor'" ng-click="changeRole(staff,2)">Tutor</label>
                     <label class="btn btn-default" ng-model="staff.role" btn-radio="'Convenor'" ng-click="changeRole(staff,3)">Convenor</label>
                   </div>
+                </td>
+                <td>
+                  <label ng-show="staff.role == 'Convenor'" class="btn btn-default" ng-model="" btn-radio="true">
+                    <i class="fa fa-check"></i>
+                  </label>
                 </td>
                 <td>
                   <button class="btn btn-danger" ng-click="removeStaff(staff)">

--- a/src/app/units/states/edit/directives/unit-staff-editor/unit-staff-editor.tpl.html
+++ b/src/app/units/states/edit/directives/unit-staff-editor/unit-staff-editor.tpl.html
@@ -1,10 +1,4 @@
 <div class="unit-staff-editor">
-  <script type="text/ng-template" id="customTemplate.html">
-  <a>
-    <user-icon></user-icon>
-    <span bind-html-unsafe="match.label | typeaheadHighlight:query"></span>
-  </a>
-</script>
   <div class="panel panel-primary">
     <div class="panel-heading">
       <h3 class="panel-title">Modify Unit Staff</h3>
@@ -56,7 +50,6 @@
           placeholder="Staff Name"
           ng-model="selectedStaff"
           typeahead="staff as staff.full_name for staff in staff | filter: $viewValue | filter: filterStaff"
-          typeahead-template-url="customTemplate.html"
           autocomplete="off"
           typeahead-editable="false"
           typeahead-wait-ms="200"

--- a/src/app/units/states/edit/directives/unit-staff-editor/unit-staff-editor.tpl.html
+++ b/src/app/units/states/edit/directives/unit-staff-editor/unit-staff-editor.tpl.html
@@ -27,7 +27,7 @@
                   </div>
                 </td>
                 <td>
-                  <button ng-show="staff.role == 'Convenor'" type="button" class="btn btn-default" ng-model="unit.main_convenor_id" ng-click="changeMainConvenor(staff)" btn-checkbox btn-checkbox-true="1" btn-checkbox-false="0">
+                  <button ng-show="staff.role == 'Convenor'" ng-disabled="staff.id == unit.main_convenor_id" type="button" class="btn btn-default" ng-model="unit.main_convenor_id" ng-click="changeMainConvenor(staff)" btn-checkbox>
                     <i class="fa fa-{{staff.id == unit.main_convenor_id ? 'check' : 'times'}}"></i>
                   </button>
                 </td>

--- a/src/app/units/states/edit/directives/unit-staff-editor/unit-staff-editor.tpl.html
+++ b/src/app/units/states/edit/directives/unit-staff-editor/unit-staff-editor.tpl.html
@@ -22,8 +22,8 @@
                 <td> {{staff.name}} </td>
                 <td>
                   <div class="btn-group">
-                    <label class="btn btn-default" data-toggle="tooltip" data-placement="top" title="Hooray!" ng-model="staff.role" btn-radio="'Tutor'" ng-click="changeRole(staff,2)">Tutor</label>
-                    <label class="btn btn-default" ng-model="staff.role" btn-radio="'Convenor'" ng-click="changeRole(staff,3)">Convenor</label>
+                    <label class="btn btn-default" tooltip="Tutors deliver unit content." ng-model="staff.role" btn-radio="'Tutor'" ng-click="changeRole(staff,2)">Tutor</label>
+                    <label class="btn btn-default" tooltip="Convenors manage the unit." ng-model="staff.role" btn-radio="'Convenor'" ng-click="changeRole(staff,3)">Convenor</label>
                   </div>
                 </td>
                 <td>


### PR DESCRIPTION
# Description
Enable the selection of main convenor for a unit from a unit's staff list. Note that only one staff member may a convenor.

If we want to include the user icon in the drop down when adding new staff to a unit, the unit serialiser will need to be extended to include each staff member's email in the unit's staff list.

![image](https://user-images.githubusercontent.com/49075321/74398605-505e1900-4e6c-11ea-9c08-293239317162.png)


## Type of change
- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
