### PR TITLE
DRAFT feat/recently-viewed-submissions

### DIFF
--- a/src/app/common/filters/tasks-in-cache.pipe.ts
+++ b/src/app/common/filters/tasks-in-cache.pipe.ts
@@ -1,0 +1,26 @@
+import { Pipe, PipeTransform } from '@angular/core';
+import { Task } from 'src/app/api/models/task';
+
+@Pipe({
+  name: 'tasksInCache',
+})
+export class TasksInCachePipe implements PipeTransform {
+  transform(tasks: Task[], useCache: boolean): Task[] {
+    if (!useCache || tasks == null) {
+      return tasks;
+    }
+
+    try {
+      const storedTasks = localStorage.getItem('recently-viewed-submissions');
+      const parsedIds = JSON.parse(storedTasks)
+      return tasks.filter((task: Task) =>
+          parsedIds.includes(task.id)
+      );
+    } catch (error) {
+      console.error('Failed to parse stored tasks:', error)
+      // this.tasksInCache = []
+    }
+
+    return tasks;
+  }
+}

--- a/src/app/units/states/tasks/inbox/directives/staff-task-list/staff-task-list.component.html
+++ b/src/app/units/states/tasks/inbox/directives/staff-task-list/staff-task-list.component.html
@@ -136,6 +136,9 @@
             <button (click)="toggleUseCache(); applyFilters()">Recently Viewed Submissions</button>
           </div>
           <!--/cache-->
+          <div class="flex flex-row justify-between items-center">
+            <button (click)="clearCache()">Clear Cache</button>
+          </div>
         </form>
       </mat-expansion-panel>
     </mat-accordion>

--- a/src/app/units/states/tasks/inbox/directives/staff-task-list/staff-task-list.component.html
+++ b/src/app/units/states/tasks/inbox/directives/staff-task-list/staff-task-list.component.html
@@ -132,6 +132,10 @@
             </button>
           </div>
           <!--/students-->
+          <div class="flex flex-row justify-between items-center">
+            <button (click)="toggleUseCache(); applyFilters()">Recently Viewed Submissions</button>
+          </div>
+          <!--/cache-->
         </form>
       </mat-expansion-panel>
     </mat-accordion>


### PR DESCRIPTION
# Description
A 'Recently Viewed Submissions' (or interacted with) filter using localstorage.
Add a toggle filter in the staff task list.
Added another field in `StaffTaskListComponent`: `tasksInCache: Task[]` and also added a `useCache: boolean` to the filter.

# TODO
- add recently interacted with
- add a way to clear the cache (localstorage)
- sort by time viewed / interacted with
- improve the visuals of the button
- prevent duplicate from being stored in localstorage (stores multiple but the filters work so that it only shows one)
- seems to break deleting comments? might also affect other features...

Fixes # (issue)

## Type of change

_Please delete options that are not relevant._

- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Not yet, still drafted.
_Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration_
Testing Ideas:
- Simulate using localstorage.
- Test when localstorage is empty.
- Test with duplicate submissions
- Test when working correctly

## Testing Checklist:

- [ ] Tested in latest Chrome
- [ ] Tested in latest Safari
- [ ] Tested in latest Firefox

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have requested a review from @macite and @jakerenzella on the Pull Request
