### PR TITLE
feat: pull overseer docker image

### DIFF
--- a/src/app/admin/institution-settings/overseer-images/overseer-image-list.component.html
+++ b/src/app/admin/institution-settings/overseer-images/overseer-image-list.component.html
@@ -47,6 +47,52 @@
       </td>
     </ng-container>
 
+    <!-- Pull Button Column -->
+    <ng-container matColumnDef="pull">
+      <th mat-header-cell *matHeaderCellDef></th>
+      <td mat-cell *matCellDef="let overseerImage">
+        <div class="right" *ngIf="!editing(overseerImage) else edit">
+          <button mat-flat-button color="primary" (click)="pullOverseerImage(overseerImage)">
+            Pull
+          </button>   
+        </div>
+      </td>
+      <td mat-footer-cell *matFooterCellDef></td>
+    </ng-container>
+
+    <!-- Last Pulled Column -->
+    <ng-container matColumnDef="last-pulled">
+      <th mat-header-cell *matHeaderCellDef>Last Pulled</th>
+      <td mat-cell *matCellDef="let overseerImage">
+        <div class="right" *ngIf="!editing(overseerImage) else edit">
+          {{overseerImage.lastPulledDate}}
+        </div>
+      </td>
+      <td mat-footer-cell *matFooterCellDef></td>
+    </ng-container>
+
+    <!-- Status Column -->
+    <ng-container matColumnDef="status">
+      <th mat-header-cell *matHeaderCellDef>Status</th>
+      <td mat-cell *matCellDef="let overseerImage">
+        <div class="right" *ngIf="!editing(overseerImage) else edit" 
+            [ngStyle]="{'color': (overseerImage.pulledImageStatus === 'success') ? 'green' : 
+                                 (overseerImage.pulledImageStatus === 'loading') ? 'orange' : 
+                                 (overseerImage.pulledImageStatus === 'failed') ? 'red' : ''}">
+            <button class="status-icon" *ngIf="overseerImage.pulledImageStatus === 'success'" [matTooltip]="overseerImage.pulledImageText">
+              <mat-icon>check_circle_outline</mat-icon>
+            </button>
+            <button class="status-icon" *ngIf="overseerImage.pulledImageStatus === 'loading'">
+              <mat-icon>access_time_icon</mat-icon>
+            </button>
+            <button class="status-icon" *ngIf="overseerImage.pulledImageStatus === 'failed'"  [matTooltip]="overseerImage.pulledImageText">
+              <mat-icon>error_outline</mat-icon>
+            </button>
+        </div>
+      </td>
+      <td mat-footer-cell *matFooterCellDef></td>
+    </ng-container>
+
     <!-- Options Column -->
     <ng-container matColumnDef="options" stickyEnd>
       <th mat-header-cell *matHeaderCellDef></th>

--- a/src/app/admin/institution-settings/overseer-images/overseer-image-list.component.scss
+++ b/src/app/admin/institution-settings/overseer-images/overseer-image-list.component.scss
@@ -41,3 +41,8 @@ td.mat-column-options {
   padding: 1rem 1rem 1rem 0;
   width: 95%;
 }
+.status-icon {
+  background-color: white;
+  border: none;
+  margin-top: 8px;
+}

--- a/src/app/admin/institution-settings/overseer-images/overseer-image-list.component.ts
+++ b/src/app/admin/institution-settings/overseer-images/overseer-image-list.component.ts
@@ -1,6 +1,6 @@
 import { Component, Inject, ViewChild } from '@angular/core';
 import { MatTableDataSource, MatTable } from '@angular/material/table';
-import { OverseerImage, OverseerImageService } from 'src/app/api/models/doubtfire-model';
+import { OverseerImage, OverseerImageService, TeachingPeriodService } from 'src/app/api/models/doubtfire-model';
 import { alertService } from 'src/app/ajs-upgraded-providers';
 import { EntityFormComponent } from 'src/app/common/entity-form/entity-form.component';
 import { UntypedFormControl, Validators } from '@angular/forms';
@@ -16,9 +16,10 @@ export class OverseerImageListComponent extends EntityFormComponent<OverseerImag
   @ViewChild(MatSort, { static: true }) sort: MatSort;
 
   // Set up the table
-  columns: string[] = ['name', 'tag', 'options'];
+  columns: string[] = ['name', 'tag', 'pull', 'last-pulled', 'status', 'options'];
   overseerImages: OverseerImage[] = new Array<OverseerImage>();
   dataSource = new MatTableDataSource(this.overseerImages);
+  loading = false;
 
   // Calls the parent's constructor, passing in an object
   // that maps all of the form controls that this form consists of.
@@ -30,8 +31,8 @@ export class OverseerImageListComponent extends EntityFormComponent<OverseerImag
   }
 
   ngAfterViewInit() {
-    // Get all the activity types and add them to the table
-    this.overseerImageService.query().subscribe((response) => {
+    // Get all the overseer images and add them to the table
+    this.overseerImageService.fetchAll().subscribe((response) => {
       this.pushToTable(response);
     });
   }
@@ -56,6 +57,15 @@ export class OverseerImageListComponent extends EntityFormComponent<OverseerImag
   // which then calls the parent's submit.
   submit() {
     super.submit(this.overseerImageService, this.alerts, this.onSuccess.bind(this));
+  }
+
+  // This method is called when pull button is clicked to pull overseer image.
+  pullOverseerImage(image: OverseerImage) {
+    this.loading = true;
+    image.pulledImageStatus = "loading";
+    this.overseerImageService.pullDockerImage(image).subscribe((response) => {
+      this.loading = false;
+    })
   }
 
   deleteOverseerImage(image: OverseerImage) {

--- a/src/app/api/models/overseer/overseer-image.ts
+++ b/src/app/api/models/overseer/overseer-image.ts
@@ -1,9 +1,13 @@
+import { StringNullableChain } from 'lodash';
 import { Entity, EntityMapping } from 'ngx-entity-service';
 
 export class OverseerImage extends Entity {
   id: number;
   name: string;
   tag: string;
+  pulledImageText: string;
+  pulledImageStatus: string;
+  lastPulledDate: string;
 
   public override toJson<T extends Entity>(mappingData: EntityMapping<T>, ignoreKeys?: string[]): object {
     return {

--- a/src/app/api/services/overseer-image.service.ts
+++ b/src/app/api/services/overseer-image.service.ts
@@ -1,4 +1,5 @@
 import { CachedEntityService } from 'ngx-entity-service';
+import { Observable, switchMap } from 'rxjs';
 import { OverseerImage } from 'src/app/api/models/doubtfire-model';
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
@@ -7,6 +8,7 @@ import API_URL from 'src/app/config/constants/apiURL';
 @Injectable()
 export class OverseerImageService extends CachedEntityService<OverseerImage> {
   protected readonly endpointFormat = 'admin/overseer_images/:id:';
+  protected readonly pullImageEndpointFormat = 'admin/overseer_images/:id:/pull_image';
 
   constructor(httpClient: HttpClient) {
     super(httpClient, API_URL);
@@ -15,9 +17,22 @@ export class OverseerImageService extends CachedEntityService<OverseerImage> {
       'id',
       'name',
       'tag',
+      'pulledImageText',
+      'pulledImageStatus',
+      'lastPulledDate'
     );
 
     this.mapping.mapAllKeysToJsonExcept('id');
+  }
+
+  public pullDockerImage(image: OverseerImage): Observable<OverseerImage> {
+    return super.put(image, {
+      endpointFormat: this.pullImageEndpointFormat
+    }).pipe(
+      switchMap(response => {
+        return super.update(image);
+      })
+    )
   }
 
   public createInstanceFrom(json: object, other?: any): OverseerImage {


### PR DESCRIPTION
_Any italic text should be deleted from the final Pull Request text, including this line_

# Description

A button has been added to the Overseer Images table for the user to pull a Docker image, with the results of the pull being displayed in the table.

## Type of change

- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

This has been tested through the client side application, by inputting true and false Docker image tags and viewing the results.

## Testing Checklist:

- [ ] Tested in latest Chrome
- [ ] Tested in latest Firefox
Hasn't been tested on Safari as I cannot get OnTrack loaded on Safari.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have requested a review from @macite and @jakerenzella on the Pull  Request
