### PR TITLE
style: restructure task comments

### DIFF
--- a/src/app/tasks/task-comments-viewer/task-comments-viewer.component.html
+++ b/src/app/tasks/task-comments-viewer/task-comments-viewer.component.html
@@ -1,5 +1,12 @@
 <div style="height: 100%" class="comments-panel" appDragDrop (onFileDropped)="uploadFiles($event)" fxLayout="column">
-  <div fxFlex class="comments-body" #commentsBody>
+  <div
+    fxFlex
+    class="comments-body"
+    #commentsBody
+    fxLayout="column"
+    fxLayoutAlign="end"
+    style="place-content: stretch !important"
+  >
     <div [hidden]="!loading" style="height: 100%" fxLayout="row" fxLayoutAlign="center center">
       <mat-spinner strokeWidth="2" diameter="100" color="accent"></mat-spinner>
     </div>
@@ -22,8 +29,10 @@
               'comment-by-other-user': !comment.authorIsMe,
               'new-comment': comment.isNew
             }"
+            [fxLayout]="comment.authorIsMe ? 'row-reverse' : 'row'"
+            fxLayoutAlign="start end"
           >
-            <div *ngIf="shouldShowAuthorIcon(comment.commentType)" fxFlex="28px" style="display: flex">
+            <div *ngIf="!comment.authorIsMe && shouldShowAuthorIcon(comment.commentType)" fxFlex="34px">
               <user-icon
                 *ngIf="comment.shouldShowAvatar && shouldShowAuthorIcon(comment.commentType)"
                 [size]="28"
@@ -35,13 +44,22 @@
               </user-icon>
             </div>
 
-            <div fxFlex class="comment-container" [ngSwitch]="comment.commentType">
+            <div
+              class="comment-container"
+              [fxLayout]="comment.authorIsMe ? 'row-reverse' : 'row'"
+              fxLayoutAlign="start center"
+              [ngSwitch]="comment.commentType"
+            >
               <div *ngSwitchCase="'status'" class="comment-status">
                 <hr class="hr-text" [attr.data-content]="comment.text" />
               </div>
 
               <div *ngSwitchCase="'assessment'" class="comment-assessment">
-                <app-task-assessment-comment [task]="task" [comment]="comment" *ngIf="overseerEnabled"></app-task-assessment-comment>
+                <app-task-assessment-comment
+                  [task]="task"
+                  [comment]="comment"
+                  *ngIf="overseerEnabled"
+                ></app-task-assessment-comment>
               </div>
 
               <div class="bubble" [ngClass]="commentClasses(comment)">

--- a/src/app/tasks/task-comments-viewer/task-comments-viewer.component.scss
+++ b/src/app/tasks/task-comments-viewer/task-comments-viewer.component.scss
@@ -37,6 +37,7 @@ $comment-inner-border-radius: 4px;
 
 .comments-scroll-content {
   padding-right: 10px;
+  max-height: 100%;
 }
 
 .comments-footer {
@@ -64,6 +65,7 @@ $comment-inner-border-radius: 4px;
 
 :host {
   overflow-x: none;
+
   p#commentTimestamp {
     color: #9696969d;
     font-size: 11px;
@@ -75,13 +77,16 @@ $comment-inner-border-radius: 4px;
   .comments-body {
     overflow-y: scroll;
     overflow-x: hidden;
+
     ::-webkit-scrollbar-track {
       display: none;
     }
+
     height: 100%;
     font-size: 15px;
     width: 100%;
   }
+
   .comments-body::-webkit-scrollbar-track {
     display: none;
   }
@@ -92,8 +97,7 @@ $comment-inner-border-radius: 4px;
   }
 
   .comment-container {
-    display: flex;
-    flex-grow: 2;
+    flex-grow: 1;
 
     .comment-overflow {
       max-width: 50px;
@@ -107,7 +111,6 @@ $comment-inner-border-radius: 4px;
 
   .comment-by-other-user .comment-container {
     display: flex;
-    flex-direction: row-reverse;
     flex-grow: 2;
 
     .original-comment {
@@ -143,6 +146,7 @@ $comment-inner-border-radius: 4px;
       text-align: center;
       height: 1.5em;
       opacity: 0.8;
+
       &:before {
         content: '';
         background: linear-gradient(to right, transparent, #9696969d, transparent);
@@ -152,6 +156,7 @@ $comment-inner-border-radius: 4px;
         width: 100%;
         height: 1px;
       }
+
       &:after {
         content: attr(data-content);
         position: relative;
@@ -167,33 +172,30 @@ $comment-inner-border-radius: 4px;
 
   // Primary comment div
   .comment {
-    display: flex;
     &.new-comment .text-bubble {
       animation: fade-in-comment-animation;
       animation-duration: 5s;
+
       @keyframes fade-in-comment-animation {
         0% {
           background: rgba(33, 150, 243, 0.4);
         }
+
         0% {
           border: rgba(33, 150, 243, 1);
         }
+
         0% {
           box-shadow: 0 0 6px rgba(33, 150, 243, 1);
         }
+
         100% {
           border: rgba(255, 255, 255, 0);
         }
+
         100% {
           box-shadow: 0 0 0px rgba(255, 255, 255, 0);
         }
-      }
-    }
-    &.comment-by-other-user {
-      flex-direction: row-reverse;
-
-      .bubble {
-        float: right;
       }
     }
 
@@ -220,14 +222,6 @@ $comment-inner-border-radius: 4px;
     }
   }
 
-  // Author Bubble
-  .comment user-icon {
-    margin-right: -37px;
-    // display: inline-block;
-    align-self: flex-end;
-    line-height: $comment-author-bubble-size - 2px;
-  }
-
   .comment.comment-by-other-user user-icon .user-icon-initials {
     box-shadow: 0 0 0 1px $comment-bubble-color-other-user-darker;
     background: $comment-bubble-color-other-user;
@@ -235,8 +229,8 @@ $comment-inner-border-radius: 4px;
     // color: $text-color;
     color: black;
   }
+
   .comment.comment-by-other-user .user-icon {
-    margin-left: -37px;
     margin-right: 0;
   }
 
@@ -248,19 +242,19 @@ $comment-inner-border-radius: 4px;
   }
 
   .bubble {
-    border-top-left-radius: $comment-inner-border-radius;
-    border-top-right-radius: $comment-border-radius;
-    border-bottom-left-radius: $comment-inner-border-radius;
-    border-bottom-right-radius: $comment-border-radius;
+    border-top-right-radius: $comment-inner-border-radius;
+    border-top-left-radius: $comment-border-radius;
+    border-bottom-right-radius: $comment-inner-border-radius;
+    border-bottom-left-radius: $comment-border-radius;
     margin-bottom: 1px;
     margin-top: 1px;
   }
 
   .comment.comment-by-other-user .bubble {
-    border-top-left-radius: $comment-border-radius;
-    border-bottom-left-radius: $comment-border-radius;
-    border-top-right-radius: $comment-inner-border-radius;
-    border-bottom-right-radius: $comment-inner-border-radius;
+    border-top-left-radius: $comment-inner-border-radius;
+    border-bottom-left-radius: $comment-inner-border-radius;
+    border-top-right-radius: $comment-border-radius;
+    border-bottom-right-radius: $comment-border-radius;
     margin-bottom: 1px;
     margin-top: 1px;
   }
@@ -268,14 +262,16 @@ $comment-inner-border-radius: 4px;
   .comment.comment-by-other-user .bubble.first-in-series {
     border-top-right-radius: $comment-border-radius;
     border-top-left-radius: $comment-border-radius;
-    border-bottom-right-radius: $comment-inner-border-radius;
+    border-bottom-left-radius: $comment-inner-border-radius;
+    border-bottom-right-radius: $comment-border-radius;
     margin-top: 0.2em;
   }
 
   .comment.comment-by-other-user .bubble.last-in-series {
     border-bottom-right-radius: $comment-border-radius;
-    border-top-left-radius: $comment-border-radius;
-    border-top-right-radius: $comment-inner-border-radius;
+    border-bottom-left-radius: $comment-border-radius;
+    border-top-left-radius: $comment-inner-border-radius;
+    border-top-right-radius: $comment-border-radius;
     margin-bottom: 0.4em;
   }
 
@@ -291,7 +287,7 @@ $comment-inner-border-radius: 4px;
 
   .bubble.last-in-series {
     border-radius: $comment-border-radius;
-    border-top-left-radius: $comment-inner-border-radius;
+    border-top-right-radius: $comment-inner-border-radius;
     margin-bottom: 0.4em;
   }
 
@@ -326,6 +322,7 @@ $comment-inner-border-radius: 4px;
     .comment-text .markdown-to-html p {
       margin: 0 0 0 0 !important;
     }
+
     .comment-audio {
       display: inline-block;
       margin: 0 auto 0 $comment-text-padding;
@@ -358,11 +355,11 @@ $comment-inner-border-radius: 4px;
       margin: 0 0 0 0px !important;
     }
 
-    .markdown-to-html p > *:last-child {
+    .markdown-to-html p>*:last-child {
       margin-bottom: 0px;
     }
 
-    .markdown-to-html p > pre:last-child {
+    .markdown-to-html p>pre:last-child {
       margin-bottom: 0em;
     }
   }
@@ -386,7 +383,8 @@ $comment-inner-border-radius: 4px;
       margin-right: 0;
       padding-right: 0;
     }
-    .markdown-to-html > *:last-child {
+
+    .markdown-to-html>*:last-child {
       margin-bottom: 0px;
     }
   }
@@ -401,6 +399,7 @@ $comment-inner-border-radius: 4px;
   .comment .discussion-bubble {
     @include base-bubble;
     max-width: 300px;
+
     mat-stepper {
       background-color: white;
     }
@@ -410,22 +409,18 @@ $comment-inner-border-radius: 4px;
 
   .comment.comment-by-other-user .text-bubble {
     background: $comment-bubble-color-other-user;
-    // color: $text-color;
     color: black;
-    // margin-right: 50px;
     margin-left: 0;
   }
 
   .comment.comment-by-other-user .pdf-bubble {
     background: $comment-bubble-color-other-user;
-    // color: $text-color;
     color: black;
     color: black;
     margin-right: 50px;
     margin-left: 0;
 
     a p {
-      // color: $text-color;
       color: black;
       margin-bottom: 0;
     }
@@ -470,10 +465,12 @@ $comment-inner-border-radius: 4px;
     border-radius: none;
     min-height: 54px;
   }
+
   .comment-submitter {
     display: flex;
     word-wrap: break-word;
     hyphens: auto;
+
     .markdown-editor {
       padding: 0;
       width: 100%;

--- a/src/app/units/states/tasks/inbox/inbox.tpl.html
+++ b/src/app/units/states/tasks/inbox/inbox.tpl.html
@@ -16,7 +16,7 @@
   >
   </task-dashboard>
   <task-comments-viewer
-    style="min-width: 300px; flex-grow: 1; max-width: 400px"
+    style="min-width: 350px; flex-grow: 1; max-width: 350px; margin-left: 10px;"
     [task]="taskData.selectedTask"
     [project]="taskData.selectedTask.project()"
   >


### PR DESCRIPTION
# Description

Restructures the task comments design, to start at the bottom of the chat window, and to place your own chats on the right hand side.

Also removes the user icon for yourself to free up space and fixes a few layout shifting bugs.

![Screen Shot 2022-09-28 at 7 50 24 pm](https://user-images.githubusercontent.com/5138218/192748424-c368d188-5404-4c47-8b74-6bb42d688967.png)
