### PR TITLE
fix: fix the data for group and stream not align

### DIFF
--- a/src/app/units/states/edit/directives/unit-tasks-editor/unit-tasks-editor.tpl.html
+++ b/src/app/units/states/edit/directives/unit-tasks-editor/unit-tasks-editor.tpl.html
@@ -47,14 +47,14 @@
                     Deadline <i ng-show="taskAdminPager.sortOrder=='due_date'" class="fa fa-caret-{{taskAdminPager.reverse ? 'down' : 'up'}}"></i>
                   </a>
                 </th>
-                <th>
-                  <a ng-click="taskAdminPager.sortOrder='tutorial_stream'; taskAdminPager.reverse=!taskAdminPager.reverse">
-                    Stream <i ng-show="taskAdminPager.sortOrder=='tutorial_stream'" class="fa fa-caret-{{taskAdminPager.reverse ? 'down' : 'up'}}"></i>
-                  </a>
-                </th>
                 <th ng-show="unit.hasGroupwork()">
                   <a ng-click="taskAdminPager.sortOrder='group_set_id'; taskAdminPager.reverse=!taskAdminPager.reverse">
                     Group Set <i ng-show="taskAdminPager.sortOrder=='group_set_id'" class="fa fa-caret-{{taskAdminPager.reverse ? 'down' : 'up'}}"></i>
+                  </a>
+                </th>
+                <th>
+                  <a ng-click="taskAdminPager.sortOrder='tutorial_stream'; taskAdminPager.reverse=!taskAdminPager.reverse">
+                    Stream <i ng-show="taskAdminPager.sortOrder=='tutorial_stream'" class="fa fa-caret-{{taskAdminPager.reverse ? 'down' : 'up'}}"></i>
                   </a>
                 </th>
                 <th ng-show="unit.hasStreams()">


### PR DESCRIPTION
# Description

Fixes # (issue)

The data for stream and group is not align in task admin page.

The origin HTML lable and data are not align

Before: 
![image](https://user-images.githubusercontent.com/33137074/158817029-43d40c8c-bb69-4bda-b891-00d09c95fb83.png)
![image](https://user-images.githubusercontent.com/33137074/158817051-50459fdd-a0e9-43de-a64c-3bb6429cc88a.png)

After: 
![image](https://user-images.githubusercontent.com/33137074/158817128-47d878a7-a02f-48ec-93a1-9ae1894fa893.png)
![image](https://user-images.githubusercontent.com/33137074/158817142-38ac388e-1f02-42c4-8f9b-00e30857c196.png)


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested both have label group set and have not group set.
![image](https://user-images.githubusercontent.com/33137074/158817345-5110b701-abe3-478a-9e06-5761a5c2d26a.png)
![image](https://user-images.githubusercontent.com/33137074/158817379-3260720b-a1b0-4775-a4e6-a5f278e0b090.png)

## Testing Checklist:

- [x] Tested in latest Edge


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have requested a review from @macite and @jakerenzella on the Pull Request
