### PR TITLE
NEW: Add submitted grade to portfolio submission

### DIFF
--- a/src/app/projects/states/portfolio/directives/portfolio-grade-select-step/portfolio-grade-select-step.coffee
+++ b/src/app/projects/states/portfolio/directives/portfolio-grade-select-step/portfolio-grade-select-step.coffee
@@ -12,7 +12,7 @@ angular.module('doubtfire.projects.states.portfolio.directives.portfolio-grade-s
     $scope.grades = gradeService.grades
     $scope.agreedToAssessmentCriteria = $scope.projectHasLearningSummaryReport()
     $scope.chooseGrade = (idx) ->
-      Project.update { id: $scope.project.project_id, target_grade: idx }, (project) ->
-        $scope.project.target_grade = project.target_grade
+      Project.update { id: $scope.project.project_id, submitted_grade: idx }, (project) ->
+        $scope.project.submitted_grade = project.submitted_grade
         $scope.project.burndown_chart_data = project.burndown_chart_data
 )

--- a/src/app/projects/states/portfolio/directives/portfolio-grade-select-step/portfolio-grade-select-step.tpl.html
+++ b/src/app/projects/states/portfolio/directives/portfolio-grade-select-step/portfolio-grade-select-step.tpl.html
@@ -26,8 +26,8 @@
       </div>
       <div class="card-body text-center">
         <div class="btn-group">
-          <label ng-repeat="grade in grades" ng-click="chooseGrade($index); status.isopen=false" class="btn btn-default col-sm-3" ng-model="project.target_grade" btn-radio="{{$index}}">
-            <grade-icon grade="grade" class="text-{{project.target_grade == grades.indexOf(grade) ? 'success' : 'muted'}}"></grade-icon>
+          <label ng-repeat="grade in grades" ng-click="chooseGrade($index); status.isopen=false" class="btn btn-default col-sm-3" ng-model="project.submitted_grade" btn-radio="{{$index}}">
+            <grade-icon grade="grade" class="text-{{project.submitted_grade == grades.indexOf(grade) ? 'success' : 'muted'}}"></grade-icon>
           </label>
         </div>
         <p class="help-block">

--- a/src/app/units/states/portfolios/portfolios.tpl.html
+++ b/src/app/units/states/portfolios/portfolios.tpl.html
@@ -79,6 +79,11 @@
               </a>
             </th>
             <th>
+              <a ng-click="sortOrder='submitted_grade'; reverse=!reverse">
+                Submitted as <i ng-show="sortOrder=='submitted_grade'" class="fa fa-caret-{{reverse ? 'down' : 'up'}}"></i>
+              </a>
+            </th>
+            <th>
               <a ng-click="sortOrder='orderScale'; reverse=!reverse">
                 Stats<i ng-show="sortOrder=='orderScale'" class="fa fa-caret-{{reverse ? 'down' : 'up'}}"></i>
               </a>
@@ -103,6 +108,9 @@
             <td>{{student.shortTutorialDescription()}}</td>
             <td class="flags-data">
               <grade-icon grade="student.target_grade"></grade-icon>
+            </td>
+            <td class="flags-data">
+              <grade-icon grade="student.submitted_grade"></grade-icon>
             </td>
             <td class="task-progress-bar">
               <progress class="task-progress" animate="true">


### PR DESCRIPTION
# Description

This PR ensures the portfolio grade select buttons correctly change the submitted grade, rather than the target grade. It also updates the portfolio assessment table to include the new submitted grade. 
Please refer to doubtfire-api PR for further information: [NEW: Add submitted grade to portfolio submission](https://github.com/doubtfire-lms/doubtfire-api/pull/285)

![submitted_grade](https://user-images.githubusercontent.com/48704308/83366086-21a28900-a3f0-11ea-9e1a-1b5bad83b530.png)




## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- Test that the "submitted_grade" value is modified when selecting the grade select buttons when submitting the portfolio.
- Test that a student cannot change the submitted grade after portfolio has been submitted (through an API request)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
