### PR TITLE
refactor/task-description-card

### DIFF
--- a/src/app/projects/states/dashboard/directives/task-dashboard/directives/task-description-card/task-description-card.component.html
+++ b/src/app/projects/states/dashboard/directives/task-dashboard/directives/task-description-card/task-description-card.component.html
@@ -1,6 +1,6 @@
 <mat-card appearance="outlined">
   <mat-card-header>
-    <mat-card-title>Task Details</mat-card-title>
+    <mat-card-title>{{ taskDef?.name }}</mat-card-title>
   </mat-card-header>
   <mat-card-content>
     <div class="markdown-to-pdf" [innerHTML]="taskDef?.description | marked"></div>

--- a/src/app/projects/states/dashboard/directives/task-dashboard/directives/task-description-card/task-description-card.component.ts
+++ b/src/app/projects/states/dashboard/directives/task-dashboard/directives/task-description-card/task-description-card.component.ts
@@ -17,7 +17,7 @@ export class TaskDescriptionCardComponent {
 
   constructor(
     @Inject(gradeService) private GradeService: any,
-    @Inject(FileDownloaderService) private fileDownloader: FileDownloaderService
+    @Inject(FileDownloaderService) private fileDownloader: FileDownloaderService,
   ) {
     this.grades = {
       names: GradeService.grades,
@@ -28,14 +28,14 @@ export class TaskDescriptionCardComponent {
   public downloadTaskSheet() {
     this.fileDownloader.downloadFile(
       this.taskDef.getTaskPDFUrl(true),
-      `${this.unit.code}-${this.taskDef.abbreviation}-TaskSheet.pdf`
+      `${this.unit.code}-${this.taskDef.abbreviation}-TaskSheet.pdf`,
     );
   }
 
   public downloadResources() {
     this.fileDownloader.downloadFile(
       this.taskDef.getTaskResourcesUrl(true),
-      `${this.unit.code}-${this.taskDef.abbreviation}-TaskResources.zip`
+      `${this.unit.code}-${this.taskDef.abbreviation}-TaskResources.zip`,
     );
   }
 


### PR DESCRIPTION
# Description
Updating the `task-description-card` component's title to reflect the actual name of the task rather than the words "Task Details".
<br>
**Note:** this will appear to double-up with the panel title. However, in our other pull request #746 , this panel title will no longer exist.

## Type of change
As per above.

# How Has This Been Tested?
## Testing Checklist:

- [x] Tested in latest Chrome
- [x] Tested in latest Safari
- [x] Tested in latest Firefox

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have requested a review from @macite and @jakerenzella on the Pull Request
