### PR TITLE
fix: split header onto seperate lines on small screens

### DIFF
--- a/src/app/common/header/header.component.html
+++ b/src/app/common/header/header.component.html
@@ -1,56 +1,72 @@
-<mat-toolbar *ngIf="showHeader" fxLayout="row" fxLayoutAlign="start center" style="min-height: 85px">
-  <a uiSref="home">
-    <mat-icon
-      uiSref="home"
-      style="margin-right: 20px; margin-left: 20px"
-      svgIcon="formatif-logo"
-      class="formatif-icon"
-      aria-hidden="false"
-      aria-label="Example user verified icon"
-    ></mat-icon>
-  </a>
+<mat-toolbar *ngIf="showHeader">
+  <mat-toolbar-row fxLayout="row" fxLayoutAlign="start center" fxLayoutAlign.xs="space-between center">
+    <a uiSref="home">
+      <mat-icon
+        uiSref="home"
+        style="margin-right: 20px; margin-left: 20px"
+        svgIcon="formatif-logo"
+        class="formatif-icon"
+        aria-hidden="false"
+        aria-label="Example user verified icon"
+      ></mat-icon>
+    </a>
 
-  <unit-dropdown [unit]="currentUnit" [unitRoles]="filteredUnitRoles" [projects]="projects"> </unit-dropdown>
+    <unit-dropdown [unit]="currentUnit" [unitRoles]="filteredUnitRoles" [projects]="projects"> </unit-dropdown>
 
-  <task-dropdown
-    [currentUnit]="currentUnit"
-    [currentProject]="currentProject"
-    [currentView]="currentView"
-    [data]="data"
-    [unitRole]="currentUnitRole"
-  ></task-dropdown>
+    <task-dropdown
+      fxHide.xs="TRUE"
+      [currentUnit]="currentUnit"
+      [currentProject]="currentProject"
+      [currentView]="currentView"
+      [data]="data"
+      [unitRole]="currentUnitRole"
+    ></task-dropdown>
 
-  <span fxFlex></span>
+    <span fxFlex fxHide.xs="TRUE"></span>
 
-  <button
-    #menuState="matMenuTrigger"
-    mat-button
-    fxShow.lt-sm="false"
-    fxShow.gt-md="true"
-    fxShow="true"
-    [matMenuTriggerFor]="menu"
-    *ngIf="currentUser.role === 'Admin' || currentUser.role === 'Convenor'"
+    <button
+      #menuState="matMenuTrigger"
+      mat-button
+      fxShow.lt-sm="false"
+      fxShow.gt-md="true"
+      fxShow="true"
+      [matMenuTriggerFor]="menu"
+      *ngIf="currentUser.role === 'Admin' || currentUser.role === 'Convenor'"
+    >
+      <mat-icon>admin_panel_settings</mat-icon>
+    </button>
+    <mat-menu #menu="matMenu">
+      <button mat-menu-item uiSref="admin/teachingperiods" *ngIf="currentUser.role === 'Admin'">
+        Manage Teaching Periods
+      </button>
+      <button mat-menu-item uiSref="institutionsettings" *ngIf="currentUser.role === 'Admin'">
+        Institution Settings
+      </button>
+      <button mat-menu-item uiSref="admin/units">Manage Units</button>
+      <button mat-menu-item uiSref="admin/users" *ngIf="currentUser.role === 'Admin'">Manage Users</button>
+    </mat-menu>
+
+    <button mat-button [matMenuTriggerFor]="menu2">
+      <user-icon [size]="32"></user-icon>
+    </button>
+    <mat-menu #menu2="matMenu">
+      <button mat-menu-item uiSref="edit_profile">Edit Profile</button>
+      <button mat-menu-item (click)="openCalendar()">Calendar</button>
+      <button mat-menu-item (click)="openAboutModal()">About</button>
+      <button mat-menu-item (click)="signOut()">Sign Out</button>
+    </mat-menu>
+  </mat-toolbar-row>
+  <mat-toolbar-row
+    style="height: max-content; margin-bottom: 4px"
+    fxHide.gt-xs="TRUE"
+    fxLayoutAlign="space-around center"
   >
-    <mat-icon>admin_panel_settings</mat-icon>
-  </button>
-  <mat-menu #menu="matMenu">
-    <button mat-menu-item uiSref="admin/teachingperiods" *ngIf="currentUser.role === 'Admin'">
-      Manage Teaching Periods
-    </button>
-    <button mat-menu-item uiSref="institutionsettings" *ngIf="currentUser.role === 'Admin'">
-      Institution Settings
-    </button>
-    <button mat-menu-item uiSref="admin/units">Manage Units</button>
-    <button mat-menu-item uiSref="admin/users" *ngIf="currentUser.role === 'Admin'">Manage Users</button>
-  </mat-menu>
-
-  <button mat-button [matMenuTriggerFor]="menu2">
-    <user-icon [size]="32"></user-icon>
-  </button>
-  <mat-menu #menu2="matMenu">
-    <button mat-menu-item uiSref="edit_profile">Edit Profile</button>
-    <button mat-menu-item (click)="openCalendar()">Calendar</button>
-    <button mat-menu-item (click)="openAboutModal()">About</button>
-    <button mat-menu-item (click)="signOut()">Sign Out</button>
-  </mat-menu>
+    <task-dropdown
+      [currentUnit]="currentUnit"
+      [currentProject]="currentProject"
+      [currentView]="currentView"
+      [data]="data"
+      [unitRole]="currentUnitRole"
+    ></task-dropdown>
+  </mat-toolbar-row>
 </mat-toolbar>

--- a/src/app/common/header/header.component.scss
+++ b/src/app/common/header/header.component.scss
@@ -1,5 +1,5 @@
 .mat-toolbar {
-  height: 72px;
+  min-height: 72px;
   background-color: #F5F5F5;
 
   font-family: 'Grotesk';


### PR DESCRIPTION
# Description
Split the unit dropdown menu onto a seperate line in the header on small screens (`< 600px`). Fix header menu overflowing on small screen sizes.


Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?
Visual inspection using Chrome and Firefox's mobile viewport tools, to a minimum size of `360px`. 
Visual inspection using an iPhone 11 running Safari.

## Testing Checklist:

- [x] Tested in latest Chrome
- [x] Tested in latest Safari
- [x] Tested in latest Firefox

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have requested a review from @macite and @jakerenzella on the Pull Request
