### PR TITLE
ENHANCE: List only _active_ units for calendar exclusion

### DIFF
--- a/src/app/common/modals/calendar-modal/calendar-modal.component.ts
+++ b/src/app/common/modals/calendar-modal/calendar-modal.component.ts
@@ -18,6 +18,7 @@ export class CalendarModalComponent implements OnInit, AfterViewInit {
   webcal: Webcal | null;
   working: boolean = true;
   copying: boolean = false;
+  projects: any[] = [];
 
   // Used to store user interaction with the reminder option. These values aren't bound directly to `this.webcal`
   // because they are resettable.
@@ -30,17 +31,23 @@ export class CalendarModalComponent implements OnInit, AfterViewInit {
     private constants: DoubtfireConstants,
     private sanitizer: DomSanitizer,
     @Inject(alertService) private alerts: any,
-    @Inject(projectService) private projects: any,
+    @Inject(projectService) private projectService: any,
     dialogRef: MatDialogRef<CalendarModalComponent>,
     @Inject(MAT_DIALOG_DATA) public data: any
   ) {}
 
   ngOnInit() {
+
     // Retrieve current webcal.
     this.working = true;
     this.webcalService.get({}).subscribe((webcal) => {
       this.loadWebcal(webcal);
       this.working = false;
+    });
+
+    // Allow selection of units with active projects.
+    this.projectService.getProjects(false, (projects) => {
+      this.projects = projects.filter((p) => p.teachingPeriod()?.active() ?? true);
     });
   }
 
@@ -194,14 +201,14 @@ export class CalendarModalComponent implements OnInit, AfterViewInit {
    * Retrieves a list of excluded projects.
    */
   get excludedProjects() {
-    return this.projects.loadedProjects.filter((p) => this.webcal.unit_exclusions.indexOf(p.unit_id) !== -1);
+    return this.projects.filter((p) => this.webcal.unit_exclusions.indexOf(p.unit_id) !== -1);
   }
 
   /**
    * Retrieves a list of included projects.
    */
   get includedProjects() {
-    return this.projects.loadedProjects.filter((p) => this.webcal.unit_exclusions.indexOf(p.unit_id) === -1);
+    return this.projects.filter((p) => this.webcal.unit_exclusions.indexOf(p.unit_id) === -1);
   }
 
   /**


### PR DESCRIPTION
# Description

Slight extension to https://github.com/doubtfire-lms/doubtfire-web/pull/293 that lists only active units for exclusion, i.e. only units that are listed on the home page, under "Units You Study".

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings