### PR TITLE
fix: missing empty string check

### DIFF
--- a/src/app/units/modals/unit-ilo-edit-modal/unit-ilo-edit-modal.tpl.html
+++ b/src/app/units/modals/unit-ilo-edit-modal/unit-ilo-edit-modal.tpl.html
@@ -25,7 +25,7 @@
       </div>
     </div>
     <div class="modal-footer text-right">
-      <input type="submit" class="btn btn-primary" ng-disabled="ilo.name == null || ilo.abbreviation == null || ilo.description == null"
+      <input type="submit" class="btn btn-primary" ng-disabled="(ilo.name == null || ilo.abbreviation == null || ilo.description == null) || (ilo.name == '' || ilo.abbreviation == '' || ilo.description == '')"
         value="{{isNew ? 'Create' : 'Update'}}" />
     </div>
   </form>

--- a/src/app/units/modals/unit-ilo-edit-modal/unit-ilo-edit-modal.tpl.html
+++ b/src/app/units/modals/unit-ilo-edit-modal/unit-ilo-edit-modal.tpl.html
@@ -20,13 +20,22 @@
         <label class="col-sm-3 control-label">Description</label>
         <div class="col-sm-7">
           <!-- <markdown-editor height="200" placeholder="Enter markdown description..." ng-model="ilo.description"></markdown-editor> -->
-          <div contenteditable ng-model="ilo.description" placeholder="Enter markdown description..." style="border-style: solid; border-width: thin; height: 200px"></div>
+          <div
+            contenteditable
+            ng-model="ilo.description"
+            placeholder="Enter markdown description..."
+            style="border-style: solid; border-width: thin; height: 200px"
+          ></div>
         </div>
       </div>
     </div>
     <div class="modal-footer text-right">
-      <input type="submit" class="btn btn-primary" ng-disabled="(ilo.name == null || ilo.abbreviation == null || ilo.description == null) || (ilo.name == '' || ilo.abbreviation == '' || ilo.description == '')"
-        value="{{isNew ? 'Create' : 'Update'}}" />
+      <input
+        type="submit"
+        class="btn btn-primary"
+        ng-disabled="!ilo.name || !ilo.abbreviation || !ilo.description"
+        value="{{isNew ? 'Create' : 'Update'}}"
+      />
     </div>
   </form>
 </div>


### PR DESCRIPTION
# Description
After new ILO was created, ilo.name, ilo.abbreviation and ilo.description will not be null but empty string instead. As the result, update empty field will be allow.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

## Testing Checklist:

- [x] Tested in latest Chrome
- [x] Tested in latest Safari
- [x] Tested in latest Firefox

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have requested a review from @macite and @jakerenzella on the Pull Request
