### PR TITLE
build: add new build target for reverse proxy in devcontainer

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -82,17 +82,41 @@
               "optimization": false,
               "extractLicenses": false,
               "sourceMap": true
+            },
+            "devcontainer": {
+              "optimization": false,
+              "extractLicenses": false,
+              "sourceMap": true,
+              "fileReplacements": [
+                {
+                  "replace": "src/app/config/constants/apiURL.ts",
+                  "with": "src/app/config/constants/apiURL.devcontainer.ts"
+                }
+              ]
             }
           }
         },
         "serve": {
           "builder": "@angular-devkit/build-angular:dev-server",
           "options": {
-            "buildTarget": "doubtfire:build"
+            "buildTarget": "doubtfire:build",
+            "port": 4200,
+            "host": "0.0.0.0"
           },
           "configurations": {
+            "development": {
+              "buildTarget": "doubtfire:build:development"
+            },
             "production": {
               "buildTarget": "doubtfire:build:production"
+            },
+            "docker": {
+              "buildTarget": "doubtfire:build:development"
+            },
+            "devcontainer": {
+              "buildTarget": "doubtfire:build:devcontainer",
+              "port": 4201,
+              "host": "localhost"
             }
           }
         },

--- a/env.config.js
+++ b/env.config.js
@@ -21,6 +21,11 @@ module.exports = {
     docker: {
       // API URL should use the DF_DOCKER_MACHINE_IP set
       API_URL: 'http://' + process.env.DF_DOCKER_MACHINE_IP + ':3000/api'
+    },
+
+    devcontainer: {
+      // API URL should use the DF_DOCKER_MACHINE_IP set
+      API_URL: 'http://' + process.env.DF_DOCKER_MACHINE_IP + ':4200/api'
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "doubtfire",
   "version": "8.0.0-4",
-  "homepage": "http://github.com/doubtfire-lms/",
+  "homepage": "https://github.com/doubtfire-lms/",
   "description": "Learning and feedback tool.",
   "license": "AGPL-3.0",
   "repository": {},
@@ -14,7 +14,7 @@
     "build:angular17": "ng build",
     "lint:fix": "ng lint --fix",
     "lint": "ng lint",
-    "serve:angular17": "export NODE_OPTIONS=--max_old_space_size=4096 && ng serve --host 0.0.0.0",
+    "serve:angular17": "export NODE_OPTIONS=--max_old_space_size=4096 && ng serve --configuration $NODE_ENV",
     "start": "npm-run-all -l -s build:angular1 -p watch:angular1 serve:angular17",
     "watch:angular1": "grunt delta",
     "deploy:build2api": "ng build --delete-output-path=true --optimization=true --configuration production --output-path dist",

--- a/src/app/config/constants/apiURL.devcontainer.ts
+++ b/src/app/config/constants/apiURL.devcontainer.ts
@@ -1,0 +1,2 @@
+const API_URL = `${window.location.origin}/api`;
+export default API_URL;


### PR DESCRIPTION
Introduce a new configuration for `serve` and `build` to allow running frontend server on a different port in devcontainer, so this change can be seamless for people with existing devcontainer setups. This should also not affect anyone who aren't using the devcontainer in their development setup.