### PR TITLE
fix: change-the-wording-of-fail-tasks

### DIFF
--- a/src/app/api/models/task-status.ts
+++ b/src/app/api/models/task-status.ts
@@ -181,7 +181,7 @@ export class TaskStatus {
     ["discuss", "Discuss"],
     ["demonstrate", "Demonstrate"],
     ["complete", "Complete"],
-    ["fail", "Fail"],
+    ["fail", "Needs Improvement"],
     ["time_exceeded", "Time Exceeded"],
   ]);
 


### PR DESCRIPTION
# Description

This change adjust the output text for any failed task from "Fail" to "Needs Improvement" this affects the tasks and learning portfolio view for a student and the marking view for a tutor. There is a corresponding backend change to adjust the comment view.

Fixes # fail tasking naming changed to Needs Improvement

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested thoroughly on local environment as student, tutor and unit head.

## Testing Checklist:

- [x] Tested in latest Chrome

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have requested a review from @macite and @jakerenzella on the Pull Request
