### PR TITLE
fix: centering of Administration icons on home page

### DIFF
--- a/src/app/home/states/home/home.component.html
+++ b/src/app/home/states/home/home.component.html
@@ -134,9 +134,9 @@
                 style="width: 100%"
                 uiSref="admin/teachingperiods"
               >
-                <mat-icon style="color: black; margin-right: 6px">date_range</mat-icon>Teaching Periods</a
-              ></mat-list-item
-            >
+                <mat-icon style="color: black; margin-right: 6px">date_range</mat-icon>Teaching Periods
+              </a>
+            </mat-list-item>
             <mat-list-item [hidden]="!ifAdmin" role="listitem">
               <a
                 fxLayout="row"
@@ -146,9 +146,12 @@
                 style="width: 100%"
                 uiSref="institutionsettings"
               >
-                <mat-icon style="color: black; margin-right: 6px">business</mat-icon>Institution Settings</a
-              ></mat-list-item
-            >
+                <div fxLayout="row" fxLayoutAlign="center center">
+                  <mat-icon style="color: black; margin-right: 6px">business</mat-icon>
+                </div>
+                Institution Settings
+              </a>
+            </mat-list-item>
             <mat-list-item role="listitem">
               <a
                 fxLayout="row"
@@ -158,9 +161,12 @@
                 style="width: 100%"
                 uiSref="admin/units"
               >
-                <mat-icon style="color: black; margin-right: 6px">school</mat-icon>Units</a
-              ></mat-list-item
-            >
+                <div fxLayout="row" fxLayoutAlign="center center">
+                  <mat-icon style="color: black; margin-right: 6px">school</mat-icon>
+                  Units
+                </div>
+              </a>
+            </mat-list-item>
             <mat-list-item role="listitem">
               <a
                 fxLayout="row"
@@ -170,9 +176,12 @@
                 style="width: 100%"
                 uiSref="admin/users"
               >
-                <mat-icon style="color: black; margin-right: 6px">people</mat-icon>Users</a
-              ></mat-list-item
-            >
+                <div fxLayout="row" fxLayoutAlign="center center">
+                  <mat-icon style="color: black; margin-right: 6px">people</mat-icon>
+                </div>
+                Users
+              </a>
+            </mat-list-item>
           </mat-list>
         </mat-card>
       </div>

--- a/src/app/home/states/home/home.component.scss
+++ b/src/app/home/states/home/home.component.scss
@@ -24,6 +24,10 @@
   text-decoration: none;
 }
 
+.mat-card-header {
+  
+}
+
 .base-card {
   margin-right: 15px;
   margin-bottom: 15px;


### PR DESCRIPTION
# Description

Fix centering of the icons on the Administration panel on the home page with the text next to the icons.

Fixes # (issue)
https://formatif.atlassian.net/browse/FOR-10?atlOrigin=eyJpIjoiMTBlZTZmNWNkOTlmNDExNDk0NDBmNWQyZjZiNDI5ZjQiLCJwIjoiaiJ9 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Visually

## Testing Checklist:

- [x] Tested in latest Chrome
- [x] Tested in latest Safari
- [x] Tested in latest Firefox

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [] I have requested a review from @macite and @jakerenzella on the Pull Request
