### PR TITLE
New: Add service worker forced refresh

### DIFF
--- a/src/app/common/header/header.coffee
+++ b/src/app/common/header/header.coffee
@@ -4,7 +4,7 @@
 angular.module('doubtfire.common.header', [
   'doubtfire.common.header.unit-dropdown'
 ])
-.controller("BasicHeaderCtrl", ($scope, $state, $rootScope, UserNotificationSettingsModal, CalendarModal, UserSettingsModal, currentUser, AboutDoubtfireModal, $transitions, $document, $filter) ->
+.controller("BasicHeaderCtrl", ($scope, $state, $rootScope, UserNotificationSettingsModal, CalendarModal, UserSettingsModal, currentUser, AboutDoubtfireModal, checkForUpdateService, $transitions, $document, $filter) ->
   $scope.currentUser = currentUser.profile
 
   $scope.tutor = $state.params?.tutor?
@@ -26,6 +26,12 @@ angular.module('doubtfire.common.header', [
   #
   $scope.openCalendar = ->
     CalendarModal.show()
+
+  #
+  # Checks for updates
+  #
+  $scope.update = ->
+    checkForUpdateService.checkForupdate()
 
   #
   # Opens the about DF modal

--- a/src/app/common/header/header.tpl.html
+++ b/src/app/common/header/header.tpl.html
@@ -191,6 +191,8 @@
           <li class="divider"></li>
           <li><a ng-click="openAboutModal()">About</a></li>
           <li class="divider"></li>
+          <li><a ng-click="update()">Check for updates</a></li>
+          <li class="divider"></li>
           <li><a ui-sref="sign_out">Sign Out</a></li>
         </ul>
       </li>

--- a/src/app/doubtfire-angular.module.ts
+++ b/src/app/doubtfire-angular.module.ts
@@ -23,6 +23,7 @@ import { MatProgressBarModule } from '@angular/material/progress-bar';
 import { MatSliderModule } from '@angular/material/slider';
 import { MatExpansionModule } from '@angular/material/expansion';
 import { MatStepperModule } from '@angular/material/stepper';
+import { MatSnackBarModule } from '@angular/material/snack-bar';
 import { MatPaginatorModule } from '@angular/material/paginator';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { MatSlideToggleModule } from '@angular/material/slide-toggle';
@@ -223,6 +224,7 @@ import {
     MatTableModule,
     MatTabsModule,
     MatChipsModule,
+    MatSnackBarModule,
     ReactiveFormsModule,
     PickerModule,
     EmojiModule,
@@ -292,7 +294,7 @@ export class DoubtfireAngularModule {
     private upgrade: UpgradeModule,
     private constants: DoubtfireConstants,
     private title: Title,
-    private updater: CheckForUpdateService,
+    private updater: CheckForUpdateService
   ) {
     setAppInjector(injector);
     setTheme('bs3'); // or 'bs4'

--- a/src/app/doubtfire-angular.module.ts
+++ b/src/app/doubtfire-angular.module.ts
@@ -127,6 +127,7 @@ import { TasksForInboxSearchPipe } from './common/filters/tasks-for-inbox-search
 import { StatusIconComponent } from './common/status-icon/status-icon.component';
 import { TaskPlagiarismCardComponent } from './projects/states/dashboard/directives/task-dashboard/directives/task-plagiarism-card/task-plagiarism-card.component';
 import { ScrollingModule } from '@angular/cdk/scrolling';
+import { CheckForUpdateService } from './sessions/service-worker-updater/check-for-update.service';
 import {
   ActivityTypeService,
   CampusService,
@@ -241,6 +242,7 @@ import {
     WebcalService,
     ActivityTypeService,
     EmojiService,
+    CheckForUpdateService,
     userProvider,
     groupServiceProvider,
     unitProvider,
@@ -289,7 +291,8 @@ export class DoubtfireAngularModule {
     injector: Injector,
     private upgrade: UpgradeModule,
     private constants: DoubtfireConstants,
-    private title: Title
+    private title: Title,
+    private updater: CheckForUpdateService,
   ) {
     setAppInjector(injector);
     setTheme('bs3'); // or 'bs4'

--- a/src/app/doubtfire-angularjs.module.ts
+++ b/src/app/doubtfire-angularjs.module.ts
@@ -285,6 +285,7 @@ import { StaffTaskListComponent } from './units/states/tasks/inbox/directives/st
 import { StatusIconComponent } from './common/status-icon/status-icon.component';
 import { TaskPlagiarismCardComponent } from './projects/states/dashboard/directives/task-dashboard/directives/task-plagiarism-card/task-plagiarism-card.component';
 import { TaskCommentService } from './api/models/doubtfire-model';
+import { CheckForUpdateService } from './sessions/service-worker-updater/check-for-update.service';
 
 export const DoubtfireAngularJSModule = angular.module('doubtfire', [
   'doubtfire.config',
@@ -313,6 +314,7 @@ DoubtfireAngularJSModule.factory('streamService', downgradeInjectable(TutorialSt
 DoubtfireAngularJSModule.factory('campusService', downgradeInjectable(CampusService));
 DoubtfireAngularJSModule.factory('webcalService', downgradeInjectable(WebcalService));
 DoubtfireAngularJSModule.factory('emojiService', downgradeInjectable(EmojiService));
+DoubtfireAngularJSModule.factory('checkForUpdateService', downgradeInjectable(CheckForUpdateService));
 
 // directive -> component
 DoubtfireAngularJSModule.directive(

--- a/src/app/sessions/service-worker-updater/check-for-update.service.ts
+++ b/src/app/sessions/service-worker-updater/check-for-update.service.ts
@@ -27,7 +27,7 @@ export class CheckForUpdateService {
     });
 
     this.updates.available.subscribe((event) => {
-      let snackBarRef = this._snackBar.open(
+      const snackBarRef = this._snackBar.open(
         'An update to the app has been found, would you like to refresh now?',
         'refresh'
       );

--- a/src/app/sessions/service-worker-updater/check-for-update.service.ts
+++ b/src/app/sessions/service-worker-updater/check-for-update.service.ts
@@ -1,0 +1,48 @@
+import { ApplicationRef, Injectable } from '@angular/core';
+import { SwUpdate } from '@angular/service-worker';
+import { interval } from 'rxjs';
+import { MatSnackBar } from '@angular/material/snack-bar';
+
+@Injectable()
+export class CheckForUpdateService {
+  constructor(appRef: ApplicationRef, private updates: SwUpdate, private _snackBar: MatSnackBar) {
+    console.log('Checking for updates every 6 hours');
+
+    // Allow the app to stabilize first, before starting polling for updates with `interval()`.
+    // const appIsStable$ = appRef.isStable.pipe(first(isStable => isStable === true));
+
+    // Checks every 4 hours
+    const updateInterval$ = interval(4 * 60 * 60 * 1000);
+    // const updateIntervalOnceAppIsStable$ = concat(appIsStable$, updateInterval$);
+
+    updateInterval$.subscribe(() => {
+      console.log('Checking for updates');
+      // If uncommented, will alert the user that it's checking for updates
+
+      // let snackBarRef = this._snackBar.open('Checking for app updates');
+      // snackBarRef.onAction().subscribe(result => {
+      //     updates.activateUpdate().then(() => document.location.reload());
+      // });
+      this.updates.checkForUpdate();
+    });
+
+    this.updates.available.subscribe((event) => {
+      let snackBarRef = this._snackBar.open(
+        'An update to the app has been found, would you like to refresh now?',
+        'refresh'
+      );
+      snackBarRef.onAction().subscribe((result) => {
+        this.updates.activateUpdate().then(() => document.location.reload());
+      });
+    });
+
+    this.updates.unrecoverable.subscribe((event) => {
+      document.location.reload();
+    });
+  }
+
+  checkForupdate() {
+    console.log('Checking for udpate');
+    this.updates.checkForUpdate();
+  }
+}

--- a/src/manifest.webmanifest
+++ b/src/manifest.webmanifest
@@ -5,7 +5,7 @@
   "background_color": "#fafafa",
   "display": "standalone",
   "scope": "/",
-  "start_url": "/",
+  "start_url": "/index.html",
   "icons": [
     {
       "src": "assets/images/android-chrome-36x36.png",


### PR DESCRIPTION
# Description

Adds an update check service which occasionally prompts the service worker to check for updates of source files on the server, and refreshes if updates are found. Also adds a button to force check for updates. Currently configured to every 4 hours.

## Type of change
- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

This can't be tested locally, so needs to be tested on staging

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] I have requested a review from @macite and @jakerenzella on the Pull Request
