### PR TITLE
Fix audio recording and UI improvements to recorder

### DIFF
--- a/src/app/common/audio-recorder/audio/audio-comment-recorder/audio-comment-recorder.html
+++ b/src/app/common/audio-recorder/audio/audio-comment-recorder/audio-comment-recorder.html
@@ -1,22 +1,40 @@
 <div class="audio-recorder">
-  <p [hidden]="canRecord">Audio recording <br> only supported in modern versions of Chrome, Firefox and Safari.</p>
+  <p [hidden]="canRecord">
+    Audio recording <br />
+    only supported in modern versions of Chrome, Firefox and Safari.
+  </p>
   <mat-spinner class="send-audio-spinner" [diameter]="72" [strokeWidth]="2" [hidden]="!isSending"></mat-spinner>
-  <div [hidden]="!canRecord || isSending">
-    <button type="button" id='btnRecord' (click)="recordingToggle()" class="btn-circle-xl">
-      <mat-icon [hidden]="isRecording" aria-label="Quit cross icon">fiber_manual_record</mat-icon>
-      <mat-icon [hidden]="!isRecording" aria-label="Quit cross icon">stop_rounded</mat-icon>
+  <div fxLayout="row" fxLayoutAlign="start center" [hidden]="!canRecord || isSending">
+    <button
+      style="width: 22px; height: 22px; line-height: 22px"
+      (click)="recordingToggle()"
+      mat-icon-button
+      aria-label="Audio recording button"
+    >
+      <mat-icon style="color: #f03d25">{{isRecording ? 'stop_circle' : 'radio_button_checked' }} </mat-icon>
     </button>
+    <button
+      style="width: 22px; height: 22px; line-height: 22px"
+      (click)="playStop()"
+      mat-icon-button
+      aria-label="Play audio recording"
+      [hidden]="!recordingAvailable"
+    >
+      <mat-icon>play_circle</mat-icon>
+    </button>
+    <audio id="audioPlayer"></audio>
+    <canvas fxFlex class="audio-visualiser" id="audio-recorder-visualiser"></canvas>
 
     <div id="button-wrapper">
-      <button type="button" id='btnSend' (click)="sendRecording()" [disabled]="!recordingAvailable" class="btn-circle">
-        <i class="fa fa-paper-plane"></i>
-      </button>
-      <button type="button" id='btnPlay' [disabled]="!recordingAvailable" (click)="playStop()" class="btn-circle">
-        <i class="fa fa-play"></i>
+      <button
+        style="width: 22px; height: 22px; line-height: 22px; margin-right: 6px"
+        (click)="sendRecording()"
+        mat-icon-button
+        aria-label="Send audio recording"
+        [disabled]="!recordingAvailable"
+      >
+        <mat-icon>send</mat-icon>
       </button>
     </div>
-
-    <audio id='audioPlayer'></audio>
-    <canvas class="audio-visualiser" id="audio-recorder-visualiser"></canvas>
   </div>
 </div>

--- a/src/app/common/audio-recorder/audio/audio-comment-recorder/audio-comment-recorder.scss
+++ b/src/app/common/audio-recorder/audio/audio-comment-recorder/audio-comment-recorder.scss
@@ -1,7 +1,4 @@
 audio-comment-recorder .audio-recorder {
-  height: 50px;
-  width: 300px;
-  margin-top: 10px;
 }
 
 .btn-circle-xl {
@@ -9,14 +6,14 @@ audio-comment-recorder .audio-recorder {
   background-color: #f03d25;
   border-radius: 72px;
   color: #fff;
-  height: 38px;
-  width: 38px;
+  height: 20px;
+  width: 20px;
   transition: width 0.1s, height 0.1s;
   border: none;
   outline: none;
 
   mat-icon {
-    font-size: 24px;
+    font-size: 16px;
     vertical-align: middle;
   }
 }
@@ -72,14 +69,11 @@ mat-spinner.send-audio-spinner {
 
 #button-wrapper {
   position: absolute;
-  bottom: 26px;
   right: 12px;
 }
 
 #audio-recorder-visualiser.audio-visualiser {
-  position: absolute;
-  height: 60px;
-  width: 110px;
-  bottom: 10px;
-  left: 25%;
+  height: 22px;
+  margin-left: 16px;
+  margin-right: 46px;
 }

--- a/src/app/common/audio-recorder/audio/base-audio-recorder.ts
+++ b/src/app/common/audio-recorder/audio/base-audio-recorder.ts
@@ -20,7 +20,7 @@ export abstract class BaseAudioRecorderComponent implements OnInit {
 
   constructor(private mediaRecorderService: any) {}
 
-  ngOnInit() {
+  ngOnInit(): void {
     this.isSending = false;
     if (this.canRecord) {
       this.init();
@@ -95,22 +95,30 @@ export abstract class BaseAudioRecorderComponent implements OnInit {
   // Which can be overridden
   protected visualise(): void {
     const draw = () => {
-      const WIDTH = this.canvas.width;
-      const HEIGHT = this.canvas.height;
+      let WIDTH = this.canvas.clientWidth;
+      let HEIGHT = this.canvas.clientHeight;
+
+      this.canvas.width = 1;
+      this.canvas.height = 1;
+
+      this.canvas.width = WIDTH = this.canvas.clientWidth;
+      this.canvas.height = HEIGHT = this.canvas.clientHeight;
       requestAnimationFrame(draw);
       analyser.getByteTimeDomainData(dataArray);
       analyser.getByteFrequencyData(dataArray);
 
-      this.canvasCtx.clearRect(0, 0, WIDTH, HEIGHT);
-      let i = 0;
-      const bar_width = 1;
-      while (i < WIDTH) {
-        const bar_x = i * 10;
+      this.canvasCtx.clearRect(0, 0, 300, HEIGHT);
+
+      const bar_width = 2;
+      const bar_gap = 2;
+
+      for (let i = 0; i < WIDTH; i++) {
+        const bar_x = i * (bar_width + bar_gap);
         const bar_y = HEIGHT / 2;
-        const bar_height = -(dataArray[i] / 4) + 1;
+        const bar_height = -(dataArray[i] / 8) + 1;
+        this.canvasCtx.fillStyle = '#8f8f8f';
         this.canvasCtx.fillRect(bar_x, bar_y, bar_width, bar_height);
         this.canvasCtx.fillRect(bar_x, bar_y - bar_height, bar_width, bar_height);
-        i++;
       }
     };
 

--- a/src/app/common/entity-form/entity-form.component.ts
+++ b/src/app/common/entity-form/entity-form.component.ts
@@ -1,3 +1,4 @@
+import { OnInit } from '@angular/core';
 import { Directive } from '@angular/core';
 import { FormGroup, AbstractControl } from '@angular/forms';
 import { Entity } from 'src/app/api/models/entity';
@@ -9,7 +10,7 @@ import { MatTableDataSource } from '@angular/material/table';
 export type OnSuccessMethod<T> = (object: T, isNew: boolean) => void;
 
 @Directive()
-export class EntityFormComponent<T extends Entity>  {
+export class EntityFormComponent<T extends Entity> implements OnInit {
   // formData consists of the various FormControl elements that the form is made up of.
   // See FormGroup:     https://angular.io/api/forms/FormGroup
   // See FormControl:   https://angular.io/api/forms/FormControl
@@ -54,6 +55,10 @@ export class EntityFormComponent<T extends Entity>  {
     for (const key of Object.keys(this.formData.controls)) {
       this.defaultFormData[key] = this.formData.get(`${key}`).value;
     }
+  }
+
+  ngOnInit(): void {
+
   }
 
 
@@ -157,7 +162,7 @@ export class EntityFormComponent<T extends Entity>  {
           alertService.add('danger', `${service.entityName} save failed: ${error.error.error? error.error.error: error.statusText}`, 6000);
         }
       }
-        
+
       );
     } else {
       // Once we mark forms as touched, erroneous state will be rendered

--- a/src/app/tasks/task-comment-composer/task-comment-composer.component.html
+++ b/src/app/tasks/task-comment-composer/task-comment-composer.component.html
@@ -42,12 +42,12 @@
   role="form"
 >
   <div fxLayout="row" fxLayoutAlign="space-around end" class="composer-container">
-    <div class="composer-action-group" [@shrinkgrow]="($expandInput | async)">
+    <div class="composer-action-group" [@shrinkgrow]="$expandInput | async">
       <!-- if active -->
       <div fxLayout="row" fxLayoutAlign="start center">
         <button
           [hidden]="($expandInput | async) === false"
-          (click)="$expandInput.next(true)"
+          (click)="$expandInput.next(false); recording = false"
           matTooltip="Expand action buttons"
           matTooltipShowDelay="400"
           mat-icon-button
@@ -88,7 +88,7 @@
         </button>
 
         <button
-          [hidden]="($expandInput | async)"
+          [hidden]="$expandInput | async"
           matTooltip="Attach a file"
           matTooltipShowDelay="400"
           mat-icon-button
@@ -115,8 +115,8 @@
           mat-icon-button
           class="btn-no-outline"
           type="button"
-          [popover]="audioDiscussionTemplate"
           aria-label="audio recording popover button"
+          (click)="recordingMode()"
         >
           <mat-icon>mic</mat-icon>
         </button>
@@ -129,13 +129,15 @@
         [class.active]="($expandInput | async) === false"
         #commentInput
         id="textField"
-        [attr.contenteditable]="contentEditableValue()"
+        [attr.contenteditable]="contentEditableValue() && !recording"
         (keydown.enter)="send($event)"
         (keydown)="keyTyped()"
         placeholder="Aa"
         name="commentComposer"
-      ></div>
-      <div id="innerButtons">
+      >
+        <audio-comment-recorder *ngIf="recording" [task]="task"></audio-comment-recorder>
+      </div>
+      <div id="innerButtons" [hidden]="recording">
         <mat-icon
           matTooltip="Choose an emoji"
           matTooltipShowDelay="400"
@@ -149,8 +151,3 @@
     </div>
   </div>
 </form>
-
-<!-- The HTML which will be injected -->
-<ng-template #audioDiscussionTemplate>
-  <audio-comment-recorder [task]="task"></audio-comment-recorder>
-</ng-template>

--- a/src/app/tasks/task-comment-composer/task-comment-composer.component.ts
+++ b/src/app/tasks/task-comment-composer/task-comment-composer.component.ts
@@ -82,6 +82,7 @@ export class TaskCommentComposerComponent implements DoCheck {
   emojiRegex: RegExp = /(?:\:)(.*?)(?=\:|$)/;
   emojiSearchResults: EmojiData[] = [];
   emojiMatch: string;
+  recording = false;
 
   constructor(
     private differs: KeyValueDiffers,
@@ -143,6 +144,11 @@ export class TaskCommentComposerComponent implements DoCheck {
 
     const finalString = nameString + typeString;
     return finalString;
+  }
+
+  recordingMode(): void {
+    this.recording = !this.recording;
+    this.$expandInput.next(true);
   }
 
   send(e: Event) {


### PR DESCRIPTION
# Description

The current audio recording popover was buggy in Chrome. This PR removes the popover and makes various fixes to the recording visualiser.

Recording not started:
![Screen Shot 2022-09-06 at 7 35 36 pm](https://user-images.githubusercontent.com/5138218/188602026-f338974c-2c51-40d4-b137-530eb7fef814.png)

Mid recording:
![Screen Shot 2022-09-06 at 7 35 49 pm](https://user-images.githubusercontent.com/5138218/188602022-917dc87b-2ca9-4420-8a7b-f645f992155d.png)

Finished Recording:
![Screen Shot 2022-09-06 at 7 35 53 pm](https://user-images.githubusercontent.com/5138218/188602017-206b8ab6-5295-4e0a-883c-6333aeff1d0e.png)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration_

## Testing Checklist:

- [X] Tested in latest Chrome
- [X] Tested in latest Safari
- [X] Tested in latest Firefox

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have requested a review from @macite and @jakerenzella on the Pull Request
