### PR TITLE
fix: Missing alert in edit-profile-form.component.ts

### DIFF
--- a/src/app/common/edit-profile-form/edit-profile-form.component.ts
+++ b/src/app/common/edit-profile-form/edit-profile-form.component.ts
@@ -6,6 +6,7 @@ import { User } from 'src/app/api/models/user/user';
 import { AuthenticationService } from 'src/app/api/services/authentication.service';
 import { UserService } from 'src/app/api/services/user.service';
 import { DoubtfireConstants } from 'src/app/config/constants/doubtfire-constants';
+import { alertService } from 'src/app/ajs-upgraded-providers';
 
 @Component({
   selector: 'f-edit-profile-form',
@@ -19,7 +20,8 @@ export class EditProfileFormComponent implements OnInit {
     private state: StateService,
     private authService: AuthenticationService,
     @Optional() @Inject(MAT_DIALOG_DATA) public data: { user: User },
-    private _snackBar: MatSnackBar
+    private _snackBar: MatSnackBar,
+    @Inject(alertService) private alertService: any,
   ) {
     this.user = data?.user || this.userService.currentUser;
   }
@@ -71,7 +73,7 @@ export class EditProfileFormComponent implements OnInit {
           });
         }
       },
-      error: (error) => console.log(error),
+      error: (error) => this.alertService.add('danger', `${error}`, 6000),
     });
   }
 }


### PR DESCRIPTION
# Description
Tested in **7.0-dev**

Missing Alert in edit-profile-form.component.ts for email validation.

Fixes # (issue)

Before:
![2022-12-08 20-35-40](https://user-images.githubusercontent.com/16495912/206413324-4d70ab11-d811-474e-a07c-15da4346e5a5.gif)

After:
<img width="1170" alt="Screenshot 2022-12-08 at 8 44 15 pm" src="https://user-images.githubusercontent.com/16495912/206413822-f9ab9336-4ed8-4e1e-98a4-f07d0920511f.png">

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

## Testing Checklist:

- [x] Tested in latest Chrome
- [x] Tested in latest Safari
- [x] Tested in latest Firefox

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have requested a review from @macite and @jakerenzella on the Pull Request
