### PR TITLE
fix: resolved issue with intelligent discussion

### DIFF
--- a/src/app/tasks/task-comment-composer/discussion-prompt-composer-dialog.html
+++ b/src/app/tasks/task-comment-composer/discussion-prompt-composer-dialog.html
@@ -1,6 +1,7 @@
-<button id="dialogCloseButton" mat-button mat-dialog-close mat-icon-button aria-label="Close dialog button">
+<button id="dialogCloseButton" mat-icon-button mat-dialog-close aria-label="Close dialog button">
   <mat-icon aria-label="Quit cross icon">close</mat-icon>
 </button>
+
 <mat-horizontal-stepper id="discussionPromptStepper" [linear]="true" #stepper>
   <mat-step>
     <ng-template matStepLabel>Introduction</ng-template>

--- a/src/app/tasks/task-comment-composer/discussion-prompt-composer/discussion-prompt-composer.component.html
+++ b/src/app/tasks/task-comment-composer/discussion-prompt-composer/discussion-prompt-composer.component.html
@@ -1,8 +1,7 @@
 <h4>Step 1. Record and add up to 3 prompts.</h4>
 <div [hidden]="!canRecord || isSending" fxLayout="row" fxLayoutAlign="space-around center">
   <div>
-    <button mat-icon-button aria-label="Record icon button" [disabled]="!canAddRecording" id='btnRecordPrompt'
-      (click)="recordingToggle()" mat-icon-button aria-label="Record audio prompt">
+    <button mat-icon-button aria-label="Record icon button" [disabled]="!canAddRecording" id='btnRecordPrompt' (click)="recordingToggle()">
       <mat-icon [hidden]="!isRecording">stop_rounded</mat-icon>
       <mat-icon [hidden]="isRecording">fiber_manual_record</mat-icon>
     </button>


### PR DESCRIPTION
# Description

Resolved issue with intelligent discussion not loading due to error.

error_handler.ts:45 ERROR Error: NG0300: Multiple components match node with tagname button: _MatButton and _MatIconButton. Find more at https://angular.io/errors/NG0300
    at throwMultipleComponentError (errors.ts:52:9)
    at findDirectiveDefMatches (shared.ts:1070:15)
    at resolveDirectives (shared.ts:831:25)
    at elementStartFirstCreatePass (element.ts:43:3)
    at Module.ɵɵelementStart (element.ts:90:7)
    at DiscussionComposerDialog_Template (discussion-prompt-composer-dialog.html:1:1)
    at executeTemplate (shared.ts:261:5)
    at renderView (render.ts:86:7)
    at renderComponent (render.ts:30:3)
    at renderChildComponents (render.ts:136:5)

Fixes # intelligent discussion 
The problem was the use of both mat-button and mat-icon-button directives on the same button element

![image](https://github.com/doubtfire-lms/doubtfire-web/assets/87599686/ce1a91d6-00a7-435c-b735-dff10b008b7d)

## Type of change

_Please delete options that are not relevant._

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested in local development environment minor HTML change.

## Testing Checklist:

- [x] Tested in latest Chrome

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] My changes generate no new warnings
- [x ] I have requested a review from @macite and @jakerenzella on the Pull Request
