### PR TITLE
NEW: Triggering page reload on server changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "watch:angular1": "grunt delta",
     "deploy:clean_api": "../doubtfire-api/clean_ui.sh",
     "deploy:build2api": "ng build --deleteOutputPath=false --optimization=true --prod --output-path ../doubtfire-api/public",
-    "deploy": "run-s -l build:angular1 deploy:clean_api deploy:build2api"
+    "deploy:post-build": "node ./post-build.js",
+    "deploy": "run-s -l build:angular1 deploy:clean_api deploy:build2api deploy:post-build"
   },
   "keywords": [],
   "author": "",

--- a/post-build.js
+++ b/post-build.js
@@ -1,0 +1,60 @@
+const path = require('path');
+const fs = require('fs');
+const util = require('util');
+
+// get application version from package.json
+const appVersion = require('./package.json').version;
+
+// promisify core API's
+const readDir = util.promisify(fs.readdir);
+const writeFile = util.promisify(fs.writeFile);
+const readFile = util.promisify(fs.readFile);
+
+console.log('\nRunning post-build tasks');
+
+// our version.json will be in the dist folder
+const versionFilePath = path.join(__dirname + '/../doubtfire-api/public/api/auto-reload/version.json');
+
+let mainHash = '';
+let mainBundleFile = '';
+
+// RegExp to find main.bundle.js, even if it doesn't include a hash in it's name (dev build)
+let mainBundleRegexp = /^main.([a-z0-9]*).js$/;
+// let mainBundleRegexp = /^main[.]?([a-zA-Z0–9]*)?.js$/;
+
+// read the dist folder files and find the one we're looking for
+readDir(path.join(__dirname, '/../doubtfire-api/public'))
+  .then((files) => {
+    console.log(`${files}`);
+    mainBundleFile = files.find((f) => mainBundleRegexp.test(f));
+    console.log(`main file is ${mainBundleFile}`);
+    if (mainBundleFile) {
+      let matchHash = mainBundleFile.match(mainBundleRegexp);
+      console.log(`Identified main hash - ${matchHash[1]}`);
+      // if it has a hash in it's name, mark it down
+      if (matchHash.length > 1 && !!matchHash[1]) {
+        mainHash = matchHash[1];
+      }
+    }
+    console.log(`Writing version and hash to ${versionFilePath}`);
+    // write current version and hash into the version.json file
+    const src = `{"version": "${appVersion}", "hash": "${mainHash}"}`;
+    return writeFile(versionFilePath, src);
+  })
+  .then(async () => {
+    // main bundle file not found, dev build?
+    if (!mainBundleFile) {
+      return;
+    }
+
+    console.log(`Replacing hash in the ${mainBundleFile}`);
+
+    // replace hash placeholder in our main.js file so the code knows it's current hash
+    const mainFilepath = path.join(__dirname, '/../doubtfire-api/public/', mainBundleFile);
+    const mainFileData = await readFile(mainFilepath, 'utf8');
+    const replacedFile = mainFileData.replace('{{POST_BUILD_ENTERS_HASH_HERE}}', mainHash);
+    return await writeFile(mainFilepath, replacedFile);
+  })
+  .catch((err) => {
+    console.log('Error with post build:', err);
+  });

--- a/src/app/common/services/version-check.service.ts
+++ b/src/app/common/services/version-check.service.ts
@@ -1,0 +1,63 @@
+import { Injectable } from '@angular/core';
+import { HttpClient, HttpHeaders } from '@angular/common/http';
+
+@Injectable({ providedIn: 'root' })
+export class VersionCheckService {
+  // this will be replaced by actual hash post-build.js
+  private currentHash = '{{POST_BUILD_ENTERS_HASH_HERE}}';
+  constructor(private http: HttpClient) {}
+
+  /**
+   * Checks in every set frequency the version of frontend application
+   * @param url - url of version check file
+   * @param {number} frequency - in milliseconds, defaults to 30 minutes
+   */
+  public initVersionCheck(url: string, frequency: number = 1000 * 60 * 30) {
+    setInterval(() => {
+      this.checkVersion(url);
+    }, frequency);
+    this.checkVersion(url);
+  }
+
+  /**
+   * Will do the call and check if the hash has changed or not
+   * @param url
+   */
+  private checkVersion(url: string) {
+    const headers = new HttpHeaders().set('Cache-Control', 'no-cache').set('Pragma', 'no-cache');
+
+    const self = this;
+    // timestamp these requests to invalidate caches
+    this.http.get(url, { headers }).subscribe(
+      (response: any) => {
+        const hash = response.hash;
+        const hashChanged = self.hasHashChanged(self.currentHash, hash);
+        // If new version, do something
+        if (hashChanged) {
+          self.http.get('', { headers, responseType: 'text' }).subscribe(() => window.location.reload());
+        }
+        // store the new hash so we wouldn't trigger versionChange again
+        // only necessary in case you did not force refresh
+        self.currentHash = hash;
+      },
+      (err) => {
+        console.error(err, 'Could not get version');
+      }
+    );
+  }
+
+  /**
+   * Checks if hash has changed.
+   * This file has the JS hash, if it is a different one than in the version.json
+   * we are dealing with version change
+   * @param currentHash
+   * @param newHash
+   * @returns {boolean}
+   */
+  private hasHashChanged(currentHash: string, newHash: any): boolean {
+    if (!currentHash || currentHash === '{{POST_BUILD_ENTERS_HASH_HERE}}') {
+      return false;
+    }
+    return currentHash !== newHash;
+  }
+}

--- a/src/app/doubtfire-angular.module.ts
+++ b/src/app/doubtfire-angular.module.ts
@@ -136,6 +136,7 @@ import {
   UserService,
   WebcalService,
 } from './api/models/doubtfire-model';
+import { VersionCheckService } from './common/services/version-check.service';
 
 @NgModule({
   // Components we declare
@@ -280,6 +281,7 @@ import {
     TasksOfTaskDefinitionPipe,
     TasksInTutorialsPipe,
     TasksForInboxSearchPipe,
+    VersionCheckService,
   ],
 })
 // There is no longer any requirement for an EntryComponents section
@@ -289,6 +291,7 @@ export class DoubtfireAngularModule {
     injector: Injector,
     private upgrade: UpgradeModule,
     private constants: DoubtfireConstants,
+    private versionCheckService: VersionCheckService,
     private title: Title
   ) {
     setAppInjector(injector);
@@ -297,6 +300,10 @@ export class DoubtfireAngularModule {
     this.constants.ExternalName.subscribe((result) => {
       this.title.setTitle(result);
     });
+
+    setTimeout(() => {
+      this.versionCheckService.initVersionCheck(`${this.constants.API_URL}/version`);
+    }, 2000);
   }
 
   ngDoBootstrap() {


### PR DESCRIPTION
This PR will add code that monitors the version currently loaded on the server, and will reload the application when it detects a version change. This should hopefully help fix the issue where people continue to run old versions of the UI for long periods.