### PR TITLE
FIX: Entity Form Sorting

### DIFF
--- a/src/app/admin/states/activities/activity-type-list/activity-type-list.component.html
+++ b/src/app/admin/states/activities/activity-type-list/activity-type-list.component.html
@@ -5,7 +5,7 @@
       <p>Add new activities or modify existing ones</p>
     </div>
   </div>
-  <table mat-table [dataSource]="dataSource" matSort (matSortChange)="sortTableData($event)">
+  <table mat-table [dataSource]="dataSource" matSort (matSortChange)="sortTableData($event)" class="mat-elevation-z3">
 
     <!-- Name Column -->
     <ng-container [formGroup]="formData" matColumnDef="name">

--- a/src/app/admin/states/activities/activity-type-list/activity-type-list.component.html
+++ b/src/app/admin/states/activities/activity-type-list/activity-type-list.component.html
@@ -5,7 +5,7 @@
       <p>Add new activities or modify existing ones</p>
     </div>
   </div>
-  <table mat-table [dataSource]="dataSource" matSort class="mat-elevation-z4">
+  <table mat-table [dataSource]="dataSource" matSort (matSortChange)="sortTableData($event)">
 
     <!-- Name Column -->
     <ng-container [formGroup]="formData" matColumnDef="name">

--- a/src/app/admin/states/activities/activity-type-list/activity-type-list.component.ts
+++ b/src/app/admin/states/activities/activity-type-list/activity-type-list.component.ts
@@ -5,7 +5,7 @@ import { ActivityTypeService } from 'src/app/api/models/activity-type/activity-t
 import { alertService } from 'src/app/ajs-upgraded-providers';
 import { EntityFormComponent } from 'src/app/common/entity-form/entity-form.component';
 import { FormControl, Validators } from '@angular/forms';
-import { MatSort } from '@angular/material/sort';
+import { MatSort, Sort } from '@angular/material/sort';
 
 @Component({
   selector: 'activity-type-list',
@@ -64,5 +64,17 @@ export class ActivityTypeListComponent extends EntityFormComponent<ActivityType>
   // which then calls the parent's submit.
   submit() {
     super.submit(this.activityTypeService, this.alerts, this.onSuccess.bind(this));
+  }
+
+  // Sorting function to sort data when sort
+  // event is triggered
+  sortTableData(sort: Sort) {
+    if (!sort.active || sort.direction === '') {
+      return;
+    }
+    switch (sort.active) {
+      case 'name':
+      case 'abbreviation': return super.sortTableData(sort);
+    }
   }
 }

--- a/src/app/admin/states/campuses/campus-list/campus-list.component.html
+++ b/src/app/admin/states/campuses/campus-list/campus-list.component.html
@@ -5,7 +5,7 @@
       <p>Add new campuses or modify existing ones</p>
     </div>
   </div>
-  <table #table mat-table [dataSource]="dataSource" matSort class="mat-elevation-z3">
+  <table #table mat-table [dataSource]="dataSource" matSort (matSortChange)="sortTableData($event)" class="mat-elevation-z3">
 
     <!-- Name Column -->
     <ng-container [formGroup]="formData" matColumnDef="name">

--- a/src/app/admin/states/campuses/campus-list/campus-list.component.ts
+++ b/src/app/admin/states/campuses/campus-list/campus-list.component.ts
@@ -80,7 +80,9 @@ export class CampusListComponent extends EntityFormComponent<Campus> {
     }
     switch (sort.active) {
       case 'name':
-      case 'abbreviation': return super.sortTableData(sort);
+      case 'abbreviation':
+      case 'mode':
+      case 'active': return super.sortTableData(sort);
     }
   }
 }

--- a/src/app/admin/states/campuses/campus-list/campus-list.component.ts
+++ b/src/app/admin/states/campuses/campus-list/campus-list.component.ts
@@ -1,6 +1,6 @@
 import { Component, Inject, ViewChild } from '@angular/core';
 import { alertService } from 'src/app/ajs-upgraded-providers';
-import { MatSort } from '@angular/material/sort';
+import { MatSort, Sort } from '@angular/material/sort';
 import { MatTableDataSource, MatTable } from '@angular/material/table';
 import { FormControl, Validators } from '@angular/forms';
 import { CampusService } from 'src/app/api/models/campus/campus.service';
@@ -70,5 +70,17 @@ export class CampusListComponent extends EntityFormComponent<Campus> {
   // which then calls the parent's submit.
   submit() {
     super.submit(this.campusService, this.alerts, this.onSuccess.bind(this));
+  }
+
+  // Sorting function to sort data when sort
+  // event is triggered
+  sortTableData(sort: Sort) {
+    if (!sort.active || sort.direction === '') {
+      return;
+    }
+    switch (sort.active) {
+      case 'name':
+      case 'abbreviation': return super.sortTableData(sort);
+    }
   }
 }

--- a/src/app/common/entity-form/entity-form.component.ts
+++ b/src/app/common/entity-form/entity-form.component.ts
@@ -4,10 +4,11 @@ import { Entity } from 'src/app/api/models/entity';
 import { EntityService, HttpOptions } from 'src/app/api/models/entity.service';
 import { Observable } from 'rxjs';
 import { Sort } from '@angular/material/sort';
+import { MatTableDataSource } from '@angular/material/table';
 
 export type OnSuccessMethod<T> = (object: T, isNew: boolean) => void;
 
-export abstract class EntityFormComponent<T extends Entity> implements OnInit {
+export class EntityFormComponent<T extends Entity> implements OnInit {
 
   // formData consists of the various FormControl elements that the form is made up of.
   // See FormGroup:     https://angular.io/api/forms/FormGroup
@@ -38,6 +39,8 @@ export abstract class EntityFormComponent<T extends Entity> implements OnInit {
   // and the same with campus as { campus_id: y }.
   // See unit-tutorials-list.component
   formDataMapping = {};
+
+  dataSource: MatTableDataSource<T>;
 
   /**
    * Create a new instance of EntityFormComponent.
@@ -213,7 +216,7 @@ export abstract class EntityFormComponent<T extends Entity> implements OnInit {
    * prepares the form's inputs to be sent off to the server in order to
    * create a new entity.
    *
-   * @param endPointKey identifies the type of data the server will recieve.
+   * @param endPointKey identifies the type of data the server will receive.
    *
    * @returns object representation of form data.
    */
@@ -256,7 +259,16 @@ export abstract class EntityFormComponent<T extends Entity> implements OnInit {
    *
    * @param sort the event received when sorting has been triggered.
    */
-  abstract sortTableData(sort: Sort);
+  sortTableData(sort: Sort) {
+    if (!sort.active || sort.direction === '') {
+      return;
+    }
+
+    this.dataSource.data = this.dataSource.data.sort((a, b) => {
+      const isAsc = sort.direction === 'asc';
+      return this.sortCompare(a[sort.active], b[sort.active], isAsc);
+    });
+  }
 
   /**
    * Function used by implemented sortTableData to determine the order

--- a/src/app/common/entity-form/entity-form.component.ts
+++ b/src/app/common/entity-form/entity-form.component.ts
@@ -3,10 +3,11 @@ import { FormGroup, AbstractControl } from '@angular/forms';
 import { Entity } from 'src/app/api/models/entity';
 import { EntityService, HttpOptions } from 'src/app/api/models/entity.service';
 import { Observable } from 'rxjs';
+import { Sort } from '@angular/material/sort';
 
 export type OnSuccessMethod<T> = (object: T, isNew: boolean) => void;
 
-export class EntityFormComponent<T extends Entity> implements OnInit {
+export abstract class EntityFormComponent<T extends Entity> implements OnInit {
 
   // formData consists of the various FormControl elements that the form is made up of.
   // See FormGroup:     https://angular.io/api/forms/FormGroup
@@ -241,9 +242,32 @@ export class EntityFormComponent<T extends Entity> implements OnInit {
    *
    * @param resource the value to be compared against the current selection.
    *
-   * @returns whether or not the probided resource is being edited.
+   * @returns whether or not the provided resource is being edited.
    */
   editing(resource): boolean {
     return this.selected === resource;
+  }
+
+  /**
+   * Function to implement custom sorting on implementors of EntityForm.
+   * You will be required to implement this method on inheritors when
+   * the data within the EntityForm contains properties whose values
+   * are objects. See unit-tutorial-list.ts for implementation.
+   *
+   * @param sort the event received when sorting has been triggered.
+   */
+  abstract sortTableData(sort: Sort);
+
+  /**
+   * Function used by implemented sortTableData to determine the order
+   * of values within the EntityForm once sorting has been triggered.
+   *
+   * @param aValue value to be compared against bValue.
+   * @param bValue value to be compared against aValue.
+   *
+   * @returns truthy comparison between aValue and bValue.
+   */
+  protected sortCompare(aValue: number | string, bValue: number | string, isAsc: boolean) {
+    return (aValue < bValue ? -1 : 1) * (isAsc ? 1 : -1);
   }
 }

--- a/src/app/units/states/edit/directives/unit-tutorials-list/unit-tutorials-list.component.html
+++ b/src/app/units/states/edit/directives/unit-tutorials-list/unit-tutorials-list.component.html
@@ -5,13 +5,13 @@
       <button mat-icon-button color="warn" (click)="deleteStream()">
         <mat-icon>delete</mat-icon>
       </button>
-    </div>       
+    </div>
     <ng-template #noStream>
       <h4>Tutorials without a stream</h4>
     </ng-template>
   </div>
 
-  <table mat-table [dataSource]="dataSource" matSort class="mat-elevation-z8">
+  <table mat-table [dataSource]="dataSource" matSort (matSortChange)="sortTableData($event)" class="mat-elevation-z8">
 
     <!-- Abbreviation Column -->
     <ng-container [formGroup]="formData" matColumnDef="abbreviation" sticky>

--- a/src/app/units/states/edit/directives/unit-tutorials-list/unit-tutorials-list.component.html
+++ b/src/app/units/states/edit/directives/unit-tutorials-list/unit-tutorials-list.component.html
@@ -11,7 +11,7 @@
     </ng-template>
   </div>
 
-  <table mat-table [dataSource]="dataSource" matSort (matSortChange)="sortTableData($event)" class="mat-elevation-z8">
+  <table mat-table [dataSource]="dataSource" matSort (matSortChange)="sortTableData($event)" class="mat-elevation-z3">
 
     <!-- Abbreviation Column -->
     <ng-container [formGroup]="formData" matColumnDef="abbreviation" sticky>

--- a/src/app/units/states/edit/directives/unit-tutorials-list/unit-tutorials-list.component.ts
+++ b/src/app/units/states/edit/directives/unit-tutorials-list/unit-tutorials-list.component.ts
@@ -26,7 +26,6 @@ export class UnitTutorialsListComponent extends EntityFormComponent<Tutorial> {
 
   campuses: Campus[] = new Array<Campus>();
   columns: string[] = ['abbreviation', 'campus', 'location', 'day', 'time', 'tutor', 'capacity', 'options'];
-  dataSource: MatTableDataSource<Tutorial>;
   tutorials: Tutorial[];
 
   constructor(
@@ -134,22 +133,21 @@ export class UnitTutorialsListComponent extends EntityFormComponent<Tutorial> {
   // Sorting function to sort data when sort
   // event is triggered
   sortTableData(sort: Sort) {
-    const data = this.tutorials.slice();
     if (!sort.active || sort.direction === '') {
-      this.tutorials = data;
       return;
     }
-
-    this.dataSource.data = data.sort((a, b) => {
+    switch (sort.active) {
+      case 'abbreviation':
+      case 'location':
+      case 'day':
+      case 'time':
+      case 'capacity': return super.sortTableData(sort);
+    }
+    this.dataSource.data = this.dataSource.data.sort((a, b) => {
       const isAsc = sort.direction === 'asc';
       switch (sort.active) {
-        case 'abbreviation': return this.sortCompare(a.abbreviation, b.abbreviation, isAsc);
         case 'campus': return this.sortCompare(a.campus.abbreviation, b.campus.abbreviation, isAsc);
-        case 'location': return this.sortCompare(a.meeting_location, b.meeting_location, isAsc);
-        case 'day': return this.sortCompare(a.meeting_day, b.meeting_day, isAsc);
-        case 'time': return this.sortCompare(a.meeting_time, b.meeting_time, isAsc);
         case 'tutor': return this.sortCompare(a.tutor.name, b.tutor.name, isAsc);
-        case 'capacity': return this.sortCompare(a.capacity, b.capacity, isAsc);
         default: return 0;
       }
     });

--- a/src/app/units/states/edit/directives/unit-tutorials-list/unit-tutorials-list.component.ts
+++ b/src/app/units/states/edit/directives/unit-tutorials-list/unit-tutorials-list.component.ts
@@ -1,6 +1,6 @@
 import { Component, Input, Inject, ViewChild, Output, EventEmitter } from '@angular/core';
 import { alertService } from 'src/app/ajs-upgraded-providers';
-import { MatSort } from '@angular/material/sort';
+import { MatSort, Sort } from '@angular/material/sort';
 import { MatTableDataSource, MatTable } from '@angular/material/table';
 import { Tutorial } from 'src/app/api/models/tutorial/tutorial';
 import { EntityFormComponent } from 'src/app/common/entity-form/entity-form.component';
@@ -129,5 +129,29 @@ export class UnitTutorialsListComponent extends EntityFormComponent<Tutorial> {
   // Handle the deletion of a stream
   deleteStream() {
     this.unit.deleteStream(this.stream);
+  }
+
+  // Sorting function to sort data when sort
+  // event is triggered
+  sortTableData(sort: Sort) {
+    const data = this.tutorials.slice();
+    if (!sort.active || sort.direction === '') {
+      this.tutorials = data;
+      return;
+    }
+
+    this.dataSource.data = data.sort((a, b) => {
+      const isAsc = sort.direction === 'asc';
+      switch (sort.active) {
+        case 'abbreviation': return this.sortCompare(a.abbreviation, b.abbreviation, isAsc);
+        case 'campus': return this.sortCompare(a.campus.abbreviation, b.campus.abbreviation, isAsc);
+        case 'location': return this.sortCompare(a.meeting_location, b.meeting_location, isAsc);
+        case 'day': return this.sortCompare(a.meeting_day, b.meeting_day, isAsc);
+        case 'time': return this.sortCompare(a.meeting_time, b.meeting_time, isAsc);
+        case 'tutor': return this.sortCompare(a.tutor.name, b.tutor.name, isAsc);
+        case 'capacity': return this.sortCompare(a.capacity, b.capacity, isAsc);
+        default: return 0;
+      }
+    });
   }
 }


### PR DESCRIPTION
# Description
Implement sorting functionality on the `EntityForm`. This was required because Angular's `mat-sort-header` can't sort values that are objects, so you need to define how those values are compared in order to sort.
