### PR TITLE
fix: fix the error message for entity-form

### DIFF
--- a/src/app/common/entity-form/entity-form.component.ts
+++ b/src/app/common/entity-form/entity-form.component.ts
@@ -154,7 +154,7 @@ export class EntityFormComponent<T extends Entity>  {
           if (this.selected) {
             this.restoreFromBackup();
           }
-          alertService.add('danger', `${service.entityName} save failed: ${error.error.error}`, 6000);
+          alertService.add('danger', `${service.entityName} save failed: ${error.error.error? error.error.error: error.statusText}`, 6000);
         }
       }
         

--- a/src/app/common/entity-form/entity-form.component.ts
+++ b/src/app/common/entity-form/entity-form.component.ts
@@ -1,4 +1,4 @@
-import { OnInit, Directive } from '@angular/core';
+import { Directive } from '@angular/core';
 import { FormGroup, AbstractControl } from '@angular/forms';
 import { Entity } from 'src/app/api/models/entity';
 import { EntityService } from 'src/app/api/models/entity.service';
@@ -9,7 +9,7 @@ import { MatTableDataSource } from '@angular/material/table';
 export type OnSuccessMethod<T> = (object: T, isNew: boolean) => void;
 
 @Directive()
-export class EntityFormComponent<T extends Entity> implements OnInit {
+export class EntityFormComponent<T extends Entity>  {
   // formData consists of the various FormControl elements that the form is made up of.
   // See FormGroup:     https://angular.io/api/forms/FormGroup
   // See FormControl:   https://angular.io/api/forms/FormControl
@@ -56,7 +56,6 @@ export class EntityFormComponent<T extends Entity> implements OnInit {
     }
   }
 
-  ngOnInit() {}
 
   /**
    * Cancel edit of current selected value.
@@ -135,8 +134,8 @@ export class EntityFormComponent<T extends Entity> implements OnInit {
       }
 
       // Handle the response
-      response.subscribe(
-        (result: T) => {
+      response.subscribe({
+        next: (result: T) => {
           alertService.add('success', `${service.entityName} saved`, 2000);
           // Success is implemented on all inheriting instances and is used
           // to handle the response appropriately for the context of the form
@@ -149,14 +148,16 @@ export class EntityFormComponent<T extends Entity> implements OnInit {
           // Reset the form to default values
           this.formData.reset(this.defaultFormData);
         },
-        (error) => {
+        error: (error) => {
           // Whoops - an error
           // Restore the form data from backup if applicable
           if (this.selected) {
             this.restoreFromBackup();
           }
-          alertService.add('danger', `${service.entityName} save failed: ${error}`, 6000);
+          alertService.add('danger', `${service.entityName} save failed: ${error.error.error}`, 6000);
         }
+      }
+        
       );
     } else {
       // Once we mark forms as touched, erroneous state will be rendered

--- a/src/app/units/states/edit/directives/unit-tutorials-list/unit-tutorials-list.component.ts
+++ b/src/app/units/states/edit/directives/unit-tutorials-list/unit-tutorials-list.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, Inject, ViewChild, Output, EventEmitter } from '@angular/core';
+import { Component, Input, Inject, ViewChild, OnInit } from '@angular/core';
 import { alertService } from 'src/app/ajs-upgraded-providers';
 import { MatSort, Sort } from '@angular/material/sort';
 import { MatTableDataSource, MatTable } from '@angular/material/table';
@@ -15,11 +15,11 @@ import { EntityFormComponent } from 'src/app/common/entity-form/entity-form.comp
 import { FormControl, Validators } from '@angular/forms';
 
 @Component({
-  selector: 'unit-tutorials-list',
+  selector: 'df-unit-tutorials-list',
   templateUrl: 'unit-tutorials-list.component.html',
   styleUrls: ['unit-tutorials-list.component.scss'],
 })
-export class UnitTutorialsListComponent extends EntityFormComponent<Tutorial> {
+export class UnitTutorialsListComponent extends EntityFormComponent<Tutorial> implements OnInit{
   @ViewChild(MatTable, { static: true }) table: MatTable<any>;
   @ViewChild(MatSort, { static: true }) sort: MatSort;
   @Input() stream: TutorialStream;

--- a/src/app/units/states/edit/directives/unit-tutorials-manager/unit-tutorials-manager.component.html
+++ b/src/app/units/states/edit/directives/unit-tutorials-manager/unit-tutorials-manager.component.html
@@ -1,13 +1,17 @@
 <div>
-  <unit-tutorials-list [unit]="unit"></unit-tutorials-list>
-  <unit-tutorials-list *ngFor="let stream of unit.tutorial_streams" [unit]="unit" [stream]="stream"></unit-tutorials-list>
-  <button class="new-activity-stream-button"mat-raised-button [matMenuTriggerFor]="activities">
+  <df-unit-tutorials-list [unit]="unit"></df-unit-tutorials-list>
+  <df-unit-tutorials-list
+    *ngFor="let stream of unit.tutorial_streams"
+    [unit]="unit"
+    [stream]="stream"
+  ></df-unit-tutorials-list>
+  <button class="new-activity-stream-button" mat-raised-button [matMenuTriggerFor]="activities">
     <mat-icon>add</mat-icon>
     New Tutorial Stream
   </button>
   <mat-menu #activities="matMenu">
     <button *ngFor="let activityType of activityTypes" mat-menu-item (click)="onClickNewActivity(activityType)">
-      <span>{{activityType.name}}</span>
+      <span>{{ activityType.name }}</span>
     </button>
   </mat-menu>
 </div>


### PR DESCRIPTION
# Description

When add tutorials to a unit stream the error message would show ` [object, object]`

<details>
  <summary>error message json</summary>
  
```json
{
    "headers": {
        "normalizedNames": {},
        "lazyUpdate": null
    },
    "status": 400,
    "statusText": "Bad Request",
    "url": "http://localhost:3000/api/tutorials/",
    "ok": false,
    "name": "HttpErrorResponse",
    "message": "Http failure response for http://localhost:3000/api/tutorials/: 400 Bad Request",
    "error": {
        "error": "tutorial[capacity] is invalid"
    }
}
```

</details>

Fixes: 
- Change the error message for ` src/app/common/entity-form/entity-form.component.ts `  in ` submit ` method
- update the ` subscribe ` function, check the document [here](https://rxjs.dev/deprecations/subscribe-arguments)
- Remove not needed import and implement interface ` OnInit ` for ` src/app/units/states/edit/directives/unit-tutorials-list/unit-tutorials-list.component.ts` which has ` ngOnInit` function
- Add ` df ` in front of the component selector as `./.eslintrc.json` defined

before: ![Screenshot 2022-05-14 013647](https://user-images.githubusercontent.com/33137074/168326476-d64f0af9-3657-4b4a-a3d9-646c70172ef0.png)

after: ![image](https://user-images.githubusercontent.com/33137074/168328025-b6ab7ba1-ed29-4d1f-9b74-4ed9f74e3c06.png)


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested all three child class component `[ activity-type-list, campus-list, entity-form ]` (`overseer-image-list` is not used). All component works fine. Also other than `Capacity`, there should have no type error because all other variables are defined as ` String` or defind by the code e.g. tutoral id. 

I also considered the error without pre-defined error message for example, cannot find the api. In that case use ` statusText` instead of error message. 
<details>
  <summary>POST http://localhost:3000/api/tutorials/ net::ERR_CONNECTION_REFUSED</summary>

```json
{
    "headers": {
        "normalizedNames": {},
        "lazyUpdate": null,
        "headers": {}
    },
    "status": 0,
    "statusText": "Unknown Error",
    "url": "http://localhost:3000/api/tutorials/",
    "ok": false,
    "name": "HttpErrorResponse",
    "message": "Http failure response for http://localhost:3000/api/tutorials/: 0 Unknown Error",
    "error": {
        "isTrusted": true
    }
}
```

</details>


## Testing Checklist:

- [x] Tested in latest Edge

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
