### PR TITLE
Modified extension request from weeks to days

### DIFF
--- a/src/app/common/modals/extension-modal/extension-modal.component.html
+++ b/src/app/common/modals/extension-modal/extension-modal.component.html
@@ -10,7 +10,7 @@
   </mat-form-field>
 
   <p>Requesting extension to: {{newDueDate}} </p>
-  <mat-slider id="requestWeekSlider" thumbLabel [min]="minWeeksCanExtend" [max]="maxWeeksCanExtend" step="1"
+  <mat-slider id="requestdaySlider" thumbLabel [min]="0" [max]="31" step="1"
     [(ngModel)]="weeksRequested">
   </mat-slider>
 </div>
@@ -18,6 +18,6 @@
 <div mat-dialog-actions style="float: right">
   <button mat-dialog-close style="margin-right: 10px;" mat-stroked-button color="primary" mat-button
     [disabled]="weeksRequested === 0 || reason.length < 15" (click)="submitApplication()">Request {{weeksRequested}}
-    {{weeksRequested === 1 ? 'week' : 'weeks'}}</button>
+    {{weeksRequested === 1 ? 'day' : 'days'}}</button>
   <button mat-dialog-close mat-stroked-button color="warn">Cancel</button>
 </div>

--- a/src/app/common/modals/extension-modal/extension-modal.component.scss
+++ b/src/app/common/modals/extension-modal/extension-modal.component.scss
@@ -1,4 +1,4 @@
-#requestWeekSlider {
+#requestdaySlider {
   width: 100%;
 }
 

--- a/src/app/common/modals/extension-modal/extension-modal.component.ts
+++ b/src/app/common/modals/extension-modal/extension-modal.component.ts
@@ -28,12 +28,12 @@ export class ExtensionModalComponent implements OnInit {
   }
 
   get newDueDate() {
-    const calculatedDueDate = this.data.task.localDueDate().add(this.weeksRequested, 'weeks');
+    const calculatedDueDate = this.data.task.localDueDate().add(this.weeksRequested, 'days');
     const taskDeadlineDate = this.data.task.definition.localDeadlineDate();
     if (calculatedDueDate > taskDeadlineDate) {
       return taskDeadlineDate.format('DD of MMMM');
     }
-    return calculatedDueDate.format('DD of MMMM');
+    return calculatedDueDate.format('DD of MMMM'); 
   }
 
   get maxWeeksCanExtend() {


### PR DESCRIPTION
# Description

This pull request is for the front-end web part. I have changed the slider so that it can be used for changing days instead of weeks ( we can select a maximum of 31 days for an extension ). Then I made changes in newduedate functions which now accept days instead of weeks for an extension request. With all this, I was successfully able to make changes in the code so that we could select days instead of weeks.

## Type of change


- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested

VIDEO 1 ( Before changes ) :- https://www.youtube.com/watch?v=Gbsse6ng5B0
VIDEO 2 ( After changes ) :- https://www.youtube.com/watch?v=_BZZHSY1NE0

## Testing Checklist:

- [ ] Tested in latest Chrome
- [ ] Tested in latest Safari
- [ ] Tested in latest Firefox

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have requested a review from @macite and @jakerenzella on the Pull Request
