### PR TITLE
fix: remove the incorrect option from for scrollIntoView()

### DIFF
--- a/src/app/projects/states/dashboard/directives/student-task-list/student-task-list.coffee
+++ b/src/app/projects/states/dashboard/directives/student-task-list/student-task-list.coffee
@@ -48,7 +48,7 @@ angular.module('doubtfire.projects.states.dashboard.directives.student-task-list
       return unless taskEl?
       funcName = if taskEl.scrollIntoViewIfNeeded? then 'scrollIntoViewIfNeeded' else if taskEl.scrollIntoView? then 'scrollIntoView'
       return unless funcName?
-      taskEl[funcName]({behavior: 'smooth', block: 'top'})
+      taskEl[funcName]({behavior: 'smooth'})
     $timeout ->
       scrollToTaskInList($scope.taskData.selectedTask) if $scope.taskData.selectedTask?
     $scope.isSelectedTask = (task) ->

--- a/src/app/units/states/tasks/inbox/directives/staff-task-list/staff-task-list.component.ts
+++ b/src/app/units/states/tasks/inbox/directives/staff-task-list/staff-task-list.component.ts
@@ -346,7 +346,7 @@ export class StaffTaskListComponent implements OnInit, OnChanges {
     if (!funcName) {
       return;
     }
-    taskEl[funcName]({ behavior: 'smooth', block: 'top' });
+    taskEl[funcName]({ behavior: 'smooth' });
   }
 
   isSelectedTask(task: Task) {


### PR DESCRIPTION
# Description

There are a lot of errors in the javascript console in Firefox when clicking on the tasks in the task list:
```
Element.scrollIntoView: 'top' (value of 'block' member of ScrollIntoViewOptions) is not a valid value for enumeration ScrollLogicalPosition.
```

`top` is not a valid option for `scrollIntoView()`, `start` is the default so there is no need to define it explicitly.

![image](https://github.com/doubtfire-lms/doubtfire-web/assets/90136978/deefe042-4e36-472c-b764-d2e56bdcf8e8)

https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

The aforementioned errors are no longer present in the javascript console on Firefox when switching tasks.

## Testing Checklist:

- [x] Tested in latest Chrome
- [ ] Tested in latest Safari
- [x] Tested in latest Firefox

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings