### PR TITLE
Looks/mobile header

### DIFF
--- a/src/app/common/header/header.component.html
+++ b/src/app/common/header/header.component.html
@@ -1,72 +1,56 @@
-<mat-toolbar *ngIf="showHeader">
-  <mat-toolbar-row fxLayout="row" fxLayoutAlign="start center" fxLayoutAlign.xs="space-between center">
-    <a uiSref="home">
-      <mat-icon
-        uiSref="home"
-        style="margin-right: 20px; margin-left: 20px"
-        svgIcon="formatif-logo"
-        class="formatif-icon"
-        aria-hidden="false"
-        aria-label="Example user verified icon"
-      ></mat-icon>
-    </a>
+<mat-toolbar *ngIf="showHeader" fxLayout="row" fxLayoutAlign="start center" style="min-height: 85px">
+  <a uiSref="home">
+    <mat-icon
+      uiSref="home"
+      style="margin-right: 20px; margin-left: 20px"
+      svgIcon="formatif-logo"
+      class="formatif-icon"
+      aria-hidden="false"
+      aria-label="Example user verified icon"
+    ></mat-icon>
+  </a>
 
-    <unit-dropdown [unit]="currentUnit" [unitRoles]="filteredUnitRoles" [projects]="projects"> </unit-dropdown>
+  <unit-dropdown [unit]="currentUnit" [unitRoles]="filteredUnitRoles" [projects]="projects"> </unit-dropdown>
 
-    <task-dropdown
-      fxHide.xs="TRUE"
-      [currentUnit]="currentUnit"
-      [currentProject]="currentProject"
-      [currentView]="currentView"
-      [data]="data"
-      [unitRole]="currentUnitRole"
-    ></task-dropdown>
+  <task-dropdown
+    [currentUnit]="currentUnit"
+    [currentProject]="currentProject"
+    [currentView]="currentView"
+    [data]="data"
+    [unitRole]="currentUnitRole"
+  ></task-dropdown>
 
-    <span fxFlex fxHide.xs="TRUE"></span>
+  <span fxFlex></span>
 
-    <button
-      #menuState="matMenuTrigger"
-      mat-button
-      fxShow.lt-sm="false"
-      fxShow.gt-md="true"
-      fxShow="true"
-      [matMenuTriggerFor]="menu"
-      *ngIf="currentUser.role === 'Admin' || currentUser.role === 'Convenor'"
-    >
-      <mat-icon>admin_panel_settings</mat-icon>
-    </button>
-    <mat-menu #menu="matMenu">
-      <button mat-menu-item uiSref="admin/teachingperiods" *ngIf="currentUser.role === 'Admin'">
-        Manage Teaching Periods
-      </button>
-      <button mat-menu-item uiSref="institutionsettings" *ngIf="currentUser.role === 'Admin'">
-        Institution Settings
-      </button>
-      <button mat-menu-item uiSref="admin/units">Manage Units</button>
-      <button mat-menu-item uiSref="admin/users" *ngIf="currentUser.role === 'Admin'">Manage Users</button>
-    </mat-menu>
-
-    <button mat-button [matMenuTriggerFor]="menu2">
-      <user-icon [size]="32"></user-icon>
-    </button>
-    <mat-menu #menu2="matMenu">
-      <button mat-menu-item uiSref="edit_profile">Edit Profile</button>
-      <button mat-menu-item (click)="openCalendar()">Calendar</button>
-      <button mat-menu-item (click)="openAboutModal()">About</button>
-      <button mat-menu-item (click)="signOut()">Sign Out</button>
-    </mat-menu>
-  </mat-toolbar-row>
-  <mat-toolbar-row
-    style="height: max-content; margin-bottom: 4px"
-    fxHide.gt-xs="TRUE"
-    fxLayoutAlign="space-around center"
+  <button
+    #menuState="matMenuTrigger"
+    mat-button
+    fxShow.lt-sm="false"
+    fxShow.gt-md="true"
+    fxShow="true"
+    [matMenuTriggerFor]="menu"
+    *ngIf="currentUser.role === 'Admin' || currentUser.role === 'Convenor'"
   >
-    <task-dropdown
-      [currentUnit]="currentUnit"
-      [currentProject]="currentProject"
-      [currentView]="currentView"
-      [data]="data"
-      [unitRole]="currentUnitRole"
-    ></task-dropdown>
-  </mat-toolbar-row>
+    <mat-icon>admin_panel_settings</mat-icon>
+  </button>
+  <mat-menu #menu="matMenu">
+    <button mat-menu-item uiSref="admin/teachingperiods" *ngIf="currentUser.role === 'Admin'">
+      Manage Teaching Periods
+    </button>
+    <button mat-menu-item uiSref="institutionsettings" *ngIf="currentUser.role === 'Admin'">
+      Institution Settings
+    </button>
+    <button mat-menu-item uiSref="admin/units">Manage Units</button>
+    <button mat-menu-item uiSref="admin/users" *ngIf="currentUser.role === 'Admin'">Manage Users</button>
+  </mat-menu>
+
+  <button mat-button [matMenuTriggerFor]="menu2">
+    <user-icon [size]="32"></user-icon>
+  </button>
+  <mat-menu #menu2="matMenu">
+    <button mat-menu-item uiSref="edit_profile">Edit Profile</button>
+    <button mat-menu-item (click)="openCalendar()">Calendar</button>
+    <button mat-menu-item (click)="openAboutModal()">About</button>
+    <button mat-menu-item (click)="signOut()">Sign Out</button>
+  </mat-menu>
 </mat-toolbar>

--- a/src/app/common/header/header.component.html
+++ b/src/app/common/header/header.component.html
@@ -1,5 +1,5 @@
 <mat-toolbar *ngIf="showHeader" fxLayout="row" fxLayoutAlign="start center" style="min-height: 85px">
-  <a uiSref="home">
+  <a uiSref="home" *ngIf="!media.isActive('xs')">
     <mat-icon
       uiSref="home"
       style="margin-right: 20px; margin-left: 20px"

--- a/src/app/common/header/header.component.scss
+++ b/src/app/common/header/header.component.scss
@@ -1,5 +1,5 @@
 .mat-toolbar {
-  min-height: 72px;
+  height: 72px;
   background-color: #F5F5F5;
 
   font-family: 'Grotesk';

--- a/src/app/common/header/header.component.ts
+++ b/src/app/common/header/header.component.ts
@@ -6,6 +6,7 @@ import { IsActiveUnitRole } from '../pipes/is-active-unit-role.pipe';
 import { UserService } from 'src/app/api/services/user.service';
 import { AuthenticationService, Project, Unit, UnitRole, User } from 'src/app/api/models/doubtfire-model';
 import { Subscription } from 'rxjs';
+import { MediaObserver } from '@angular/flex-layout';
 @Component({
   selector: 'app-header',
   templateUrl: './header.component.html',
@@ -36,7 +37,8 @@ export class HeaderComponent implements OnInit, OnDestroy {
     private checkForUpdateService: CheckForUpdateService,
     private globalState: GlobalStateService,
     private userService: UserService,
-    private authService: AuthenticationService
+    private authService: AuthenticationService,
+    private media: MediaObserver
   ) {}
 
   ngOnInit(): void {

--- a/src/app/common/header/task-dropdown/task-dropdown.component.html
+++ b/src/app/common/header/task-dropdown/task-dropdown.component.html
@@ -43,7 +43,7 @@
   <ng-container *ngIf="currentActivity">
     <span style="color: rgb(216, 216, 216)">/</span>
     <button mat-button [matMenuTriggerFor]="menu2" #menuState="matMenuTrigger">
-      {{ currentActivity }} <mat-icon>{{ menuState.menuOpen ? 'arrow_drop_up' : 'arrow_drop_down' }} </mat-icon>
+      {{ menuText }} <mat-icon>{{ menuState.menuOpen ? 'arrow_drop_up' : 'arrow_drop_down' }} </mat-icon>
     </button>
     <mat-menu #menu2="matMenu">
       <ng-container *ngIf="currentProject !== null && currentView === 'PROJECT'">

--- a/src/app/common/header/task-dropdown/task-dropdown.component.ts
+++ b/src/app/common/header/task-dropdown/task-dropdown.component.ts
@@ -1,25 +1,64 @@
-import { Component, Input } from '@angular/core';
+import { Component, Input, OnDestroy, OnInit } from '@angular/core';
 import { UIRouter } from '@uirouter/core';
 import { Project, Unit, UnitRole } from 'src/app/api/models/doubtfire-model';
 import { ViewType } from 'src/app/projects/states/index/global-state.service';
+import { MediaObserver } from '@angular/flex-layout';
+import { Subscription } from 'rxjs';
 
 @Component({
   selector: 'task-dropdown',
   templateUrl: './task-dropdown.component.html',
   styleUrls: ['./task-dropdown.component.scss'],
 })
-export class TaskDropdownComponent {
-  currentActivity: any;
+export class TaskDropdownComponent implements OnDestroy, OnInit {
+  currentActivity: string;
+  menuText: string;
+  private mediaSubscription: Subscription;
   @Input() data: { isTutor: boolean };
   @Input() currentUnit: Unit;
   @Input() currentProject: Project;
   @Input() currentView: ViewType;
   @Input() unitRole: UnitRole;
 
+  taskToShortName: { [key: string]: string } = {
+    'Learning Outcomes': 'Outcomes',
+    'Mark Tasks Offline': 'Offline',
+    'Portfolio Creation': 'Portfolio',
+    'Staff Tasks': 'Staff Tasks',
+    'Student Groups': 'Groups',
+    'Student List': 'Students',
+    'Student Plagiarism': 'Plagiarism',
+    'Student Portfolios': 'Portfolios',
+    'Task Explorer': 'Explorer',
+    'Task Inbox': 'Inbox',
+    'Task Lists': 'Tasks',
+    'Tutorial List': 'Tutorials',
+    'Unit Administration': 'Admin',
+    'Unit Analytics': 'Analytics',
+  };
+
+  ngOnInit(): void {
+    this.mediaSubscription = this.media.asObservable().subscribe((change) => {
+      if (change.some((item) => item.mqAlias === 'xs')) {
+        this.menuText = this.taskToShortName?.[this.currentActivity] ?? this.currentActivity;
+      } else {
+        this.menuText = this.currentActivity;
+      }
+    });
+  }
+
   taskDropdownData: { title: string; target: string; visible: any }[];
-  constructor(private router: UIRouter) {
+  constructor(private router: UIRouter, private media: MediaObserver) {
     this.router.transitionService.onSuccess({ to: '**' }, (trans) => {
       this.currentActivity = trans.to().data.task;
+      this.menuText =
+        media.isActive('xs') && this.currentActivity in this.taskToShortName
+          ? this.taskToShortName[this.currentActivity]
+          : this.currentActivity;
     });
+  }
+
+  ngOnDestroy(): void {
+    this.mediaSubscription.unsubscribe();
   }
 }

--- a/src/app/common/header/task-dropdown/task-dropdown.component.ts
+++ b/src/app/common/header/task-dropdown/task-dropdown.component.ts
@@ -1,19 +1,16 @@
-import { Component, Input, OnDestroy, OnInit } from '@angular/core';
+import { Component, Input } from '@angular/core';
 import { UIRouter } from '@uirouter/core';
 import { Project, Unit, UnitRole } from 'src/app/api/models/doubtfire-model';
 import { ViewType } from 'src/app/projects/states/index/global-state.service';
-import { MediaObserver } from '@angular/flex-layout';
-import { Subscription } from 'rxjs';
 
 @Component({
   selector: 'task-dropdown',
   templateUrl: './task-dropdown.component.html',
   styleUrls: ['./task-dropdown.component.scss'],
 })
-export class TaskDropdownComponent implements OnDestroy, OnInit {
+export class TaskDropdownComponent {
   currentActivity: string;
   menuText: string;
-  private mediaSubscription: Subscription;
   @Input() data: { isTutor: boolean };
   @Input() currentUnit: Unit;
   @Input() currentProject: Project;
@@ -29,7 +26,7 @@ export class TaskDropdownComponent implements OnDestroy, OnInit {
     'Student List': 'Students',
     'Student Plagiarism': 'Plagiarism',
     'Student Portfolios': 'Portfolios',
-    'Task Explorer': 'Explorer',
+    'Task Explorer': 'Task Explorer',
     'Task Inbox': 'Inbox',
     'Task Lists': 'Tasks',
     'Tutorial List': 'Tutorials',
@@ -37,28 +34,12 @@ export class TaskDropdownComponent implements OnDestroy, OnInit {
     'Unit Analytics': 'Analytics',
   };
 
-  ngOnInit(): void {
-    this.mediaSubscription = this.media.asObservable().subscribe((change) => {
-      if (change.some((item) => item.mqAlias === 'xs')) {
-        this.menuText = this.taskToShortName?.[this.currentActivity] ?? this.currentActivity;
-      } else {
-        this.menuText = this.currentActivity;
-      }
-    });
-  }
-
   taskDropdownData: { title: string; target: string; visible: any }[];
-  constructor(private router: UIRouter, private media: MediaObserver) {
+  constructor(private router: UIRouter) {
     this.router.transitionService.onSuccess({ to: '**' }, (trans) => {
       this.currentActivity = trans.to().data.task;
-      this.menuText =
-        media.isActive('xs') && this.currentActivity in this.taskToShortName
-          ? this.taskToShortName[this.currentActivity]
-          : this.currentActivity;
+      this.menuText = this.taskToShortName?.[this.currentActivity] ?? this.currentActivity;
     });
   }
 
-  ngOnDestroy(): void {
-    this.mediaSubscription.unsubscribe();
-  }
 }

--- a/src/app/common/header/unit-dropdown/unit-dropdown.component.html
+++ b/src/app/common/header/unit-dropdown/unit-dropdown.component.html
@@ -26,6 +26,19 @@
 </div>
 
 <mat-menu #menu="matMenu" class="unit-dropdown-menu">
+  <button *ngIf="media.isActive('xs')" uiSref="home" fxLayout="row" fxLayoutAlign="start center" mat-menu-item>
+    <mat-icon
+      uiSref="home"
+      style="margin-right: 20px"
+      svgIcon="formatif-logo"
+      class="formatif-icon"
+      aria-hidden="false"
+      aria-label="Home Icon"
+    ></mat-icon>
+    <div class="unitName">Home</div>
+    <span fxFlex></span>
+  </button>
+
   <div mat-subheader [hidden]="unitRoles?.length === 0">Units you teach</div>
   <div *ngFor="let unitRole of unitRoles">
     <button

--- a/src/app/common/header/unit-dropdown/unit-dropdown.component.ts
+++ b/src/app/common/header/unit-dropdown/unit-dropdown.component.ts
@@ -2,6 +2,7 @@ import { Component, Inject, Input, OnInit } from '@angular/core';
 import { UIRouter } from '@uirouter/angular';
 import { dateService } from 'src/app/ajs-upgraded-providers';
 import { Project, Unit, UnitRole } from 'src/app/api/models/doubtfire-model';
+import { MediaObserver } from '@angular/flex-layout';
 
 @Component({
   selector: 'unit-dropdown',
@@ -16,7 +17,8 @@ export class UnitDropdownComponent implements OnInit {
   unitTitle: string;
 
   constructor(
-    @Inject(dateService) private DateService: any
+    @Inject(dateService) private DateService: any,
+    public media: MediaObserver
   ) {}
 
   ngOnInit(): void {}


### PR DESCRIPTION
# Description
Replace the two line mobile header menu with a compact single line header, for better usability on mobile devices.
* Move the home icon into the unit dropdown menu on small screens (`<600px`)
* Display shortened forms of task names in the header on all screen sizes.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Visual inspection using Chrome and Firefox's mobile viewport tools.

## Testing Checklist:

- [x] Tested in latest Chrome
- [ ] Tested in latest Safari
- [x] Tested in latest Firefox

# Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have requested a review from @macite and @jakerenzella on the Pull Request
