### PR TITLE
refactor: replace fxLayout with tailwind equivalent - edit-profile-form component

### DIFF
--- a/src/app/common/edit-profile-form/edit-profile-form.component.html
+++ b/src/app/common/edit-profile-form/edit-profile-form.component.html
@@ -2,7 +2,7 @@
   <div class="main-container flex flex-row justify-start items-center" style="width: 100%;">
     <div class="main flex flex-col items-start place-content-start" style="width: 100%">
       <!-- avatar -->
-      <div class="flex flex-row place-content-center place-content-between items-center" style="margin-bottom: 25px">
+      <div class="flex flex-row place-content-between items-center" style="margin-bottom: 25px">
         <a style="margin-left: 20px" href="https://gravatar.com/connect/?source=_signup/" target="_blank">
           <user-icon [size]="80" [user]="user" style="margin-right: 25px"></user-icon
         ></a>
@@ -13,7 +13,7 @@
         </div>
       </div>
 
-      <div class="flex flex-row w-full h-full">
+      <div class="flex flex-row w-full min-w-full h-full min-h-full">
         <mat-form-field class="grow shrink basis-full self-start" style="max-width: 48%" appearance="outline">
           <mat-label>First Name</mat-label>
           <input matInput class="outline-none" [(ngModel)]="user.firstName" name="first" required />
@@ -39,14 +39,13 @@
           </mat-select>
         </mat-form-field> -->
         <div class="grow shrink basis-full" style="max-width: 3%"></div>
-        <mat-form-field class="w-full min-w-full h-full" appearance="outline">
-        <!-- <mat-form-field fxFlexFill appearance="outline"> -->
+        <mat-form-field class="min-w-full h-full" appearance="outline">
           <mat-label>Preferred Name</mat-label>
           <input matInput [(ngModel)]="user.nickname" name="preferred_name" />
         </mat-form-field>
       </div>
 
-      <mat-form-field fxFlexFill appearance="outline" [hidden]="!customPronouns">
+      <mat-form-field class="w-full h-full" appearance="outline" [hidden]="!customPronouns">
         <mat-label>Custom Pronouns</mat-label>
         <input
           matInput
@@ -59,19 +58,19 @@
       </mat-form-field>
 
       @if (user.systemRole === 'Student') {
-      <mat-form-field appearance="outline" fxFlexFill>
+      <mat-form-field class="w-full h-full" appearance="outline">
         <mat-label>Student ID</mat-label>
         <input matInput [(ngModel)]="user.studentId" name="student_id" required />
       </mat-form-field>
       }
 
-      <mat-form-field appearance="outline" fxFlexFill>
+      <mat-form-field class="w-full h-full" appearance="outline">
         <mat-label>Email</mat-label>
         <input type="email" matInput [(ngModel)]="user.email" name="email" required />
       </mat-form-field>
 
       @if (canSeeSystemRole) {
-      <mat-form-field fxFlexFill appearance="outline">
+        <mat-form-field class="w-full h-full" appearance="outline">
         <mat-label>System Role</mat-label>
         <mat-select [(ngModel)]="user.systemRole" name="systemRole" [disabled]="!canEditSystemRole">
           <mat-option value="Admin">Administrator</mat-option>
@@ -82,39 +81,39 @@
       </mat-form-field>
       }
 
-      <section fxLayout="column" fxFlexFill fxLayoutAlign="center start">
+      <section class="flex flex-col w-full h-full items-start place-content-center">
         <mat-checkbox class="" color="primary" [(ngModel)]="user.receiveFeedbackNotifications" name="feedback_n"
           >Receive notifications for new messages</mat-checkbox
         >
-        <div fxFlex></div>
+        <div class="flex-1"></div>
         <mat-checkbox color="primary" [(ngModel)]="user.receivePortfolioNotifications" name="portfolio_n"
           >Receive notifications when your portfolio is ready</mat-checkbox
         >
-        <div fxFlex></div>
-        <mat-checkbox fxFlex color="primary" [(ngModel)]="user.receiveTaskNotifications" name="task_n"
+        <div class="flex-1"></div>
+        <mat-checkbox class="flex-1" color="primary" [(ngModel)]="user.receiveTaskNotifications" name="task_n"
           >Receive notifications when new tasks are available</mat-checkbox
         >
       </section>
-      <section fxLayout="row" fxFlexFill fxLayoutAlign="start center">
+      <section class="flex flex-row w-full h-full items-center place-content-start place-content-center">
         <mat-checkbox color="primary" [(ngModel)]="user.optInToResearch" name="optin"
           >Send anonymous research statistics
         </mat-checkbox>
       </section>
 
-      <div fxLayout="row" fxFlexFill style="padding-top: 12px">
-        <button [hidden]="mode === 'edit'" fxFlexAlign="start" type="button" mat-stroked-button (click)="signOut()">
+      <div class="flex flex-row w-full h-full" style="padding-top: 12px">
+        <button class="self-start" [hidden]="mode === 'edit'" type="button" mat-stroked-button (click)="signOut()">
           Sign Out
         </button>
-        <div fxFlex></div>
+        <div class="flex-1"></div>
         @if (mode === 'create') {
-        <button [disabled]="form.invalid" fxFlexAlign="end" type="submit" mat-flat-button color="primary">
+        <button class="self-end" [disabled]="form.invalid" type="submit" mat-flat-button color="primary">
           Confirm Account
         </button>
         } @if (mode === 'edit') {
         <button
+          class="self-end"
           type="button"
           [disabled]="form.invalid"
-          fxFlexAlign="end"
           (click)="submit()"
           mat-flat-button
           color="primary"

--- a/src/app/common/edit-profile-form/edit-profile-form.component.html
+++ b/src/app/common/edit-profile-form/edit-profile-form.component.html
@@ -1,8 +1,8 @@
-<form #form="ngForm" (ngSubmit)="submit()" fxLayout="column" fxLayoutAlign="center start" class="p-16">
-  <div class="main-container" style="width: 100%" fxLayout="row" fxLayoutAlign="center start">
-    <div class="main" style="width: 100%" fxLayout="column" fxLayoutAlign="start start">
+<form #form="ngForm" (ngSubmit)="submit()" class="p-16 flex flex-col justify-start items-center">
+  <div class="main-container flex flex-row justify-start items-center" style="width: 100%;">
+    <div class="main flex flex-col items-start place-content-start" style="width: 100%">
       <!-- avatar -->
-      <div fxLayout="row" fxLayoutAlign="space-between center" style="margin-bottom: 25px">
+      <div class="flex flex-row place-content-center place-content-between items-center" style="margin-bottom: 25px">
         <a style="margin-left: 20px" href="https://gravatar.com/connect/?source=_signup/" target="_blank">
           <user-icon [size]="80" [user]="user" style="margin-right: 25px"></user-icon
         ></a>

--- a/src/app/common/edit-profile-form/edit-profile-form.component.html
+++ b/src/app/common/edit-profile-form/edit-profile-form.component.html
@@ -7,27 +7,27 @@
           <user-icon [size]="80" [user]="user" style="margin-right: 25px"></user-icon
         ></a>
 
-        <div fxLayout="column" fxLayoutAlign="space-around start">
+        <div class="flex flex-col place-content-start place-content-around items-start">
           <h1>{{ initialFirstName }}</h1>
           Set up your {{ externalName.value }} profile
         </div>
       </div>
 
-      <div fxLayout="row" fxFlexFill>
-        <mat-form-field fxFlex="48" appearance="outline" fxFlexAlign="start">
+      <div class="flex flex-row w-full h-full">
+        <mat-form-field class="grow shrink basis-full self-start" style="max-width: 48%" appearance="outline">
           <mat-label>First Name</mat-label>
           <input matInput class="outline-none" [(ngModel)]="user.firstName" name="first" required />
         </mat-form-field>
 
-        <div fxFlex></div>
+        <div class="flex-1"></div>
 
-        <mat-form-field fxFlex="48" appearance="outline" fxFlexAlign="end">
+          <mat-form-field class="grow shrink basis-full self-end" style="max-width: 48%" appearance="outline">
           <mat-label>Second Name</mat-label>
           <input matInput [(ngModel)]="user.lastName" name="last" required />
         </mat-form-field>
       </div>
 
-      <div fxLayout="row" fxFlexFill>
+      <div class="flex flex-row w-full h-full">
         <!-- <mat-form-field fxFlex="25" fxFlexAlign="start" appearance="outline">
           <mat-label>Pronouns</mat-label>
           <mat-select [(ngModel)]="formPronouns.pronouns" name="pronouns">
@@ -37,9 +37,10 @@
             <mat-option value="They/Them">They/Them</mat-option>
             <mat-option value="__customPronouns">Custom</mat-option>
           </mat-select>
-        </mat-form-field>
-        <div fxFlex="3"></div> -->
-        <mat-form-field fxFlexFill appearance="outline">
+        </mat-form-field> -->
+        <div class="grow shrink basis-full" style="max-width: 3%"></div>
+        <mat-form-field class="w-full min-w-full h-full" appearance="outline">
+        <!-- <mat-form-field fxFlexFill appearance="outline"> -->
           <mat-label>Preferred Name</mat-label>
           <input matInput [(ngModel)]="user.nickname" name="preferred_name" />
         </mat-form-field>

--- a/src/app/common/edit-profile-form/edit-profile-form.component.html
+++ b/src/app/common/edit-profile-form/edit-profile-form.component.html
@@ -1,27 +1,39 @@
 <form #form="ngForm" (ngSubmit)="submit()" class="p-16 flex flex-col justify-start items-center">
-  <div class="main-container flex flex-row justify-start items-center" style="width: 100%;">
+  <div class="main-container flex flex-row justify-start items-center" style="width: 100%">
     <div class="main flex flex-col items-start place-content-start" style="width: 100%">
       <!-- avatar -->
       <div class="flex flex-row place-content-between items-center" style="margin-bottom: 25px">
-        <a style="margin-left: 20px" href="https://gravatar.com/connect/?source=_signup/" target="_blank">
+        <a
+          style="margin-left: 20px"
+          href="https://gravatar.com/connect/?source=_signup/"
+          target="_blank"
+        >
           <user-icon [size]="80" [user]="user" style="margin-right: 25px"></user-icon
         ></a>
 
-        <div class="flex flex-col place-content-start place-content-around items-start">
+        <div class="flex flex-col place-content-around items-start">
           <h1>{{ initialFirstName }}</h1>
           Set up your {{ externalName.value }} profile
         </div>
       </div>
 
       <div class="flex flex-row w-full min-w-full h-full min-h-full">
-        <mat-form-field class="grow shrink basis-full self-start" style="max-width: 48%" appearance="outline">
+        <mat-form-field
+          class="grow shrink basis-full self-start"
+          style="max-width: 48%"
+          appearance="outline"
+        >
           <mat-label>First Name</mat-label>
           <input matInput class="outline-none" [(ngModel)]="user.firstName" name="first" required />
         </mat-form-field>
 
         <div class="flex-1"></div>
 
-          <mat-form-field class="grow shrink basis-full self-end" style="max-width: 48%" appearance="outline">
+        <mat-form-field
+          class="grow shrink basis-full self-end"
+          style="max-width: 48%"
+          appearance="outline"
+        >
           <mat-label>Second Name</mat-label>
           <input matInput [(ngModel)]="user.lastName" name="last" required />
         </mat-form-field>
@@ -58,10 +70,10 @@
       </mat-form-field>
 
       @if (user.systemRole === 'Student') {
-      <mat-form-field class="w-full h-full" appearance="outline">
-        <mat-label>Student ID</mat-label>
-        <input matInput [(ngModel)]="user.studentId" name="student_id" required />
-      </mat-form-field>
+        <mat-form-field class="w-full h-full" appearance="outline">
+          <mat-label>Student ID</mat-label>
+          <input matInput [(ngModel)]="user.studentId" name="student_id" required />
+        </mat-form-field>
       }
 
       <mat-form-field class="w-full h-full" appearance="outline">
@@ -71,55 +83,82 @@
 
       @if (canSeeSystemRole) {
         <mat-form-field class="w-full h-full" appearance="outline">
-        <mat-label>System Role</mat-label>
-        <mat-select [(ngModel)]="user.systemRole" name="systemRole" [disabled]="!canEditSystemRole">
-          <mat-option value="Admin">Administrator</mat-option>
-          <mat-option value="Convenor">Convenor</mat-option>
-          <mat-option value="Tutor">Tutor</mat-option>
-          <mat-option value="Student">Student</mat-option>
-        </mat-select>
-      </mat-form-field>
+          <mat-label>System Role</mat-label>
+          <mat-select
+            [(ngModel)]="user.systemRole"
+            name="systemRole"
+            [disabled]="!canEditSystemRole"
+          >
+            <mat-option value="Admin">Administrator</mat-option>
+            <mat-option value="Convenor">Convenor</mat-option>
+            <mat-option value="Tutor">Tutor</mat-option>
+            <mat-option value="Student">Student</mat-option>
+          </mat-select>
+        </mat-form-field>
       }
 
       <section class="flex flex-col w-full h-full items-start place-content-center">
-        <mat-checkbox class="" color="primary" [(ngModel)]="user.receiveFeedbackNotifications" name="feedback_n"
+        <mat-checkbox
+          color="primary"
+          [(ngModel)]="user.receiveFeedbackNotifications"
+          name="feedback_n"
           >Receive notifications for new messages</mat-checkbox
         >
         <div class="flex-1"></div>
-        <mat-checkbox color="primary" [(ngModel)]="user.receivePortfolioNotifications" name="portfolio_n"
+        <mat-checkbox
+          color="primary"
+          [(ngModel)]="user.receivePortfolioNotifications"
+          name="portfolio_n"
           >Receive notifications when your portfolio is ready</mat-checkbox
         >
         <div class="flex-1"></div>
-        <mat-checkbox class="flex-1" color="primary" [(ngModel)]="user.receiveTaskNotifications" name="task_n"
+        <mat-checkbox
+          class="flex-1"
+          color="primary"
+          [(ngModel)]="user.receiveTaskNotifications"
+          name="task_n"
           >Receive notifications when new tasks are available</mat-checkbox
         >
       </section>
-      <section class="flex flex-row w-full h-full items-center place-content-start place-content-center">
+      <section class="flex flex-row w-full h-full items-center place-content-start">
         <mat-checkbox color="primary" [(ngModel)]="user.optInToResearch" name="optin"
           >Send anonymous research statistics
         </mat-checkbox>
       </section>
 
       <div class="flex flex-row w-full h-full" style="padding-top: 12px">
-        <button class="self-start" [hidden]="mode === 'edit'" type="button" mat-stroked-button (click)="signOut()">
+        <button
+          class="self-start"
+          [hidden]="mode === 'edit'"
+          type="button"
+          mat-stroked-button
+          (click)="signOut()"
+        >
           Sign Out
         </button>
         <div class="flex-1"></div>
         @if (mode === 'create') {
-        <button class="self-end" [disabled]="form.invalid" type="submit" mat-flat-button color="primary">
-          Confirm Account
-        </button>
-        } @if (mode === 'edit') {
-        <button
-          class="self-end"
-          type="button"
-          [disabled]="form.invalid"
-          (click)="submit()"
-          mat-flat-button
-          color="primary"
-        >
-          Save Profile
-        </button>
+          <button
+            class="self-end"
+            [disabled]="form.invalid"
+            type="submit"
+            mat-flat-button
+            color="primary"
+          >
+            Confirm Account
+          </button>
+        }
+        @if (mode === 'edit') {
+          <button
+            class="self-end"
+            type="button"
+            [disabled]="form.invalid"
+            (click)="submit()"
+            mat-flat-button
+            color="primary"
+          >
+            Save Profile
+          </button>
         }
       </div>
     </div>

--- a/src/app/common/edit-profile-form/edit-profile-form.component.html
+++ b/src/app/common/edit-profile-form/edit-profile-form.component.html
@@ -50,7 +50,7 @@
             <mat-option value="__customPronouns">Custom</mat-option>
           </mat-select>
         </mat-form-field> -->
-        <div class="grow shrink basis-full" style="max-width: 3%"></div>
+        <!-- <div fxFlex="3"></div> -->
         <mat-form-field class="min-w-full h-full" appearance="outline">
           <mat-label>Preferred Name</mat-label>
           <input matInput [(ngModel)]="user.nickname" name="preferred_name" />


### PR DESCRIPTION
# Description

Replaced depreciated fxLayout library implemented with equivalent Tailwindcss for edit-profile-form component. 

## Type of change

# How Has This Been Tested?

before:
![edit-profile-form-new-user-no-changes](https://github.com/thoth-tech/doubtfire-web/assets/128195951/506c96f5-1fc9-41bd-9f4f-e67dc5fcf84b)
![edit-profil-form-component-no-changes-80](https://github.com/thoth-tech/doubtfire-web/assets/128195951/310fd2c4-7b9a-4dff-8966-d82beef5dc82)


after:
![edit-profile-more-new-user-tailwind](https://github.com/thoth-tech/doubtfire-web/assets/128195951/6e8e6547-7412-406e-924f-570341047f67)
![edit-profile-form-component-tailwind](https://github.com/thoth-tech/doubtfire-web/assets/128195951/6e27dbad-bab2-47f9-800b-7f5bafbb171a)


## Testing Checklist:

- [x] Tested in latest Chrome
- [x] Tested in latest Safari
- [x] Tested in latest Firefox

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

**This was peer reviewed by Minh Tho Duong and then Daniel Maddern**