### PR TITLE
feat: recreate bootstrap rating component

### DIFF
--- a/src/app/common/star-rating/star-rating.component.html
+++ b/src/app/common/star-rating/star-rating.component.html
@@ -1,0 +1,5 @@
+<div class="star-rating-animation">
+  <div *ngFor="let star of stars" [ngClass]="[star.class]" (click)="selectStar(star.id)">
+    <mat-icon>{{star.icon}}</mat-icon>
+  </div>
+</div>

--- a/src/app/common/star-rating/star-rating.component.scss
+++ b/src/app/common/star-rating/star-rating.component.scss
@@ -1,0 +1,30 @@
+.star {
+  margin: 0px 0px;
+  color: #a9a5a5;
+  display: inline-block;
+  cursor: pointer;
+  transition: all .3s;
+  transform: scale(1);
+}
+
+.star .mat-icon {
+  width: 26px;
+}
+
+.star-gold {
+  color: orange;
+}
+
+// make all stars orange
+.star-rating-animation:hover .star-hover {
+  color: orange;
+}
+
+// make all stars right from selected gray
+.star-rating-animation .star-hover:hover ~ .star-hover {
+  color: #ddd;
+}
+
+.star-rating-animation .star-hover:hover {
+  transform: scale(1.3);
+}

--- a/src/app/common/star-rating/star-rating.component.scss
+++ b/src/app/common/star-rating/star-rating.component.scss
@@ -12,15 +12,13 @@
 }
 
 .star-gold {
-  color: orange;
+  color: #ffd019;
 }
 
-// make all stars orange
 .star-rating-animation:hover .star-hover {
-  color: orange;
+  color: #ffd019;
 }
 
-// make all stars right from selected gray
 .star-rating-animation .star-hover:hover ~ .star-hover {
   color: #ddd;
 }

--- a/src/app/common/star-rating/star-rating.component.ts
+++ b/src/app/common/star-rating/star-rating.component.ts
@@ -1,0 +1,42 @@
+import { Component, OnInit, Input, Output, EventEmitter } from '@angular/core';
+
+@Component({
+  selector: 'star-rating',
+  templateUrl: './star-rating.component.html',
+  styleUrls: ['./star-rating.component.scss']
+})
+export class StarRatingComponent implements OnInit {
+  @Input() totalStars: number;
+  @Input() selectedRating: number;
+  @Output() newSelectedRating = new EventEmitter<number>();
+
+  stars = [];
+
+  constructor() {}
+
+  ngOnInit(): void {
+    for (let i = 0; i < this.totalStars; i++) {
+      const starClass = 'star star-hover ' + (i < this.selectedRating ? 'star-gold' : 'star-silver');
+      this.stars.push({
+        id: i + 1,
+        icon: 'star',
+        class: starClass
+      });
+    }
+  }
+
+  selectStar(value: number): void{
+    this.stars.filter(star => {
+      if (star.id <= value){
+        star.class = 'star-gold star-hover star';
+      }
+      else {
+        star.class = 'star-gray star-hover star';
+      }
+      return star;
+    });
+    this.selectedRating = value;
+    this.newSelectedRating.emit(value);
+  }
+
+}

--- a/src/app/doubtfire-angular.module.ts
+++ b/src/app/doubtfire-angular.module.ts
@@ -165,6 +165,7 @@ import { HeaderComponent } from './common/header/header.component';
 import { UnitDropdownComponent } from './common/header/unit-dropdown/unit-dropdown.component';
 import { TaskDropdownComponent } from './common/header/task-dropdown/task-dropdown.component';
 import { SplashScreenComponent } from './home/splash-screen/splash-screen.component';
+import { StarRatingComponent } from './common/star-rating/star-rating.component';
 
 @NgModule({
   // Components we declare
@@ -222,6 +223,7 @@ import { SplashScreenComponent } from './home/splash-screen/splash-screen.compon
     UnitDropdownComponent,
     TaskDropdownComponent,
     SplashScreenComponent,
+    StarRatingComponent
   ],
   // Module Imports
   imports: [


### PR DESCRIPTION
# Description

This PR implements a star rating component created in Angular intended to replace Bootstrap's rating component. The current rating, and maximum rating values are passed to the component which displays the maximum rating amount of stars (e.g. if maximum rating is 10, then 10 stars will show). When a rating has been selected (via clicking on a star), the component will emit an event `(newSelectedRating)` which will pass the chosen value to the parent component. The hover animation has also been implemented to reflect the Bootstrap version. Once merged, this will be used by my [grade-task-modal](https://github.com/thoth-tech/doubtfire-web/pull/1) component (which has already been thoroughly tested with). Additionally, there are still 4 other components that use the Bootstrap version.

Before:
<img width="324" alt="image" src="https://user-images.githubusercontent.com/49971210/162930225-dd01ba2b-b979-4198-8ad1-a0c3c1a0e4f2.png">


After:
<img width="312" alt="image" src="https://user-images.githubusercontent.com/49971210/162934369-0ed22079-747f-44be-b13c-f94e9b0ebbe0.png">

Fixes # (Provides an Angular star rating component to replace the Bootstrap version)

## Type of change

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

This has been tested thoroughly in my [grade-task-modal](https://github.com/thoth-tech/doubtfire-web/pull/1) component.

## Testing Checklist:

- [ ] Tested in latest Chrome
- [ ] Tested in latest Safari
- [X] Tested in latest Firefox

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have requested a review from @macite and @jakerenzella on the Pull Request
