### PR TITLE
create new unit modal

### DIFF
--- a/src/app/admin/modals/create-new-unit-modal/create-new-unit-modal-content.component.html
+++ b/src/app/admin/modals/create-new-unit-modal/create-new-unit-modal-content.component.html
@@ -1,0 +1,45 @@
+<h3 mat-dialog-title>Create Unit</h3>
+
+<form mat-dialog-content action="" #createUnitForm="ngForm" (ngSubmit)="createUnit(createUnitForm.value)">
+  <div fxLayout="column">
+    <mat-form-field appearance="fill">
+      <mat-label>Unit Code</mat-label>
+      <input matInput placeholder="COS123456" name="unitCode" ngModel />
+    </mat-form-field>
+    <mat-form-field appearance="fill">
+      <mat-label>Unit Name</mat-label>
+      <input matInput placeholder="Introduction to OnTrack" name="unitName" ngModel />
+    </mat-form-field>
+    <mat-form-field appearance="fill">
+      <mat-label>Teaching Period</mat-label>
+      <mat-select (valueChange)="handleChangeTeachingPeriod($event)" name="selectedTeachingPeriod" ngModel>
+        <mat-option *ngFor="let tp of teachingPeriods; let i = index" [value]="tp.id">
+          {{ tp.name }}
+        </mat-option>
+      </mat-select>
+    </mat-form-field>
+    <div>
+      <mat-form-field appearance="fill">
+        <mat-label>Start Date</mat-label>
+        <input
+          matInput
+          [matDatepicker]="startDatePicker"
+          [disabled]="!showDates"
+          name="startDate"
+          [(ngModel)]="startDate"
+        />
+        <mat-datepicker-toggle matSuffix [for]="startDatePicker"></mat-datepicker-toggle>
+        <mat-datepicker #startDatePicker></mat-datepicker>
+      </mat-form-field>
+      <mat-form-field appearance="fill">
+        <mat-label>End Date</mat-label>
+        <input matInput [matDatepicker]="endDatePicker" [disabled]="!showDates" name="endDate" [(ngModel)]="endDate" />
+        <mat-datepicker-toggle matSuffix [for]="endDatePicker"></mat-datepicker-toggle>
+        <mat-datepicker #endDatePicker></mat-datepicker>
+      </mat-form-field>
+    </div>
+    <mat-dialog-actions align="end">
+      <button mat-raised-button color="primary">Create</button>
+    </mat-dialog-actions>
+  </div>
+</form>

--- a/src/app/admin/modals/create-new-unit-modal/create-new-unit-modal-content.component.ts
+++ b/src/app/admin/modals/create-new-unit-modal/create-new-unit-modal-content.component.ts
@@ -1,0 +1,87 @@
+import { HttpClient } from '@angular/common/http';
+import { Component, Inject } from '@angular/core';
+import { DoubtfireConstants } from 'src/app/config/constants/doubtfire-constants';
+import { MatDialogRef } from '@angular/material/dialog';
+import { alertService } from 'src/app/ajs-upgraded-providers';
+import { analyticsService } from 'src/app/ajs-upgraded-providers';
+@Component({
+  selector: 'create-new-unit-modal-content',
+  templateUrl: 'create-new-unit-modal-content.component.html',
+})
+export class CreateNewUnitModalContent {
+  constructor(
+    private http: HttpClient,
+    private constants: DoubtfireConstants,
+    private dialogRef: MatDialogRef<CreateNewUnitModalContent>,
+    @Inject(alertService) private alerts: any,
+    @Inject(analyticsService) private AnalyticsService: any
+  ) {}
+  showDates = false;
+  startDate: Date;
+  endDate: Date;
+  selectedTeachingPeriod: number;
+  teachingPeriods: object[] = [
+    { id: null, name: 'Custom date' },
+    { id: 1, name: 'T1' },
+    { id: 2, name: 'T2' },
+    { id: 3, name: 'T3' },
+  ];
+  public createUnit(unit: { unitName: string; unitCode: string; teachingPeriod: number }): void {
+    this.AnalyticsService.event('Unit Admin', 'Started to Create Unit');
+    this.http
+      .post(
+        `${this.constants.API_URL}/units`,
+        this.formatPostBody(unit.unitName, unit.unitCode, this.selectedTeachingPeriod)
+      )
+      .subscribe({
+        next: () => {
+          this.dialogRef.close();
+          this.alerts.add('success', 'Unit successfully created', 2000);
+        },
+        error: (err) => {
+          this.AnalyticsService.event('danger', `Error creating unit - ${err.data.error}`);
+        },
+        complete: () => {
+          this.AnalyticsService.event('Unit Admin', 'Saved New Unit');
+          window.location.reload();
+        },
+      });
+  }
+  public handleChangeTeachingPeriod(event: number): void {
+    if (event == null) {
+      this.showDates = true;
+      this.startDate = new Date();
+      this.endDate = new Date();
+      this.selectedTeachingPeriod = 0;
+      return;
+    }
+    [this.startDate, this.endDate] = this.getTeachingPeriodDates(event);
+    this.selectedTeachingPeriod = event;
+    this.showDates = false;
+    return;
+  }
+  private formatPostBody(unitName: string, unitCode: string, teachingPeriod: number) {
+    if (teachingPeriod) {
+      return {
+        unit: {
+          name: unitName,
+          code: unitCode,
+          teaching_period_id: teachingPeriod,
+        },
+      };
+    }
+    return {
+      unit: {
+        name: unitName,
+        code: unitCode,
+        start_date: this.startDate,
+        end_date: this.endDate,
+      },
+    };
+  }
+  private getTeachingPeriodDates(teachingPeriodId: number): Date[] {
+    if (teachingPeriodId == 1) return [new Date('2018-03-05'), new Date('2018-05-25')];
+    if (teachingPeriodId == 2) return [new Date('2018-07-09'), new Date('2018-09-28')];
+    if (teachingPeriodId == 3) return [new Date('2018-11-05'), new Date('2019-02-01')];
+  }
+}

--- a/src/app/admin/modals/create-new-unit-modal/create-new-unit-modal.component.ts
+++ b/src/app/admin/modals/create-new-unit-modal/create-new-unit-modal.component.ts
@@ -1,0 +1,16 @@
+import { Component } from '@angular/core';
+import { MatDialog } from '@angular/material/dialog';
+import { CreateNewUnitModalContent } from './create-new-unit-modal-content.component';
+
+@Component({
+  selector: 'create-new-unit-modal',
+  template: '',
+})
+export class CreateNewUnitModal {
+  constructor(public dialog: MatDialog) {}
+  public show(): void {
+    this.dialog.open(CreateNewUnitModalContent, {
+      width: '500px',
+    });
+  }
+}

--- a/src/app/admin/states/units/units.coffee
+++ b/src/app/admin/states/units/units.coffee
@@ -18,7 +18,7 @@ angular.module('doubtfire.admin.states.units', [])
       roleWhitelist: ['Admin', 'Convenor']
   $stateProvider.state "admin/units", unitsAdminViewStateData
 )
-.controller("AdministerUnitsState", ($scope, $state, $modal, DoubtfireConstants, CreateUnitModal, alertService, GlobalStateService, newUnitService) ->
+.controller("AdministerUnitsState", ($scope, $state, $modal, DoubtfireConstants, CreateUnitModal, alertService, GlobalStateService, newUnitService, CreateNewUnitModal) ->
   GlobalStateService.setView("OTHER")
   $scope.dataLoaded = false
 
@@ -64,4 +64,7 @@ angular.module('doubtfire.admin.states.units', [])
 
   $scope.createUnit = ->
     CreateUnitModal.show $scope.units
+  
+  $scope.openCreateModal = ->
+    CreateNewUnitModal.show $scope.units
 )

--- a/src/app/admin/states/units/units.tpl.html
+++ b/src/app/admin/states/units/units.tpl.html
@@ -116,6 +116,11 @@
         <i class="fa fa-plus"></i>
         Create Unit
       </button>
+      <button class="btn btn-success pull-right" ng-click="openCreateModal()">
+        <i class="fa fa-university"></i>
+        <i class="fa fa-plus"></i>
+        Create Unit
+      </button>
     </div>
   </div>
 </div>

--- a/src/app/ajs-upgraded-providers.ts
+++ b/src/app/ajs-upgraded-providers.ts
@@ -29,7 +29,6 @@ export const visualisationsProvider = {
   deps: ['$injector'],
 };
 
-
 export const calendarModalProvider = {
   provide: calendarModal,
   useFactory: (i: any) => i.get('CalendarModal'),

--- a/src/app/doubtfire-angular.module.ts
+++ b/src/app/doubtfire-angular.module.ts
@@ -40,6 +40,9 @@ import { MatLegacyChipsModule as MatChipsModule } from '@angular/material/legacy
 import { MatGridListModule } from '@angular/material/grid-list';
 import { PdfViewerModule } from 'ng2-pdf-viewer';
 import { UIRouterUpgradeModule } from '@uirouter/angular-hybrid';
+import { MatDatepickerModule } from '@angular/material/datepicker';
+import { MatNativeDateModule } from '@angular/material/core';
+import { MatDialogModule as MatDialogModuleNew } from '@angular/material/dialog';
 
 import { setTheme } from 'ngx-bootstrap/utils';
 
@@ -191,6 +194,8 @@ import { InboxComponent } from './units/states/tasks/inbox/inbox.component';
 import { ProjectProgressBarComponent } from './common/project-progress-bar/project-progress-bar.component';
 import { TeachingPeriodListComponent } from './admin/states/teaching-periods/teaching-period-list/teaching-period-list.component';
 
+import { CreateNewUnitModal } from './admin/modals/create-new-unit-modal/create-new-unit-modal.component';
+import { CreateNewUnitModalContent } from './admin/modals/create-new-unit-modal/create-new-unit-modal-content.component';
 // Note we need a separate function as it's required
 // by the AOT compiler.
 export function playerFactory() {
@@ -269,6 +274,8 @@ export function playerFactory() {
     InboxComponent,
     ProjectProgressBarComponent,
     TeachingPeriodListComponent,
+    CreateNewUnitModal,
+    CreateNewUnitModalContent,
   ],
   // Module Imports
   imports: [
@@ -327,6 +334,9 @@ export function playerFactory() {
       enabled: environment.production,
       registrationStrategy: () => interval(6000).pipe(take(1)),
     }),
+    MatDatepickerModule,
+    MatNativeDateModule,
+    MatDialogModuleNew,
   ],
   // Services we provide
   providers: [
@@ -392,6 +402,7 @@ export function playerFactory() {
     TasksInTutorialsPipe,
     TasksForInboxSearchPipe,
     IsActiveUnitRole,
+    CreateNewUnitModal,
   ],
 })
 

--- a/src/app/doubtfire-angularjs.module.ts
+++ b/src/app/doubtfire-angularjs.module.ts
@@ -266,6 +266,7 @@ import { FooterComponent } from './common/footer/footer.component';
 import { TaskAssessmentCardComponent } from './projects/states/dashboard/directives/task-dashboard/directives/task-assessment-card/task-assessment-card.component';
 import { TaskSubmissionCardComponent } from './projects/states/dashboard/directives/task-dashboard/directives/task-submission-card/task-submission-card.component';
 import { InboxComponent } from './units/states/tasks/inbox/inbox.component';
+import { CreateNewUnitModal } from './admin/modals/create-new-unit-modal/create-new-unit-modal.component';
 
 export const DoubtfireAngularJSModule = angular.module('doubtfire', [
   'doubtfire.config',
@@ -312,6 +313,7 @@ DoubtfireAngularJSModule.factory('TaskSubmission', downgradeInjectable(TaskSubmi
 DoubtfireAngularJSModule.factory('GlobalStateService', downgradeInjectable(GlobalStateService));
 DoubtfireAngularJSModule.factory('TransitionHooksService', downgradeInjectable(TransitionHooksService));
 DoubtfireAngularJSModule.factory('EditProfileService', downgradeInjectable(EditProfileDialogService));
+DoubtfireAngularJSModule.factory('CreateNewUnitModal', downgradeInjectable(CreateNewUnitModal));
 
 // directive -> component
 DoubtfireAngularJSModule.directive(
@@ -400,6 +402,7 @@ DoubtfireAngularJSModule.directive(
   'taskPlagiarismCard',
   downgradeComponent({ component: TaskPlagiarismCardComponent })
 );
+DoubtfireAngularJSModule.directive('createNewUnitModal', downgradeComponent({ component: CreateNewUnitModal }));
 
 // Global configuration
 


### PR DESCRIPTION
# Description

As part of component migration. The component here is create unit modal. There are 2 new field added start date and end date.
Changes made:

1. Created new component create-new-unit-modal.component.ts to replace the older AngularJS component
2. Added 2 new date fields (start and end date) in the modal
3. Downgraded the component in doubtfire-angularjs.module.ts because the parent component of the modal is still AngularJS component.
4. Imported material ui (MatDatepickerModule, MatNativeDateModule, MatDialogModule as MatDialogModuleNew) modules which are used in the component.

Images:
Before:
<img width="1440" alt="Screen Shot 2023-05-10 at 10 01 14 pm" src="https://github.com/doubtfire-lms/doubtfire-web/assets/81000542/0a2eb3dd-f506-4ad8-8d92-1906247461d3">
After:
<img width="1440" alt="Screen Shot 2023-05-10 at 10 01 25 pm" src="https://github.com/doubtfire-lms/doubtfire-web/assets/81000542/933411f2-418f-4c57-92dc-af986d8c8240">

Fixes # (issue)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

I tested it by creating new units

## Testing Checklist:

- [x] Tested in latest Chrome
- [x] Tested in latest Safari
- [x] Tested in latest Firefox

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have requested a review from @macite and @jakerenzella on the Pull Request
