### PR TITLE
FIX: Ensure material icons style overrides Roboto in typography file

### DIFF
--- a/src/styles/common/typeface.scss
+++ b/src/styles/common/typeface.scss
@@ -1,10 +1,12 @@
-$roboto-path: "./fonts/roboto";
+// TODO: Evaluate when this file can be removed
+
+$roboto-path: './fonts/roboto';
 
 @font-face {
   font-family: 'Roboto';
   font-style: normal;
   font-weight: 300;
-  src: local('Roboto Light'), local('Roboto-Light'), url('#{$roboto-path}/Roboto-Light.woff') format('woff'),
+  src: local('Roboto Light'), local('Roboto-Light'), url('#{$roboto-path}/Roboto-Light.woff') format('woff');
 }
 @font-face {
   font-family: 'Roboto';
@@ -29,4 +31,8 @@ $roboto-path: "./fonts/roboto";
   font-style: italic;
   font-weight: 400;
   src: local('Roboto Italic'), local('Roboto-Italic'), url('#{$roboto-path}/Roboto-Italic.woff') format('woff');
+}
+
+.mat-icon {
+  font-family: 'Material Icons' !important;
 }


### PR DESCRIPTION
# Description

Fixes the issue where material icons would be loaded as Roboto before initialised. 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Run on all browsers locally.

## Testing Checklist:

- [X] Tested in latest Chrome
- [X] Tested in latest Safari
- [X] Tested in latest Firefox

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have requested a review from @macite and @jakerenzella on the Pull Request
