### PR TITLE
FIX: Remove redundant DiscussionComment interface

### DIFF
--- a/src/app/tasks/task-comments-viewer/intelligent-discussion-player/intelligent-discussion-player.component.ts
+++ b/src/app/tasks/task-comments-viewer/intelligent-discussion-player/intelligent-discussion-player.component.ts
@@ -6,17 +6,7 @@ import * as moment from 'moment';
 import { MicrophoneTesterComponent } from 'src/app/common/audio-recorder/audio/microphone-tester/microphone-tester.component';
 import { IntelligentDiscussionRecorderComponent } from './intelligent-discussion-recorder/intelligent-discussion-recorder.component';
 import { AudioPlayerComponent } from 'src/app/common/audio-player/audio-player.component';
-
-interface DiscussionComment {
-  created_at: string;
-  id: number;
-  task_comment_id: number;
-  time_completed: string;
-  time_started: string;
-  response: string;
-  status: string;
-  numberOfPrompts: number;
-}
+import { DiscussionComment } from 'src/app/api/models/task-comment/discussion-comment';
 
 @Component({
   selector: 'intelligent-discussion-player',

--- a/src/tsconfig.app.json
+++ b/src/tsconfig.app.json
@@ -4,11 +4,6 @@
     "outDir": "../out/app",
     "types": []
   },
-  "files": [
-    "main.ts",
-    "polyfills.ts"
-  ],
-  "include": [
-    "src/**/*.d.ts"
-  ]
+  "files": ["main.ts", "polyfills.ts"],
+  "include": ["src/**/*.d.ts", "src/**/*.ts"]
 }


### PR DESCRIPTION
The DiscussionComment used to be an interface on the discussion-player component, however, with the new DIscussionComment class, it should not be used to ensure the type definition reflects the actual properties of the class. Also includes a small change to include all ts files in the tsconfig