### PR TITLE
 enhance/view-completion-percentage-on-hover

### DIFF
--- a/src/app/common/footer/footer.component.html
+++ b/src/app/common/footer/footer.component.html
@@ -141,7 +141,7 @@
         <mat-icon class="small-icon">file_download</mat-icon>
       </button>
       <f-project-progress-bar
-        matTooltip="Progress towards {{ selectedTask?.project.targetGradeWord }}"
+        matTooltip="{{selectedTask?.project.taskStats[4]?.value}}% progress towards {{ selectedTask?.project.targetGradeWord }}"
         [matTooltipDisabled]="selectedTask === undefined"
         [progress]="selectedTask?.project.taskStats"
       ></f-project-progress-bar>


### PR DESCRIPTION
# Description

Student's progress bar previously did not display a percentage (value) in the tooltip.

Fixes # (issue)
On hover, the tooltip now displays a value for the percentage. 

## Type of change
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Tested in Browser

## Testing Checklist:

- [x] Tested in latest Chrome
- [ ] Tested in latest Safari
- [x] Tested in latest Firefox

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have requested a review from @macite and @jakerenzella on the Pull Request
