### PR TITLE
Extension modal refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ tmp.scss
 a.env
 dist/
 .angulardoc.json
+.nx
+.idea

--- a/src/app/common/modals/extension-modal/extension-modal.component.html
+++ b/src/app/common/modals/extension-modal/extension-modal.component.html
@@ -5,25 +5,30 @@
     request shortly.
   </p>
 
-  <mat-form-field style="width: 100%">
+  <mat-form-field style="width: 100%" appearance="outline">
     <mat-label>Reason</mat-label>
-    <input
+    <textarea
       type="text"
       matInput
       [formControl]="extensionData.controls.extensionReason"
       [errorStateMatcher]="matcher"
       placeholder="Reason"
-    />
-    <mat-hint align="end">{{ extensionData.controls.extensionReason.value.length }} / 256</mat-hint>
+    ></textarea>
+    <mat-hint align="end"
+      >{{ extensionData.controls.extensionReason.value.length }} / {{ reasonMaxLength }}</mat-hint
+    >
     @if (extensionData.controls.extensionReason.hasError('required')) {
       <mat-error>You must enter a reason</mat-error>
     }
     @if (extensionData.controls.extensionReason.hasError('minlength')) {
       <mat-error>The reason must be at least {{ reasonMinLength }} characters long</mat-error>
     }
+    @if (extensionData.controls.extensionReason.hasError('maxlength')) {
+      <mat-error>The reason must be less than {{ reasonMaxLength }} characters long</mat-error>
+    }
   </mat-form-field>
 
-  <mat-form-field>
+  <mat-form-field appearance="outline">
     <mat-label>Choose a date</mat-label>
     <input
       matInput

--- a/src/app/common/modals/extension-modal/extension-modal.component.html
+++ b/src/app/common/modals/extension-modal/extension-modal.component.html
@@ -1,25 +1,41 @@
 <h3 mat-dialog-title>Extension request</h3>
-<div mat-dialog-content>
-  <p>
-    Please explain why you require an extension for this task, <br />
-    The teaching team will assess the request shortly.
+<div mat-dialog-content [formGroup]="extensionData">
+  <p style="width: 100%">
+    Please explain why you require an extension for this task, the teaching team will assess the
+    request shortly.
   </p>
 
   <mat-form-field style="width: 100%">
-    <input required matInput maxlength="256" placeholder="Reason" [(ngModel)]="reason" />
-    <mat-hint align="end">{{ reason.length }} / 256</mat-hint>
+    <mat-label>Reason</mat-label>
+    <input
+      type="text"
+      matInput
+      [formControl]="extensionData.controls.extensionReason"
+      [errorStateMatcher]="matcher"
+      placeholder="Reason"
+    />
+    <mat-hint align="end">{{ extensionData.controls.extensionReason.value.length }} / 256</mat-hint>
+    @if (extensionData.controls.extensionReason.hasError('required')) {
+      <mat-error>You must enter a reason</mat-error>
+    }
+    @if (extensionData.controls.extensionReason.hasError('minlength')) {
+      <mat-error>The reason must be at least {{ reasonMinLength }} characters long</mat-error>
+    }
   </mat-form-field>
 
-  <p>Requesting extension to: {{ newDueDate }}</p>
-  <mat-slider
-    id="requestWeekSlider"
-    thumbLabel
-    [min]="minWeeksCanExtend"
-    [max]="maxWeeksCanExtend"
-    step="1"
-    [(ngModel)]="weeksRequested"
-    ><input matSliderThumb /><input matSliderThumb />
-  </mat-slider>
+  <mat-form-field>
+    <mat-label>Choose a date</mat-label>
+    <input
+      matInput
+      [min]="minDate"
+      [max]="maxDate"
+      [matDatepicker]="extensionDatePicker"
+      (dateInput)="addEvent('input', $event)"
+      placeholder="Choose a date"
+    />
+    <mat-datepicker-toggle matSuffix [for]="extensionDatePicker"></mat-datepicker-toggle>
+    <mat-datepicker #extensionDatePicker></mat-datepicker>
+  </mat-form-field>
 </div>
 
 <div mat-dialog-actions style="float: right">
@@ -30,9 +46,15 @@
     mat-stroked-button
     color="primary"
     mat-button
-    [disabled]="weeksRequested === 0 || reason.length < 15"
+    [disabled]="!extensionData.valid"
     (click)="submitApplication()"
   >
-    Request {{ weeksRequested }} {{ weeksRequested === 1 ? 'week' : 'weeks' }}
+    Request extension to
+    {{
+      extensionDate.toLocaleDateString(currentLocale, {
+        month: 'long',
+        day: 'numeric'
+      })
+    }}
   </button>
 </div>

--- a/src/app/common/modals/extension-modal/extension-modal.component.html
+++ b/src/app/common/modals/extension-modal/extension-modal.component.html
@@ -1,6 +1,6 @@
 <h3 mat-dialog-title>Extension request</h3>
 <div mat-dialog-content [formGroup]="extensionData">
-  <p style="width: 100%">
+  <p class="w-full">
     Please explain why you require an extension for this task, the teaching team will assess the
     request shortly.
   </p>

--- a/src/app/common/modals/extension-modal/extension-modal.component.scss
+++ b/src/app/common/modals/extension-modal/extension-modal.component.scss
@@ -1,5 +1,0 @@
-#requestWeekSlider {
-  width: 100%;
-}
-
-

--- a/src/app/common/modals/extension-modal/extension-modal.component.ts
+++ b/src/app/common/modals/extension-modal/extension-modal.component.ts
@@ -1,51 +1,66 @@
-import { Component, OnInit, Inject, LOCALE_ID } from '@angular/core';
-import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
-import { alertService } from 'src/app/ajs-upgraded-providers';
-import { ExtensionComment } from 'src/app/api/models/task-comment/extension-comment';
-import { TaskComment, TaskCommentService, Task } from 'src/app/api/models/doubtfire-model';
-import { AppInjector } from 'src/app/app-injector';
-import { formatDate } from '@angular/common';
+import {Component, Inject, LOCALE_ID} from '@angular/core';
+import {MatDialogRef, MAT_DIALOG_DATA} from '@angular/material/dialog';
+import {alertService} from 'src/app/ajs-upgraded-providers';
+import {TaskComment, TaskCommentService, Task} from 'src/app/api/models/doubtfire-model';
+import {AppInjector} from 'src/app/app-injector';
+import {FormControl, Validators, FormGroup, FormGroupDirective, NgForm} from '@angular/forms';
+import {MatDatepickerInputEvent} from '@angular/material/datepicker';
+import {differenceInWeeks, differenceInDays, isAfter, addDays} from 'date-fns';
+import {ErrorStateMatcher} from '@angular/material/core';
+
+/** Error when invalid control is dirty, touched, or submitted. */
+export class ReasonErrorStateMatcher implements ErrorStateMatcher {
+  isErrorState(control: FormControl | null, form: FormGroupDirective | NgForm | null): boolean {
+    const isSubmitted = form && form.submitted;
+    return !!(control && control.invalid && (control.dirty || control.touched || isSubmitted));
+  }
+}
 
 @Component({
   selector: 'extension-modal',
   templateUrl: './extension-modal.component.html',
-  styleUrls: ['./extension-modal.component.scss'],
 })
-export class ExtensionModalComponent implements OnInit {
-  weeksRequested: number;
-  reason: string = '';
+export class ExtensionModalComponent {
+  protected reasonMinLength: number = 15;
   constructor(
     public dialogRef: MatDialogRef<ExtensionModalComponent>,
-    @Inject(MAT_DIALOG_DATA) public data: {task: Task, afterApplication?: () => void},
-    @Inject(alertService) private alerts: any
+    @Inject(MAT_DIALOG_DATA) public data: {task: Task; afterApplication?: () => void},
+    @Inject(alertService) private alerts: any,
   ) {}
 
-  ngOnInit() {
-    this.weeksRequested = this.minWeeksCanExtend + 1;
-    if (this.weeksRequested > this.maxWeeksCanExtend) {
-      this.weeksRequested = this.maxWeeksCanExtend;
+  matcher = new ReasonErrorStateMatcher();
+  currentLocale = AppInjector.get(LOCALE_ID);
+  extensionData = new FormGroup({
+    extensionReason: new FormControl('', [
+      Validators.required,
+      Validators.minLength(this.reasonMinLength),
+    ]),
+  });
+
+  get extensionDuration(): number {
+    // calculating the number of weeks between now and the requested date, rounding up
+    const days = differenceInDays(this.extensionDate, this.data.task.localDueDate());
+    let weeks = differenceInWeeks(this.extensionDate, this.data.task.localDueDate());
+    if (days % 7 > 0 || weeks == 0) {
+      // round week count up if there are less than a week left or requested range is not in weeks
+      weeks++;
     }
+    return weeks;
   }
 
-  get newDueDate() {
-    const calculatedDueDate = new Date(this.data.task.localDueDate().getTime() + this.weeksRequested * 1000 * 60 * 60 * 24 * 7 );
-    const taskDeadlineDate: Date = this.data.task.definition.localDeadlineDate();
-
-    const locale: string = AppInjector.get(LOCALE_ID);
-
-    if (calculatedDueDate > taskDeadlineDate) {
-      return formatDate(taskDeadlineDate, 'dd MMMM', locale);
-    } else {
-      return formatDate(calculatedDueDate, 'dd MMMM', locale);
-    }
-  }
-
-  get maxWeeksCanExtend() {
-    return this.data.task.maxWeeksCanExtend();
-  }
-
-  get minWeeksCanExtend() {
-    return this.data.task.minWeeksCanExtend();
+  // minimum date is due date if before target date, current date if after target date
+  minDate = new Date(
+    addDays(
+      isAfter(Date.now(), this.data.task.localDueDate())
+        ? new Date()
+        : this.data.task.localDueDate(),
+      1,
+    ),
+  );
+  maxDate = this.data.task.localDeadlineDate(); // deadline, hard deadline
+  extensionDate = new Date(this.minDate);
+  addEvent(type: string, event: MatDatepickerInputEvent<Date>) {
+    this.extensionDate = new Date(event.value);
   }
 
   private scrollCommentsDown(): void {
@@ -58,19 +73,25 @@ export class ExtensionModalComponent implements OnInit {
 
   submitApplication() {
     const tcs: TaskCommentService = AppInjector.get(TaskCommentService);
+    tcs
+      .requestExtension(
+        this.extensionData.controls.extensionReason.value,
+        this.extensionDuration,
+        this.data.task,
+      )
+      .subscribe({
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        next: ((tc: TaskComment) => {
+          this.alerts.add('success', 'Extension requested.', 2000);
+          this.scrollCommentsDown();
+          if (typeof this.data.afterApplication === 'function') {
+            this.data.afterApplication();
+          }
+        }).bind(this),
 
-    tcs.requestExtension(this.reason, this.weeksRequested, this.data.task).subscribe({
-      next: ((tc: TaskComment) => {
-        this.alerts.add('success', 'Extension requested.', 2000);
-        this.scrollCommentsDown();
-        if (typeof this.data.afterApplication === 'function') {
-          this.data.afterApplication();
-        }
-      }).bind(this),
-
-      error: ((response: any) => {
-        this.alerts.add('danger', 'Error requesting extension ' + response);
-      }).bind(this),
-    });
+        error: ((response: never) => {
+          this.alerts.add('danger', 'Error requesting extension ' + response);
+        }).bind(this),
+      });
   }
 }

--- a/src/app/common/modals/extension-modal/extension-modal.component.ts
+++ b/src/app/common/modals/extension-modal/extension-modal.component.ts
@@ -22,6 +22,7 @@ export class ReasonErrorStateMatcher implements ErrorStateMatcher {
 })
 export class ExtensionModalComponent {
   protected reasonMinLength: number = 15;
+  protected reasonMaxLength: number = 256;
   constructor(
     public dialogRef: MatDialogRef<ExtensionModalComponent>,
     @Inject(MAT_DIALOG_DATA) public data: {task: Task; afterApplication?: () => void},
@@ -34,6 +35,7 @@ export class ExtensionModalComponent {
     extensionReason: new FormControl('', [
       Validators.required,
       Validators.minLength(this.reasonMinLength),
+      Validators.maxLength(this.reasonMaxLength),
     ]),
   });
 

--- a/src/app/common/modals/extension-modal/extension-modal.service.ts
+++ b/src/app/common/modals/extension-modal/extension-modal.service.ts
@@ -1,7 +1,7 @@
-import { Injectable } from '@angular/core';
-import { Task } from 'src/app/api/models/task';
-import { MatDialogRef, MAT_DIALOG_DATA, MatDialog } from '@angular/material/dialog';
-import { ExtensionModalComponent } from './extension-modal.component';
+import {Injectable} from '@angular/core';
+import {Task} from 'src/app/api/models/task';
+import {MatDialogRef, MatDialog} from '@angular/material/dialog';
+import {ExtensionModalComponent} from './extension-modal.component';
 
 @Injectable({
   providedIn: 'root',

--- a/src/app/tasks/modals/upload-submission-modal/upload-submission-modal.tpl.html
+++ b/src/app/tasks/modals/upload-submission-modal/upload-submission-modal.tpl.html
@@ -85,11 +85,11 @@
       <div class="card card-default">
         <div class="card-heading">
           <h4>
-            Learning Outcome Alignment
+            Learning Outcome Alignment <b style='color:red;'>*</b>
           </h4>
           <p>
             Please rate the relevancy of this task to the specific learning outcome.
-            You <strong>must</strong> relate this task to at least one outcome.
+            You must relate this task to at least one outcome and provide a rationale to proceed.
           </p>
           <p class="text-muted">
             If you think the task is not related to a specific outcome, click the highest filled circle to remove its relevancy.
@@ -129,7 +129,7 @@
         </div><!--/alignment-list-group-->
         <div class="card-footer">
           <p>
-            Jusitfy your relevancy alignments with a comment to explain your choices.
+            Justify your relevancy alignments with a comment to explain your choices. <b style='color:red;'>*</b>
           </p>
           <textarea ng-model="alignmentsRationale" class="form-control input-lg" rows="3" placeholder="My rationale is...">
           </textarea>

--- a/src/app/tasks/modals/upload-submission-modal/upload-submission-modal.tpl.html
+++ b/src/app/tasks/modals/upload-submission-modal/upload-submission-modal.tpl.html
@@ -85,7 +85,7 @@
       <div class="card card-default">
         <div class="card-heading">
           <h4>
-            Learning Outcome Alignment <b style='color:red;'>*</b>
+            Learning Outcome Alignment <b class="text-red-500">*</b>
           </h4>
           <p>
             Please rate the relevancy of this task to the specific learning outcome.
@@ -129,7 +129,7 @@
         </div><!--/alignment-list-group-->
         <div class="card-footer">
           <p>
-            Justify your relevancy alignments with a comment to explain your choices. <b style='color:red;'>*</b>
+            Justify your relevancy alignments with a comment to explain your choices. <b class="text-red-500">*</b>
           </p>
           <textarea ng-model="alignmentsRationale" class="form-control input-lg" rows="3" placeholder="My rationale is...">
           </textarea>


### PR DESCRIPTION
## List of changes

- Add input validation and clearly communicate the length requirement for the reason field
- Replace the length slider and switch to a date picker to improve UX
- Add red asterisks to `upload-submission-modal` as a quick fix to indicate mandatory fields

## Notes

Date picker range logic:

- Start date is tomorrow of target date if not overdue, or tomorrow of current day if overdue.
- End date is always the due date (`due_date` on the backend, the hard deadline).
- The component calculates the number of weeks and rounds it up before sending the request to maintain compatibility with the current backend logic. The extension granularity refactor (weeks -> days) will be rebased on top of this.

## Screenshots

Reason not provided:
![image](https://github.com/doubtfire-lms/doubtfire-web/assets/90136978/d8f0bd45-cd1a-4ab0-bc84-6bf101f2308f)

Reason not long enough:
![image](https://github.com/doubtfire-lms/doubtfire-web/assets/90136978/85604099-21e4-4498-aec2-7a2d5e69f974)

The current target date (displayed as due date on the frontend) is 14 May, available range starts at 15 May:
![image](https://github.com/doubtfire-lms/doubtfire-web/assets/90136978/f5e3b45f-cfa7-4728-8871-411ac164a197)

The due date (hard deadline) is 18 May, so the extension can only be selected up to that day:
![image](https://github.com/doubtfire-lms/doubtfire-web/assets/90136978/aef351df-248a-468d-8d54-a7afa6521c4e)

Overdue task, target date is 2 Apr, starting date in the date picker is the next day after today (1 May), since it doesn't make sense to request extensions to a past date:
![image](https://github.com/doubtfire-lms/doubtfire-web/assets/90136978/ff48f7f2-733f-4a18-97e9-691228971de0)



