### PR TITLE
fix: added addtional return to staffaligntmentsfortasksdefintions met…

### DIFF
--- a/src/app/api/models/unit.ts
+++ b/src/app/api/models/unit.ts
@@ -290,7 +290,7 @@ export class Unit extends Entity {
 
   public staffAlignmentsForTaskDefinition(td: TaskDefinition): TaskOutcomeAlignment[] {
     return this.taskOutcomeAlignments.filter( (alignment: TaskOutcomeAlignment) => {
-      alignment.taskDefinition.id === td.id;
+      return alignment.taskDefinition.id === td.id;
     }).sort((a: TaskOutcomeAlignment, b: TaskOutcomeAlignment) => {
       return a.learningOutcome.iloNumber - b.learningOutcome.iloNumber;
     });


### PR DESCRIPTION
# Description

This change was to fix the bug in prod of the task outcome alignments not being displayed, It was related to the alignments array not being populated. 

Fixes # (issue)

This was because a return statement was missing from the staffAlignmentsForTaskDefinitons method in Unit.ts

## Type of change

_Please delete options that are not relevant._

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested on my Mac in safari and Windows Chrome by launching doubtfire-deploy and logging in as a astudent.

## Testing Checklist:

- [Y ] Tested in latest Chrome
- [Y] Tested in latest Safari
- [N ] Tested in latest Firefox

# Checklist:

- [Y ] My code follows the style guidelines of this project
- [Y ] I have performed a self-review of my own code
- [N/A ] I have commented my code in hard-to-understand areas
- [N/A ] I have made corresponding changes to the documentation
- [Y ] My changes generate no new warnings
- [Y ] I have requested a review from @macite and @jakerenzella on the Pull Request
