### PR TITLE
build: update GitHub actions

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
       - name: Login to DockerHub
         uses: docker/login-action@v2
         if: github.event_name != 'pull_request'
@@ -50,7 +50,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
       - name: Login to DockerHub
         uses: docker/login-action@v2
         if: github.event_name != 'pull_request'

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       - name: Login to DockerHub
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       - name: Login to DockerHub

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -27,7 +27,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Setup meta for development image
         id: docker_meta
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v4
         with:
           images: lmsdoubtfire/doubtfire-web
           tags: |
@@ -59,7 +59,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Setup meta for web server
         id: docker_meta
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v4
         with:
           images: lmsdoubtfire/doubtfire-web
           tags: |

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       - name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         if: github.event_name != 'pull_request'
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -52,7 +52,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       - name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         if: github.event_name != 'pull_request'
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -34,7 +34,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}.x-dev
       - name: Build and push web server
         id: docker_build
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: .
           push: ${{ github.event_name != 'pull_request' }}
@@ -70,7 +70,7 @@ jobs:
             type=semver,pattern=prod-{{major}}
       - name: Build and push web server
         id: docker_build
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           file: deploy.Dockerfile
           context: .

--- a/.github/workflows/nodejs-ci.yml
+++ b/.github/workflows/nodejs-ci.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: browser-actions/setup-chrome@latest
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm install -g @angular/cli

--- a/.github/workflows/nodejs-ci.yml
+++ b/.github/workflows/nodejs-ci.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         node-version: [16.x]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: browser-actions/setup-chrome@latest
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v1


### PR DESCRIPTION
# Description

Update all GitHub docker-related actions. These changes are just for upkeeping and should not affect the existing CI.

- `docker/build-push-action` from v2 to v3 ([changelog](https://github.com/docker/build-push-action/compare/v2.10.0...v3.2.0))
- `docker/metadata-action` from v3 to v4 ([changelog](https://github.com/docker/metadata-action/compare/v3.8.0...v4.1.1))
- `docker/login-action` from v1 to v2 ([changelog](https://github.com/docker/login-action/compare/v1.14.1...v2.1.0
))
- `docker/setup-buildx-action` from v1 to v2 ([changelog](https://github.com/docker/setup-buildx-action/compare/v1.7.0...v2.2.1))
- `actions/checkout` from v2 to v3 ([changelog](https://github.com/actions/checkout/compare/v2.5.0...v3.1.0))
- `actions/setup-node` from v3 to v4 ([changelog](https://github.com/actions/setup-node/compare/v3.5.1..v1.4.6))

## Type of change

- [x] Build dependencies update

# How Has This Been Tested?

- [ ] Ensure the PR CI is completed and green before merging.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
