### PR TITLE
Fix/fix markdown rendering

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "font-awesome": "~4.6.3",
     "jquery": "2.1.4",
     "lodash": "^4.17.11",
-    "marked": "^0.8.2",
+    "marked": "^2.0.3",
     "moment": "^2.24.0",
     "ng-csv": "0.2.3",
     "ng-file-upload": "~5.0.9",

--- a/src/app/common/pipes/marked.pipe.ts
+++ b/src/app/common/pipes/marked.pipe.ts
@@ -1,15 +1,26 @@
 import { Pipe, PipeTransform } from '@angular/core';
-import * as marked from 'marked';
+import marked from 'marked';
 
 @Pipe({
-  name: 'marked'
+  name: 'marked',
 })
-
 export class MarkedPipe implements PipeTransform {
-  private renderer = new marked.Renderer();
+  // Set the options for the markdown renderer
+  constructor() {
+    marked.setOptions({
+      renderer: new marked.Renderer(),
+      pedantic: false,
+      gfm: true,
+      breaks: false,
+      smartLists: true,
+      smartypants: false,
+      xhtml: false,
+    });
+  }
+
   transform(value: string, ...args: any[]): string {
     if (value && value.length > 0) {
-      return marked.inlineLexer(value, [], {});
+      return marked(value);
     }
     return value;
   }

--- a/src/app/tasks/task-comments-viewer/task-comments-viewer.component.scss
+++ b/src/app/tasks/task-comments-viewer/task-comments-viewer.component.scss
@@ -28,7 +28,6 @@ $comment-inner-border-radius: 4px;
 
 .comments-body {
   overflow-y: auto;
-
   @include scrollable();
 }
 
@@ -308,11 +307,15 @@ $comment-inner-border-radius: 4px;
     .comment-text,
     .comment-pdf,
     .comment-discussion,
-    .markdown-to-html {
+    .markdown-to-html p {
       padding-right: 6px;
       padding-left: 4px;
       word-break: break-word;
       -webkit-font-smoothing: antialiased;
+    }
+
+    .comment-text .markdown-to-html p {
+      margin: 0 0 0 0 !important;
     }
     .comment-audio {
       display: inline-block;
@@ -340,17 +343,21 @@ $comment-inner-border-radius: 4px;
       margin-bottom: 0px;
     }
 
-    .markdown-to-html {
+    .markdown-to-html p {
       padding-left: $comment-text-padding;
       padding-right: $comment-text-padding;
     }
 
-    .markdown-to-html > *:last-child {
+    .text-bubble .comment-text .markdown-to-html p {
+      margin: 0 0 0 0px !important;
+    }
+
+    .markdown-to-html p > *:last-child {
       margin-bottom: 0px;
     }
 
-    .markdown-to-html > pre:last-child {
-      margin-bottom: 0.5em;
+    .markdown-to-html p > pre:last-child {
+      margin-bottom: 0em;
     }
   }
 


### PR DESCRIPTION
# Description

Updates the marked package, and reenables github markdown syntax for all task comments

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested and run locally
![Screen Shot 2021-04-15 at 1 27 23 pm](https://user-images.githubusercontent.com/5138218/114809880-52b06000-9dee-11eb-8ce4-10535f3b2e1b.png)
