### PR TITLE
refactor(migration): replace-fx-layout-with-tailwind-equivalent-sign-in

### DIFF
--- a/src/app/common/hero-sidebar/hero-sidebar.component.html
+++ b/src/app/common/hero-sidebar/hero-sidebar.component.html
@@ -1,12 +1,10 @@
-<div class="left-banner" fxLayout="column">
+<div class="left-banner flex column">
   <div class="header">
-    <div class="wordmark" fxLayout="row" fxLayoutAlign="start center">
+    <div class="wordmark flex-row justify-start items-center content-center">
       <img src="../../../assets/images/logo-white.svg" width="40px" alt="Homepage Logo" style="padding-right: 6px" />
       <p>{{ externalName.value }}</p>
     </div>
     <h1>Manage your learning, with feedback you'll want to receive.</h1>
   </div>
-
-  <div fxFlex="10"></div>
-  <div fxFlex="grow" class="pattern"></div>
+  <div class="pattern"></div>
 </div>

--- a/src/app/common/hero-sidebar/hero-sidebar.component.scss
+++ b/src/app/common/hero-sidebar/hero-sidebar.component.scss
@@ -1,9 +1,12 @@
 :host {
-  height: 100%;
+  display: flex;
+  height: 100vh;
   margin-left: -15px;
 }
 
 .left-banner {
+  display: flex;
+  flex-direction: column;
   flex-shrink: 0;
   width: 480px;
   background: #1153fc;
@@ -19,7 +22,6 @@
     font-size: 1.5em;
     font-weight: bold;
     color: #fff;
-    margin: 20px;
   }
 
   .wordmark {
@@ -35,6 +37,7 @@
   }
 
   .pattern {
+    flex-grow: 1;
     -webkit-mask-image: -webkit-gradient(linear, left top, left bottom, to(rgba(0, 0, 0, 1)), from(rgba(0, 0, 0, 0)));
     mask-image: -webkit-gradient(linear, left top, left bottom, to(rgba(0, 0, 0, 1)), from(rgba(0, 0, 0, 0)));
     transition: 4s linear all;

--- a/src/app/sessions/states/sign-in/sign-in.component.html
+++ b/src/app/sessions/states/sign-in/sign-in.component.html
@@ -1,33 +1,32 @@
-<section class="welcome" fxFlex fxLayout="row">
-  <f-hero-sidebar fxHide.lt-md fxFlexAlign="start"></f-hero-sidebar>
-  <section class="content" fxFlex.gt-sm [ngClass.gt-sm]="'large'" fxLayout.gt-sm="column">
+<section class="welcome flex column">
+  <f-hero-sidebar class="self-start"></f-hero-sidebar>
+  <section class="content flex-column large">
     <div class="container">
       <div class="subcontainer">
-        <div class="wordmark" fxLayout="row" fxLayoutAlign="start center" fxHide.gt-sm fxFlexAlign="start">
+        <div class="wordmark flex-row justify-start items-center content-center self-start md:hidden">
           <img src="../../../assets/images/logo-bw.svg" width="40px" alt="Homepage Logo" />
           <p>{{ externalName.value }}</p>
         </div>
-        <h1 class="welcome-heading" fxFlexAlign="start">Welcome to {{ externalName.value }}</h1>
+        <h1 class="welcome-heading self-start">Welcome to {{ externalName.value }}</h1>
         <form
           #form="ngForm"
           (ngSubmit)="signIn({ username: formData.username, password: formData.password })"
-          fxLayout="column"
-          fxLayoutAlign="center start"
-          class="sign-in-form"
+          class="sign-in-form flex-column justify-center items-center content-center"
         >
-          <mat-form-field appearance="outline" fxFlex fxFlexFill *ngIf="showCredentials">
+          <mat-form-field class="w-full h-full" appearance="outline" *ngIf="showCredentials">
             <mat-label>Username</mat-label>
             <input matInput name="username" required [(ngModel)]="formData.username" />
           </mat-form-field>
 
-          <mat-form-field appearance="outline" fxFlex fxFlexFill *ngIf="showCredentials">
+          <mat-form-field class="w-full h-full" appearance="outline" *ngIf="showCredentials">
             <mat-label>Password</mat-label>
             <input type="password" matInput name="password" required [(ngModel)]="formData.password" />
           </mat-form-field>
           <mat-checkbox *ngIf="!showCredentials" matInput name="autoLogin" [(ngModel)]="formData.autoLogin"
             >Automatically login</mat-checkbox
           >
-          <button fxFlex fxFlexFill mat-flat-button color="primary" type="form">Sign In</button>
+          <br>
+          <button class="w-full h-full" mat-flat-button color="primary" type="form">Sign In</button>
         </form>
       </div>
     </div>

--- a/src/app/sessions/states/sign-in/sign-in.component.scss
+++ b/src/app/sessions/states/sign-in/sign-in.component.scss
@@ -1,5 +1,14 @@
 @import '../../../../styles/common/hero-sidebar-layout.scss';
 
+.welcome {
+  display: flex;
+}
+
+.content {
+  flex-grow: 1;
+  padding-top: 100px;
+}
+
 .sign-in-form {
   section {
     padding: 8px;


### PR DESCRIPTION
Replaced fx-layout with equivalent tailwind maintaining the quality of the sign-in page