### PR TITLE
fix: inbox search box width

### DIFF
--- a/src/app/units/states/tasks/inbox/directives/staff-task-list/staff-task-list.component.html
+++ b/src/app/units/states/tasks/inbox/directives/staff-task-list/staff-task-list.component.html
@@ -8,7 +8,7 @@
 
       <div class="grow">
         <input
-          class="search"
+          class="search w-full"
           autocomplete="off"
           spellcheck="false"
           type="text"


### PR DESCRIPTION
# Description

The default inbox sidebar width cuts off the rightmost button in the search box, which is particularly noticeable on firefox-based browsers.

This fix just applies full width to the search input box, which seems to resolve everything.

Fixes # (issue)

## Type of change

_Please delete options that are not relevant._

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested on both firefox and chromium (unfortunately I'm not able to test on Safari).

## Testing Checklist:

- [x] Tested in latest Chrome
- [ ] Tested in latest Safari
- [x] Tested in latest Firefox

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have requested a review from @macite and @jakerenzella on the Pull Request
