### PR TITLE
feat: accept promela files

### DIFF
--- a/src/app/common/file-uploader/file-uploader.coffee
+++ b/src/app/common/file-uploader/file-uploader.coffee
@@ -68,7 +68,7 @@ angular.module('doubtfire.common.file-uploader', ["ngFileUpload"])
         extensions: ['pas', 'cpp', 'c', 'cs', 'csv', 'h', 'hpp', 'java', 'py', 'js', 'html', 'coffee', 'rb', 'css',
                     'scss', 'yaml', 'yml', 'xml', 'json', 'ts', 'r', 'rmd', 'rnw', 'rhtml', 'rpres', 'tex',
                     'vb', 'sql', 'txt', 'md', 'jack', 'hack', 'asm', 'hdl', 'tst', 'out', 'cmp', 'vm', 'sh', 'bat',
-                    'dat', 'ipynb']
+                    'dat', 'ipynb', 'pml']
         icon:       'fa-file-code-o'
         name:       'code'
       image:


### PR DESCRIPTION
Super trivial change, add the promela file extension to the list of accepted file extensions. Tested with the backend change and everything works fine.

Screenshot:
![image](https://github.com/thoth-tech/doubtfire-web/assets/90136978/a8e185c4-9c31-4a89-a469-30c624d050d5)
