### PR TITLE
fix: grade and quality point display on task-assessment-card

### DIFF
--- a/src/app/api/models/task.ts
+++ b/src/app/api/models/task.ts
@@ -137,7 +137,11 @@ export class Task extends Entity {
   }
 
   public hasGrade(): boolean {
-    return this.grade !== undefined && this.grade !== null && TaskStatus.GRADEABLE_STATUSES.includes(this.status);
+    return (
+      this.grade !== undefined &&
+      this.grade !== null &&
+      TaskStatus.GRADEABLE_STATUSES.includes(this.status)
+    );
   }
 
   public hasQualityPoints(): boolean {
@@ -145,7 +149,10 @@ export class Task extends Entity {
   }
 
   public hasBeenGraded(): boolean {
-    return typeof this.grade === 'number';
+    if (this.hasGrade()) {
+      return typeof this.grade === 'number';
+    }
+    return false;
   }
 
   public hasBeenGivenQualityPoints(): boolean {

--- a/src/app/api/models/task.ts
+++ b/src/app/api/models/task.ts
@@ -1,7 +1,7 @@
-import { Entity, EntityCache, RequestOptions } from 'ngx-entity-service';
-import { AppInjector } from 'src/app/app-injector';
-import { formatDate } from '@angular/common';
-import { DoubtfireConstants } from 'src/app/config/constants/doubtfire-constants';
+import {Entity, EntityCache, RequestOptions} from 'ngx-entity-service';
+import {AppInjector} from 'src/app/app-injector';
+import {formatDate} from '@angular/common';
+import {DoubtfireConstants} from 'src/app/config/constants/doubtfire-constants';
 import {
   TaskDefinition,
   Project,
@@ -16,13 +16,13 @@ import {
   TaskSimilarity,
   TaskSimilarityService,
 } from './doubtfire-model';
-import { Grade } from './grade';
-import { LOCALE_ID } from '@angular/core';
-import { HttpClient } from '@angular/common/http';
-import { Observable, map } from 'rxjs';
-import { gradeTaskModal, uploadSubmissionModal } from 'src/app/ajs-upgraded-providers';
-import { AlertService } from 'src/app/common/services/alert.service';
-import { MappingFunctions } from '../services/mapping-fn';
+import {Grade} from './grade';
+import {LOCALE_ID} from '@angular/core';
+import {HttpClient} from '@angular/common/http';
+import {Observable, map} from 'rxjs';
+import {gradeTaskModal, uploadSubmissionModal} from 'src/app/ajs-upgraded-providers';
+import {AlertService} from 'src/app/common/services/alert.service';
+import {MappingFunctions} from '../services/mapping-fn';
 
 export class Task extends Entity {
   id: number;
@@ -74,7 +74,7 @@ export class Task extends Entity {
 
   /**
    * Provide the task definition id to allow mapping in service.
-  */
+   */
   public get taskDefId(): number {
     return this.definition.id;
   }
@@ -116,7 +116,7 @@ export class Task extends Entity {
     );
   }
 
-  public hasTaskKey(key: { studentId: number; taskDefAbbr: string }): boolean {
+  public hasTaskKey(key: {studentId: number; taskDefAbbr: string}): boolean {
     return this.taskKey() === key;
   }
 
@@ -250,11 +250,11 @@ export class Task extends Entity {
 
   private timeToDescription(earlyTime: Date, laterTime: Date) {
     const times = [
-      { period: 'weeks', value: 7 * 24 * 60 * 60 * 1000.0 },
-      { period: 'days', value: 24 * 60 * 60 * 1000.0 },
-      { period: 'hours', value: 60 * 60 * 1000.0 },
-      { period: 'minutes', value: 60 * 1000.0 },
-      { period: 'seconds', value: 1000.0 },
+      {period: 'weeks', value: 7 * 24 * 60 * 60 * 1000.0},
+      {period: 'days', value: 24 * 60 * 60 * 1000.0},
+      {period: 'hours', value: 60 * 60 * 1000.0},
+      {period: 'minutes', value: 60 * 1000.0},
+      {period: 'seconds', value: 1000.0},
     ];
 
     const timeDiff = laterTime.getTime() - earlyTime.getTime();
@@ -275,7 +275,9 @@ export class Task extends Entity {
         // Always show in days, Hours, Minutes and Seconds.
         return `${diff} ${data.period.charAt(0).toUpperCase() + data.period.substring(1)}`;
       } else if (diff === 1 && data.period !== 'weeks') {
-        return `1 ${data.period.charAt(0).toUpperCase() + data.period.substring(1, data.period.length - 2)}`;
+        return `1 ${
+          data.period.charAt(0).toUpperCase() + data.period.substring(1, data.period.length - 2)
+        }`;
       }
     }
 
@@ -316,7 +318,9 @@ export class Task extends Entity {
 
   // Are we approaching the deadline?
   public isDeadlineSoon() {
-    return this.daysUntilDeadlineDate() <= 14 && this.timePastDeadlineDate() < 0 && !this.inFinalState();
+    return (
+      this.daysUntilDeadlineDate() <= 14 && this.timePastDeadlineDate() < 0 && !this.inFinalState()
+    );
   }
 
   public betweenDueDateAndDeadlineDate(): boolean {
@@ -365,7 +369,8 @@ export class Task extends Entity {
       }
 
       // if the comment is preceeded by a non-content comment, mark it as start of series.
-      comments[i].firstInSeries = comments[i].isBubbleComment && (i === 0 || !comments[i - 1].isBubbleComment);
+      comments[i].firstInSeries =
+        comments[i].isBubbleComment && (i === 0 || !comments[i - 1].isBubbleComment);
 
       // if the comment is proceeded by a non-conent comment, mark it as end of series.
       if (comments[i].isBubbleComment && !comments[i + 1]?.isBubbleComment) {
@@ -382,7 +387,7 @@ export class Task extends Entity {
     comments;
   }
 
-  public taskKey(): { studentId: number; taskDefAbbr: string } {
+  public taskKey(): {studentId: number; taskDefAbbr: string} {
     return {
       studentId: this.project.student.id,
       taskDefAbbr: this.definition.abbreviation,
@@ -400,15 +405,20 @@ export class Task extends Entity {
 
   public getSimilarityData(match: number): Observable<unknown> {
     const httpClient = AppInjector.get(HttpClient);
-    return httpClient.get(`${AppInjector.get(DoubtfireConstants).API_URL}/tasks/${this.id}/similarity/${match}`);
+    return httpClient.get(
+      `${AppInjector.get(DoubtfireConstants).API_URL}/tasks/${this.id}/similarity/${match}`,
+    );
   }
 
   public updateSimilarity(match: number, other: any, dismissed: boolean): Observable<any> {
     const httpClient = AppInjector.get(HttpClient);
-    return httpClient.put(`${AppInjector.get(DoubtfireConstants).API_URL}/tasks/${this.id}/similarity/${match}`, {
-      dismissed: dismissed,
-      other: other,
-    });
+    return httpClient.put(
+      `${AppInjector.get(DoubtfireConstants).API_URL}/tasks/${this.id}/similarity/${match}`,
+      {
+        dismissed: dismissed,
+        other: other,
+      },
+    );
   }
 
   public inFinalState(): boolean {
@@ -455,7 +465,7 @@ export class Task extends Entity {
     return TaskStatus.statusClass(this.status);
   }
 
-  public statusHelp(): { detail: string; reason: string; action: string } {
+  public statusHelp(): {detail: string; reason: string; action: string} {
     return TaskStatus.HELP_DESCRIPTIONS.get(this.status);
   }
 
@@ -477,7 +487,7 @@ export class Task extends Entity {
       .get(
         `${AppInjector.get(DoubtfireConstants).API_URL}/projects/${this.project.id}/task_def_id/${
           this.definition.id
-        }/submission_details`
+        }/submission_details`,
       )
       .pipe(
         map((response: object) => {
@@ -485,20 +495,22 @@ export class Task extends Entity {
           this.processingPdf = response['processing_pdf'];
           this.submissionDate = MappingFunctions.mapDate(response, 'submission_date', this);
           return this;
-        })
+        }),
       );
   }
 
   public get overseerEnabled(): boolean {
     return (
-      this.unit.overseerEnabled && this.definition.assessmentEnabled && this.definition.hasTaskAssessmentResources
+      this.unit.overseerEnabled &&
+      this.definition.assessmentEnabled &&
+      this.definition.hasTaskAssessmentResources
     );
   }
 
   public submissionUrl(asAttachment: boolean = false): string {
-    return `${AppInjector.get(DoubtfireConstants).API_URL}/projects/${this.project.id}/task_def_id/${
-      this.definition.id
-    }/submission${asAttachment ? '?as_attachment=true' : ''}`;
+    return `${AppInjector.get(DoubtfireConstants).API_URL}/projects/${
+      this.project.id
+    }/task_def_id/${this.definition.id}/submission${asAttachment ? '?as_attachment=true' : ''}`;
   }
 
   public testSubmissionUrl(): string {
@@ -508,16 +520,18 @@ export class Task extends Entity {
   }
 
   public submittedFilesUrl(asAttachment: boolean = false): string {
-    return `${AppInjector.get(DoubtfireConstants).API_URL}/projects/${this.project.id}/task_def_id/${
-      this.definition.id
-    }/submission_files${asAttachment ? '?as_attachment=true' : ''}`;
+    return `${AppInjector.get(DoubtfireConstants).API_URL}/projects/${
+      this.project.id
+    }/task_def_id/${this.definition.id}/submission_files${
+      asAttachment ? '?as_attachment=true' : ''
+    }`;
   }
 
   public recreateSubmissionPdf(): Observable<object> {
     const httpClient: HttpClient = AppInjector.get(HttpClient);
-    const url = `${AppInjector.get(DoubtfireConstants).API_URL}/projects/${this.project.id}/task_def_id/${
-      this.definition.id
-    }/submission`;
+    const url = `${AppInjector.get(DoubtfireConstants).API_URL}/projects/${
+      this.project.id
+    }/task_def_id/${this.definition.id}/submission`;
 
     return httpClient.put(url, {});
   }
@@ -529,7 +543,7 @@ export class Task extends Entity {
   public presentTaskSubmissionModal(
     status: TaskStatusEnum,
     reuploadEvidence: boolean = false,
-    isTestSubmission: boolean = false
+    isTestSubmission: boolean = false,
   ) {
     const oldStatus = this.status;
 
@@ -557,7 +571,7 @@ export class Task extends Entity {
         }
         const alerts: any = AppInjector.get(AlertService);
         alerts.add('info', 'Submission cancelled. Status was reverted.', 6000);
-      }
+      },
     );
   }
 
@@ -565,7 +579,7 @@ export class Task extends Entity {
     if (this.inTimeExceeded() && !this.isPastDeadline()) {
       alerts.message(
         'You have submitted after the deadline for feedback. Your task will not be reviewed by a tutor. It is now your responsibility to ensure this task meets the required standard.',
-        8000
+        8000,
       );
     }
 
@@ -599,7 +613,7 @@ export class Task extends Entity {
             projectId: this.project.id,
             taskDefId: this.definition.id,
           },
-          options
+          options,
         )
         .subscribe({
           next: (response) => {
@@ -635,7 +649,7 @@ export class Task extends Entity {
           () => {
             this.status = oldStatus;
             alerts.message('Status reverted, as no grade was specified', 6000);
-          }
+          },
         );
       }
     } else {
@@ -646,7 +660,8 @@ export class Task extends Entity {
   public triggerTransition(status: TaskStatusEnum): void {
     if (this.status === status) return;
 
-    const requiresFileUpload = ['ready_for_feedback', 'need_help'].includes(status) && this.requiresFileUpload();
+    const requiresFileUpload =
+      ['ready_for_feedback', 'need_help'].includes(status) && this.requiresFileUpload();
 
     if (requiresFileUpload) {
       this.presentTaskSubmissionModal(status);
@@ -689,14 +704,16 @@ export class Task extends Entity {
   public unpin(): void {
     const http = AppInjector.get(HttpClient);
 
-    http.delete(`${AppInjector.get(DoubtfireConstants).API_URL}/tasks/${this.id}/pin`, {}).subscribe({
-      next: (_data) => {
-        this.pinned = false;
-      },
-      error: (message) => {
-        (AppInjector.get(AlertService) as AlertService).error(message, 6000);
-      },
-    });
+    http
+      .delete(`${AppInjector.get(DoubtfireConstants).API_URL}/tasks/${this.id}/pin`, {})
+      .subscribe({
+        next: (_data) => {
+          this.pinned = false;
+        },
+        error: (message) => {
+          (AppInjector.get(AlertService) as AlertService).error(message, 6000);
+        },
+      });
   }
 
   public canApplyForExtension(): boolean {
@@ -709,11 +726,16 @@ export class Task extends Entity {
   }
 
   public wasSubmittedOnTime() {
-    return this.submissionDate && this.submissionDate.getTime() <= this.definition.finalDeadlineDate().getTime();
+    return (
+      this.submissionDate &&
+      this.submissionDate.getTime() <= this.definition.finalDeadlineDate().getTime()
+    );
   }
 
   public maxWeeksCanExtend(): number {
-    return Math.ceil(this.daysBetween(this.localDueDate(), this.definition.localDeadlineDate()) / 7);
+    return Math.ceil(
+      this.daysBetween(this.localDueDate(), this.definition.localDeadlineDate()) / 7,
+    );
   }
 
   /**
@@ -735,11 +757,11 @@ export class Task extends Entity {
   public fetchSimilarities(): Observable<TaskSimilarity[]> {
     const taskSimilarityService: TaskSimilarityService = AppInjector.get(TaskSimilarityService);
     return taskSimilarityService.query(
-      { taskId: this.id },
+      {taskId: this.id},
       {
         cache: this.similarityCache,
         constructorParams: this,
-      }
+      },
     );
   }
 }

--- a/src/app/api/models/task.ts
+++ b/src/app/api/models/task.ts
@@ -144,6 +144,14 @@ export class Task extends Entity {
     return this.definition.maxQualityPts > 0 && TaskStatus.GRADEABLE_STATUSES.includes(this.status);
   }
 
+  public hasBeenGraded(): boolean {
+    return typeof this.grade === 'number';
+  }
+
+  public hasBeenGivenQualityPoints(): boolean {
+    return this.qualityPts > 0 || TaskStatus.GRADEABLE_STATUSES.includes(this.status);
+  }
+
   public localDueDate(): Date {
     if (this.dueDate) {
       return this.dueDate;

--- a/src/app/projects/states/dashboard/directives/task-dashboard/directives/task-assessment-card/task-assessment-card.component.html
+++ b/src/app/projects/states/dashboard/directives/task-dashboard/directives/task-assessment-card/task-assessment-card.component.html
@@ -3,57 +3,36 @@
     <mat-card-title>Assessment Information</mat-card-title>
   </mat-card-header>
   <mat-card-content>
-    <div [hidden]="!task.definition.isGraded"></div>
-    <h5>This task {{ hasBeenGraded(task) ? 'has been' : 'will be' }} assigned a grade</h5>
-
-    <div [hidden]="hasBeenGraded(task)">
-      <p>
-        This task will be graded against a grade standard. Your work will be assessed and assigned a grade according to
-        a Pass, Credit, Distinction or High Distinction standard.
-      </p>
-      <div class="callout callout-primary">
-        <h5>Advice for achieving a {{ task.project.targetGradeWord }}</h5>
+    <div [hidden]="!task.definition.isGraded">
+      <div [hidden]="hasBeenGraded(task)" class="callout callout-info">
         <p>
-          As you are attempting to achieve a {{ task.project.targetGradeWord }} in this unit, you should attempt to
-          achieve a <strong>{{ task.project.targetGradeWord }}</strong> grade on this task. Ask your tutor to find out
-          more on what they are looking for when they are assessing this work to a specific grade.
+          This task will be graded against a grade standard. Your work will be assessed and assigned
+          a grade according to a Pass, Credit, Distinction or High Distinction standard.
+        </p>
+      </div>
+      <div [hidden]="!hasBeenGraded(task)" class="callout callout-success">
+        <b>This task has been assigned a grade.</b>
+        <p>
+          Your tutor has marked you on this task to a
+          <strong>{{ task.gradeWord }}</strong> standard.
         </p>
       </div>
     </div>
-    <div [hidden]="!hasBeenGraded(task)">
-      Your tutor has marked you on this task to a <strong>{{ task.gradeWord }}</strong> standard.
-    </div>
     <!--/graded-task-is-graded-->
     <!--/graded-task-->
-    <hr [hidden]="!(task.definition.isGraded && task.definition.maxQualityPts > 0)" />
     <div [hidden]="!(task.definition.maxQualityPts > 0)">
-      <h5>
-        <span [hidden]="hasBeenGivenStars(task)">
-          This task will be assessed on a scale to {{ task.definition.maxQualityPts }}
-        </span>
-        <span [hidden]="!hasBeenGivenStars(task)"> This task has been assessed for quality </span>
-      </h5>
-      <p [hidden]="hasBeenGivenStars(task)">
+      <p [hidden]="hasBeenGivenStars(task)" class="callout callout-info">
         This task will be graded against a quality scale from
         <strong>0 to {{ task.definition.maxQualityPts }}</strong
-        >. Your work will assessed and assigned a star rating based on the quality of your submission.
+        >. Your work will assessed and assigned a star rating based on the quality of your
+        submission.
       </p>
-      <div [hidden]="!hasBeenGivenStars(task)">
-        <!-- TODO: The 'tickInterval' property no longer exists -->
-        <mat-slider
-          [max]="task.definition.maxQualityPts"
-          [min]="0"
-          [step]="1"
-          thumbLabel="stars"
-          disabled="true"
-          [(ngModel)]="task.qualityPts"
-          aria-labelledby="star rating"
-          ><input matSliderThumb /><input matSliderThumb />
-        </mat-slider>
+      <div [hidden]="!hasBeenGivenStars(task)" class="callout callout-success">
+        <b>This task has been assessed for quality.</b>
         <p>
-          You have been awarded out
-          <strong>{{ task.qualityPts }} of {{ task.definition.maxQualityPts }}</strong>
-          avaliable points for this task.
+          You have been awarded
+          <strong>{{ task.qualityPts }} out of {{ task.definition.maxQualityPts }}</strong>
+          available points for this task.
         </p>
       </div>
     </div>

--- a/src/app/projects/states/dashboard/directives/task-dashboard/directives/task-assessment-card/task-assessment-card.component.html
+++ b/src/app/projects/states/dashboard/directives/task-dashboard/directives/task-assessment-card/task-assessment-card.component.html
@@ -4,13 +4,13 @@
   </mat-card-header>
   <mat-card-content>
     <div [hidden]="!task.definition.isGraded">
-      <div [hidden]="hasBeenGraded(task)" class="callout callout-info">
+      <div [hidden]="task.hasBeenGraded()" class="callout callout-info">
         <p>
           This task will be graded against a grade standard. Your work will be assessed and assigned
           a grade according to a Pass, Credit, Distinction or High Distinction standard.
         </p>
       </div>
-      <div [hidden]="!hasBeenGraded(task)" class="callout callout-success">
+      <div [hidden]="!task.hasBeenGraded()" class="callout callout-success">
         <b>This task has been assigned a grade.</b>
         <p>
           Your tutor has marked you on this task to a
@@ -21,13 +21,13 @@
     <!--/graded-task-is-graded-->
     <!--/graded-task-->
     <div [hidden]="!(task.definition.maxQualityPts > 0)">
-      <p [hidden]="hasBeenGivenStars(task)" class="callout callout-info">
+      <p [hidden]="task.hasBeenGivenQualityPoints()" class="callout callout-info">
         This task will be graded against a quality scale from
         <strong>0 to {{ task.definition.maxQualityPts }}</strong
         >. Your work will assessed and assigned a star rating based on the quality of your
         submission.
       </p>
-      <div [hidden]="!hasBeenGivenStars(task)" class="callout callout-success">
+      <div [hidden]="!task.hasBeenGivenQualityPoints()" class="callout callout-success">
         <b>This task has been assessed for quality.</b>
         <p>
           You have been awarded

--- a/src/app/projects/states/dashboard/directives/task-dashboard/directives/task-assessment-card/task-assessment-card.component.ts
+++ b/src/app/projects/states/dashboard/directives/task-dashboard/directives/task-assessment-card/task-assessment-card.component.ts
@@ -13,12 +13,4 @@ export class TaskAssessmentCardComponent {
 
   @Input() task: Task;
   gradeNames = this.gradeService.grades;
-
-  hasBeenGivenStars(task: Task): boolean {
-    return task?.qualityPts > 0 || this.taskService.gradeableStatuses.includes(task?.status);
-  }
-
-  hasBeenGraded(task: Task): boolean {
-    return typeof task?.grade === 'number';
-  }
 }

--- a/src/app/units/states/edit/directives/unit-tasks-editor/task-definition-editor/task-definition-options/task-definition-options.component.html
+++ b/src/app/units/states/edit/directives/unit-tasks-editor/task-definition-editor/task-definition-options/task-definition-options.component.html
@@ -24,8 +24,7 @@
         min="0"
         max="100"
         type="number"
-        [(value)]="taskDefinition.maxQualityPts"
-        [formControl]="scoreControl"
+        [(ngModel)]="taskDefinition.maxQualityPts"
       />
     </mat-form-field>
     <span class="basis-1/2">Provide a score alongside the task status. We recommend avoiding this practice.</span>

--- a/src/app/units/states/edit/directives/unit-tasks-editor/task-definition-editor/task-definition-options/task-definition-options.component.ts
+++ b/src/app/units/states/edit/directives/unit-tasks-editor/task-definition-editor/task-definition-options/task-definition-options.component.ts
@@ -1,5 +1,4 @@
 import { Component, Input } from '@angular/core';
-import { FormControl, Validators } from '@angular/forms';
 import { TaskDefinition } from 'src/app/api/models/task-definition';
 import { Unit } from 'src/app/api/models/unit';
 
@@ -10,8 +9,6 @@ import { Unit } from 'src/app/api/models/unit';
 })
 export class TaskDefinitionOptionsComponent {
   @Input() taskDefinition: TaskDefinition;
-
-  public scoreControl = new FormControl('', [Validators.max(100), Validators.min(0)]);
 
   public get unit(): Unit {
     return this.taskDefinition?.unit;


### PR DESCRIPTION
## Changes

- Fix quality point option in task definition editor
- Remove the unhelpful generic instructions in `task-assessment-card`
- Refactor grade and quality point display into separate callouts

## Screenshots

Not graded yet:
![image](https://github.com/doubtfire-lms/doubtfire-web/assets/90136978/33db358b-d593-4170-bcf9-58b0adc7abfa)

No quality assessment yet:
![image](https://github.com/doubtfire-lms/doubtfire-web/assets/90136978/c33efb47-3185-413b-91ab-09cd484f71a7)

Not graded but assessed for quality:
![image](https://github.com/doubtfire-lms/doubtfire-web/assets/90136978/9ca7a8f6-b1d4-4ad1-82dc-0847111a9bd5)


Graded and assessed for quality:
![image](https://github.com/doubtfire-lms/doubtfire-web/assets/90136978/1e438cee-ca06-4992-8623-530c85108519)

