### PR TITLE
feat: add feature tutor can see the student target grade when marking

### DIFF
--- a/src/app/common/services/project-service.coffee
+++ b/src/app/common/services/project-service.coffee
@@ -512,6 +512,13 @@ angular.module("doubtfire.common.services.projects", [])
         _.extend project, response
         if unit_obj
           projectService.addTaskDetailsToProject(project, unit_obj)
+    
+    project.targetGradeWord = () ->
+      # the array only have four element so use this if statement to make sure it's not undefined
+      if project.target_grade >= 0 and project.target_grade <= 3
+        gradeService.grades[project.target_grade]
+      else
+        "Unknown"
 
     project
 

--- a/src/app/projects/states/dashboard/directives/task-dashboard/task-dashboard.coffee
+++ b/src/app/projects/states/dashboard/directives/task-dashboard/task-dashboard.coffee
@@ -44,6 +44,20 @@ angular.module('doubtfire.projects.states.dashboard.directives.task-dashboard', 
         taskFilesUrl: TaskFeedback.getTaskFilesUrl($scope.task)
       }
 
+      # add the target grade based on the index:
+      # 0: pass, 1: credit and so on
+      switch $scope.task.project().target_grade
+        when 0
+          $scope.task.project().target_grade_word = "Pass"
+        when 1
+          $scope.task.project().target_grade_word = "Credit"
+        when 2
+          $scope.task.project().target_grade_word = "Distinction"
+        when 3
+          $scope.task.project().target_grade_word = "High Distinction"
+        else
+          $scope.task.project().target_grade_word = "Unknown"
+      
       updateCurrentView()
     )
 

--- a/src/app/projects/states/dashboard/directives/task-dashboard/task-dashboard.coffee
+++ b/src/app/projects/states/dashboard/directives/task-dashboard/task-dashboard.coffee
@@ -44,20 +44,6 @@ angular.module('doubtfire.projects.states.dashboard.directives.task-dashboard', 
         taskFilesUrl: TaskFeedback.getTaskFilesUrl($scope.task)
       }
 
-      # add the target grade based on the index:
-      # 0: pass, 1: credit and so on
-      switch $scope.task.project().target_grade
-        when 0
-          $scope.task.project().target_grade_word = "Pass"
-        when 1
-          $scope.task.project().target_grade_word = "Credit"
-        when 2
-          $scope.task.project().target_grade_word = "Distinction"
-        when 3
-          $scope.task.project().target_grade_word = "High Distinction"
-        else
-          $scope.task.project().target_grade_word = "Unknown"
-      
       updateCurrentView()
     )
 

--- a/src/app/projects/states/dashboard/directives/task-dashboard/task-dashboard.tpl.html
+++ b/src/app/projects/states/dashboard/directives/task-dashboard/task-dashboard.tpl.html
@@ -3,7 +3,7 @@
     <div class="panel-title">
       {{task.definition.name}}
       <span ng-show="tutor || showFooter"
-        >by {{task.project().student_name}} (Aiming at {{task.project().target_grade_word}})</span
+        >by {{task.project().student_name}} (Aiming at {{task.project().targetGradeWord()}})</span
       >
 
       <div

--- a/src/app/projects/states/dashboard/directives/task-dashboard/task-dashboard.tpl.html
+++ b/src/app/projects/states/dashboard/directives/task-dashboard/task-dashboard.tpl.html
@@ -1,9 +1,16 @@
 <div class="panel panel-pdf panel-default panel-scrollable">
   <div class="panel-heading" ng-show="task">
     <div class="panel-title">
-      {{task.definition.name}} <span ng-show="tutor || showFooter">by {{task.project().student_name}}</span>
+      {{task.definition.name}}
+      <span ng-show="tutor || showFooter"
+        >by {{task.project().student_name}} (Aiming at {{task.project().target_grade_word}})</span
+      >
 
-      <div class="dropdown pull-right" dropdown ng-show="task.has_pdf || task.definition.has_task_sheet || overseer_enabled.value">
+      <div
+        class="dropdown pull-right"
+        dropdown
+        ng-show="task.has_pdf || task.definition.has_task_sheet || overseer_enabled.value"
+      >
         <button class="btn btn-default dropdown-toggle" dropdown-toggle>
           <i class="fa fa-search"></i>
           <span class="caret"></span>


### PR DESCRIPTION
# Description

A new feature that staff can see the student target grade while marking.


## Type of change

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

This PR has been tested by login both tutor and student account, when student change the target grade refresh the tutor page see to see if changed as well. Some image: 
![image](https://user-images.githubusercontent.com/33137074/163159992-949357c4-e961-4bab-9d2d-f70a95e77db8.png)
![image](https://user-images.githubusercontent.com/33137074/163160023-2f07ca55-099f-45d4-919e-6eb16c004730.png)


## Testing Checklist:

- [X] Tested in latest Edge

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have requested a review from @macite and @jakerenzella on the Pull Request
