### PR TITLE
Looks/staff task list qol changes

### DIFF
--- a/src/app/units/states/tasks/inbox/directives/staff-task-list/staff-task-list.component.html
+++ b/src/app/units/states/tasks/inbox/directives/staff-task-list/staff-task-list.component.html
@@ -194,7 +194,7 @@
             fxLayoutAlign="start center"
             [ngClass]="{ hover: task.hover }"
             (mouseover)="task.hover = true"
-            (mouseout)="task.hover = false"
+            (mouseout)="task.hover = task.optionsOpened"
           >
             <user-icon fxFlexAlign="center" [user]="task.project.student" [size]="30"> </user-icon>
             <div class="task-list-data truncate" fxFlex [hidden]="isNarrow">
@@ -216,46 +216,44 @@
             <div *ngIf="task.hasGrade()" matTooltip="The grade assigned to the submission" matTooltipPosition="above">
               <mat-chip style="margin-right: 6px" [hidden]="isNarrow">{{ task.gradeDesc() }} </mat-chip>
             </div>
-            <status-icon
-              [hidden]="isNarrow"
-              matBadge="{{ task.qualityPts }}/{{ task.definition.maxQualityPts }}"
-              [matBadgeHidden]="!task.hasQualityPoints() || !task.qualityPts"
-              matBadgePosition="before"
-              [status]="task.status"
-            ></status-icon>
+            <div
+              matBadge="{{ task.numNewComments }}"
+              [matBadgeHidden]="task.numNewComments <= 0 || task.plagiarismDetected()"
+              matBadgePosition="after"
+              matBadgeSize="small"
+              matBadgeColor="warn"
+            >
+              <status-icon
+                [hidden]="isNarrow"
+                matBadge="{{ task.qualityPts }}/{{ task.definition.maxQualityPts }}"
+                [matBadgeHidden]="!task.hasQualityPoints() || !task.qualityPts"
+                matBadgePosition="before"
+                [status]="task.status"
+              >
+              </status-icon>
+            </div>
             <div class="overflow" [hidden]="isNarrow" *ngIf="!isTaskDefMode">
               <button [hidden]="task.hover" mat-icon-button aria-label="task-overflow">
                 <mat-icon class="warn-icon" *ngIf="task.plagiarismDetected()">remove_red_eye</mat-icon>
-
-                <div
-                  *ngIf="task.pinned"
-                  matBadge="{{ task.numNewComments }}"
-                  [matBadgeHidden]="task.numNewComments <= 0 || task.plagiarismDetected()"
-                  matBadgePosition="before"
-                  matBadgeSize="small"
-                  matBadgeColor="warn"
-                >
-                  <mat-icon class="pin-icon">push_pin</mat-icon>
-                </div>
-
-                <div *ngIf="!task.pinned">
-                  <div class="new_comments" *ngIf="task.numNewComments > 0 && !task.plagiarismDetected()">
-                    {{ task.numNewComments }}
-                  </div>
-                </div>
+                  <mat-icon *ngIf="task.pinned" class="pin-icon">push_pin</mat-icon>
               </button>
               <button
                 [hidden]="!task.hover"
                 mat-icon-button
                 aria-label="task overflow"
                 [matMenuTriggerFor]="overflowMenu"
+                (menuOpened)="setSelectedTask(task); task.optionsOpened = true"
+                (menuClosed)="task.hover = false; task.optionsOpened = false"
+                matTooltip="Submission options"
+                matTooltipPosition="right"
+                matTooltipShowDelay="400"
               >
                 <mat-icon>more_horiz</mat-icon>
               </button>
               <mat-menu #overflowMenu="matMenu" yPosition="below">
                 <button [disabled] mat-menu-item (click)="togglePin(task)">
                   <mat-icon> {{ task.pinned ? 'remove_circle' : 'add_alert' }} </mat-icon>
-                  <span>{{ task.pinned ? 'unpin from inbox' : 'pin to inbox' }} </span>
+                  <span>{{ task.pinned ? 'Unpin from inbox' : 'Pin to inbox' }} </span>
                 </button>
               </mat-menu>
             </div>

--- a/src/app/units/states/tasks/inbox/directives/staff-task-list/staff-task-list.component.scss
+++ b/src/app/units/states/tasks/inbox/directives/staff-task-list/staff-task-list.component.scss
@@ -28,7 +28,6 @@
 $warn-color: #f44336;
 
 .pin-icon.mat-icon {
-  padding-top: 10px;
   color: gray;
 }
 
@@ -208,5 +207,6 @@ user-icon {
   .mat-icon {
     font-size: 50px;
     color: rgba(0, 0, 0, 0.2);
+    align-self: center;
   }
 }


### PR DESCRIPTION
# Description

Various small changes to the `staff-task-list-component`, including:
- Notification icon on component is consistent, regardless of whether the component is pinned or not
- Overflow on component now has tooltip
- Overflow no longer hides when clicked
- Clicking the overflow on a non-selected component no longer has spacing issues
- Consistent capitalisation for pin/unpin options

Fixes # (issue)
N/A -- These are QOL changes

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Only through visual inspection. No functionality is changed.

## Testing Checklist:

- [x] Tested in latest Chrome
- [ ] Tested in latest Safari
- [ ] Tested in latest Firefox

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have requested a review from @macite and @jakerenzella on the Pull Request
