### PR TITLE
Fix marking shortcuts

### DIFF
--- a/src/app/units/states/tasks/inbox/directives/staff-task-list/staff-task-list.component.ts
+++ b/src/app/units/states/tasks/inbox/directives/staff-task-list/staff-task-list.component.ts
@@ -123,26 +123,26 @@ export class StaffTaskListComponent implements OnInit, OnChanges, OnDestroy {
     }
   }
   ngOnDestroy(): void {
-    this.hotkeys.removeShortcuts('meta.shift.arrowdown');
-    this.hotkeys.removeShortcuts('meta.shift.arrowup');
+    this.hotkeys.removeShortcuts('alt.shift.arrowdown');
+    this.hotkeys.removeShortcuts('alt.shift.arrowup');
   }
 
   ngOnInit(): void {
     const registeredHotkeys = this.hotkeys.getHotkeys().map((hotkey) => hotkey.keys);
 
-    if (!registeredHotkeys.includes('meta.shift.arrowdown')) {
+    if (!registeredHotkeys.includes('alt.shift..arrowdown')) {
       this.hotkeys
         .addShortcut({
-          keys: 'meta.shift.arrowdown',
+          keys: 'alt.shift.arrowdown',
           description: 'Select next task',
         })
         .subscribe(() => this.nextTask());
     }
 
-    if (!registeredHotkeys.includes('meta.shift.arrowup')) {
+    if (!registeredHotkeys.includes('alt.shift.arrowup')) {
       this.hotkeys
         .addShortcut({
-          keys: 'meta.shift.arrowup',
+          keys: 'alt.shift.arrowup',
           description: 'Select previous task',
         })
         .subscribe(() => this.previousTask());

--- a/src/app/units/states/tasks/inbox/inbox.component.ts
+++ b/src/app/units/states/tasks/inbox/inbox.component.ts
@@ -19,6 +19,7 @@ import {SelectedTaskService} from 'src/app/projects/states/dashboard/selected-ta
 import {HotkeysService, HotkeysHelpComponent} from '@ngneat/hotkeys';
 import {MatDialog} from '@angular/material/dialog';
 import {UserService} from 'src/app/api/services/user.service';
+import {DoubtfireConstants} from 'src/app/config/constants/doubtfire-constants';
 
 @Component({
   selector: 'f-inbox',
@@ -58,6 +59,7 @@ export class InboxComponent implements OnInit, AfterViewInit {
     private router: UIRouter,
     public dialog: MatDialog,
     private userService: UserService,
+    private constants: DoubtfireConstants,
   ) {
     this.selectedTask.currentPdfUrl$.subscribe((url) => {
       this.visiblePdfUrl = url;
@@ -76,7 +78,7 @@ export class InboxComponent implements OnInit, AfterViewInit {
         const ref = this.dialog.open(HotkeysHelpComponent, {
           // width: '250px',
         });
-        ref.componentInstance.title = 'Formatif Marking Shortcuts';
+        ref.componentInstance.title = `${this.constants.ExternalName.value} Marking Shortcuts`;
         ref.componentInstance.dismiss.subscribe(() => ref.close());
       });
     }
@@ -85,17 +87,31 @@ export class InboxComponent implements OnInit, AfterViewInit {
   ngOnInit(): void {
     this.hotkeys
       .addShortcut({
-        keys: 'control.c',
+        keys: 'alt.shift.r',
+        description: 'Mark selected task as redo',
+      })
+      .subscribe(() => this.selectedTask.selectedTask?.updateTaskStatus('redo'));
+
+    this.hotkeys
+      .addShortcut({
+        keys: 'alt.shift.f',
+        description: 'Mark selected task as fix',
+      })
+      .subscribe(() => this.selectedTask.selectedTask?.updateTaskStatus('fix_and_resubmit'));
+
+    this.hotkeys
+      .addShortcut({
+        keys: 'alt.shift.c',
         description: 'Mark selected task as complete',
       })
       .subscribe(() => this.selectedTask.selectedTask?.updateTaskStatus('complete'));
 
     this.hotkeys
       .addShortcut({
-        keys: 'control.f',
-        description: 'Mark selected task as fix',
+        keys: 'alt.shift.d',
+        description: 'Mark selected task as discuss',
       })
-      .subscribe(() => this.selectedTask.selectedTask?.updateTaskStatus('fix_and_resubmit'));
+      .subscribe(() => this.selectedTask.selectedTask?.updateTaskStatus('discuss'));
 
     this.dragMoveAudited$ = this.dragMove$.pipe(
       withLatestFrom(this.inboxStartSize$),


### PR DESCRIPTION
# Description

Changed the new marking shortcuts from `control + key` to `alt + shift + key` to avoid conflicting with common browser shortcuts (such as `control + c` for copy).

Also added shortcuts for redo and discuss, and made it so the shortcut help modal gets the application name from `DoubtfireConstants` instead of being fixed as Formatif.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Tested all shortcuts on firefox and chrome.

## Testing Checklist:

- [x] Tested in latest Chrome
- [ ] Tested in latest Safari
- [x] Tested in latest Firefox

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have requested a review from @macite and @jakerenzella on the Pull Request
