### PR TITLE
Fix/hide pdf no sheet

### DIFF
--- a/src/app/units/states/tasks/viewer/directives/f-task-sheet-view/f-task-sheet-view.component.html
+++ b/src/app/units/states/tasks/viewer/directives/f-task-sheet-view/f-task-sheet-view.component.html
@@ -1,12 +1,12 @@
 <div class="w-full h-full overflow-auto">
-  @switch (taskDef) { @case (taskDef) { @if (taskDef) {
+  @switch (taskDef) { @case (taskDef) { @if (taskDef && taskDef.hasTaskSheet) {
 
-  <f-pdf-viewer [pdfUrl]="taskDef.getTaskPDFUrl()" [hidden]="!taskDef.hasTaskSheet"></f-pdf-viewer>
+  <f-pdf-viewer [pdfUrl]="taskDef.getTaskPDFUrl()"></f-pdf-viewer>
 
   } @else {
 
   <div fxFlexFill fxLayout="column" fxLayoutAlign="center center">
-    <mat-icon>subtitles_off</mat-icon>
+    <mat-icon>subtitles_off</mat-icon> No Task Sheet
   </div>
 
   } } }

--- a/src/app/units/states/tasks/viewer/directives/f-task-sheet-view/f-task-sheet-view.component.html
+++ b/src/app/units/states/tasks/viewer/directives/f-task-sheet-view/f-task-sheet-view.component.html
@@ -1,7 +1,7 @@
 <div class="w-full h-full overflow-auto">
   @switch (taskDef) { @case (taskDef) { @if (taskDef) {
 
-  <f-pdf-viewer [pdfUrl]="taskDef.getTaskPDFUrl()"></f-pdf-viewer>
+  <f-pdf-viewer [pdfUrl]="taskDef.getTaskPDFUrl()" [hidden]="!taskDef.hasTaskSheet"></f-pdf-viewer>
 
   } @else {
 

--- a/src/app/units/states/tasks/viewer/directives/f-task-sheet-view/f-task-sheet-view.component.html
+++ b/src/app/units/states/tasks/viewer/directives/f-task-sheet-view/f-task-sheet-view.component.html
@@ -1,5 +1,5 @@
 <div class="w-full h-full overflow-auto">
-  @switch (taskDef) { @case (taskDef) { @if (taskDef && taskDef.hasTaskSheet) {
+  @switch (taskDef) { @case (taskDef) { @if (taskDef?.hasTaskSheet) {
 
   <f-pdf-viewer [pdfUrl]="taskDef.getTaskPDFUrl()"></f-pdf-viewer>
 


### PR DESCRIPTION
# Description

Fixes #
Fix unwanted loading of the pdf-viewer component when it was not needed (no task sheet)
Add No Task sheet text alongside the icon for better information

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested using frontend, tutor view

## Testing Checklist:

- [x] Tested in latest Chrome
- [x] Tested in latest Safari

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have requested a review from @macite and @jakerenzella on the Pull Request
