### PR TITLE
fix: task list scrolling

### DIFF
--- a/src/app/units/states/tasks/inbox/directives/staff-task-list/staff-task-list.component.html
+++ b/src/app/units/states/tasks/inbox/directives/staff-task-list/staff-task-list.component.html
@@ -171,7 +171,7 @@
   <!--/search-options-->
   @if (filteredTasks) {
   <cdk-virtual-scroll-viewport class="tasks-viewport scrollable" itemSize="60">
-    <mat-list style="margin: 0; padding: 0">
+    <mat-list class="m-0 p-0">
       <mat-list-item
         class="clearfix"
         *cdkVirtualFor="let task of filteredTasks; templateCacheSize: 0"

--- a/src/app/units/states/tasks/inbox/directives/staff-task-list/staff-task-list.component.html
+++ b/src/app/units/states/tasks/inbox/directives/staff-task-list/staff-task-list.component.html
@@ -171,7 +171,7 @@
   <!--/search-options-->
   @if (filteredTasks) {
   <cdk-virtual-scroll-viewport class="tasks-viewport scrollable" itemSize="60">
-    <mat-list>
+    <mat-list style="margin: 0; padding: 0">
       <mat-list-item
         class="clearfix"
         *cdkVirtualFor="let task of filteredTasks; templateCacheSize: 0"


### PR DESCRIPTION
# Description

Scrolling on staff task lists (e.g. in the inbox and explorer screens) was a bit broken. On firefox in particular, scrolling too far would cause box to start jumping up and down. This seems to be a result of the `<mat-list>` containing the elements having 1 pixel of padding: https://v17.material.angular.io/cdk/scrolling/overview#elements-with-parent-tag-requirements.

Should be fixed by manually setting 0 margin and padding.

## Type of change

_Please delete options that are not relevant._

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested on Firefox and Chromium. Afaik the issue was only obviously present on Chromium before, and with this change it isn't present on either. No noticeable visual changes.

## Testing Checklist:

- [x] Tested in latest Chrome
- [ ] Tested in latest Safari
- [x] Tested in latest Firefox

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have requested a review from @macite and @jakerenzella on the Pull Request
