### PR TITLE
Fix portfolio download

### DIFF
--- a/src/app/common/pdf-viewer-panel/pdf-viewer-panel.component.ts
+++ b/src/app/common/pdf-viewer-panel/pdf-viewer-panel.component.ts
@@ -16,7 +16,7 @@ export class PdfViewerPanelComponent implements OnInit {
   ngOnInit(): void {}
 
   downloadPdf() {
-    this.fileDownloader.downloadFile(this.pdfUrl, 'displayed-pdf.pdf');
+    this.fileDownloader.downloadFile(this.pdfUrl + "?as_attachment=true", 'displayed-pdf.pdf');
   }
 
   downloadResources() {

--- a/src/app/units/states/tasks/inbox/directives/staff-task-list/staff-task-list.component.html
+++ b/src/app/units/states/tasks/inbox/directives/staff-task-list/staff-task-list.component.html
@@ -49,7 +49,7 @@
           <div class="task-definition">
             <div fxLayout="row" fxLayoutAlign="space-between center">
               <mat-form-field fxFlex>
-                <mat-label>Task Definition</mat-label>
+                <mat-label>Task</mat-label>
                 <mat-select [(ngModel)]="filters.taskDefinitionIdSelected" name="taskDefID"
                   (selectionChange)="taskDefinitionIdChanged()">
                   <mat-option value="" [hidden]="isTaskDefMode">All Task Definitions</mat-option>


### PR DESCRIPTION
# Description

Fix downloading portfolios, ensuring that the attachment parameter is passed to the API to ensure it includes the appropriate filename.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Locally.

## Testing Checklist:

- [ ] Tested in latest Chrome
- [X] Tested in latest Safari
- [ ] Tested in latest Firefox

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have requested a review from @macite and @jakerenzella on the Pull Request
