### PR TITLE
refactor: replace fxLayout with tailwind equivalent -task-dashboard

### DIFF
--- a/src/app/projects/states/dashboard/directives/task-dashboard/task-dashboard.component.html
+++ b/src/app/projects/states/dashboard/directives/task-dashboard/task-dashboard.component.html
@@ -20,7 +20,7 @@
 
   <!-- Render if no PDF URL is available for the current view -->
   <ng-template #noPdfUrl>
-    <div fxFlexFill fxLayout="column" fxLayoutAlign="center center">
+    <div class="flex flex-col w-full h-full justify-center items-center">
       <mat-icon>subtitles_off</mat-icon>
     </div>
   </ng-template>


### PR DESCRIPTION
# Description

Replace the deprecated fx-Layout with equivalent Tailwind for task dashboard component.

# How Has This Been Tested?

- Log in to a student account
- Select an enrolled unit
- Select a specific task
- The task dashboard component appears in the center section
- A file named task-dashboard.tpl.html defines different views in the section, including View Task Details, View Submission, View Task Sheet, Download Submission PDF, Download Submission Files, and View Submission History.
- If the view contents PDF format, there is a link with resize feature
- If the view does not content PDF format, the elements are displayed in column, with full width and height, and center align

## Before:

<img width="1440" alt="SIT764 tailwind-task-dashboard (before)" src="https://github.com/doubtfire-lms/doubtfire-web/assets/140044678/fa351971-a7dd-4419-ac86-156cd484932b">

## After:

<img width="1440" alt="SIT764 tailwind-task-dashboard (after)" src="https://github.com/doubtfire-lms/doubtfire-web/assets/140044678/e452022f-d313-4482-81cf-1d359f2a8450">

## Testing Checklist:

- [x] Tested in latest Chrome
- [x] Tested in latest Safari
- [x] Tested in latest Firefox

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings