### PR TITLE
fix/marking-hotkeys

### DIFF
--- a/src/app/units/states/tasks/inbox/inbox.component.ts
+++ b/src/app/units/states/tasks/inbox/inbox.component.ts
@@ -83,19 +83,19 @@ export class InboxComponent implements OnInit, AfterViewInit {
   }
 
   ngOnInit(): void {
-    this.hotkeys
-      .addShortcut({
-        keys: 'control.c',
-        description: 'Mark selected task as complete',
-      })
-      .subscribe(() => this.selectedTask.selectedTask?.updateTaskStatus('complete'));
+    // this.hotkeys
+    //   .addShortcut({
+    //     keys: 'control.c',
+    //     description: 'Mark selected task as complete',
+    //   })
+    //   .subscribe(() => this.selectedTask.selectedTask?.updateTaskStatus('complete'));
 
-    this.hotkeys
-      .addShortcut({
-        keys: 'control.f',
-        description: 'Mark selected task as fix',
-      })
-      .subscribe(() => this.selectedTask.selectedTask?.updateTaskStatus('fix_and_resubmit'));
+    // this.hotkeys
+    //   .addShortcut({
+    //     keys: 'control.f',
+    //     description: 'Mark selected task as fix',
+    //   })
+    //   .subscribe(() => this.selectedTask.selectedTask?.updateTaskStatus('fix_and_resubmit'));
 
     this.dragMoveAudited$ = this.dragMove$.pipe(
       withLatestFrom(this.inboxStartSize$),


### PR DESCRIPTION
# Description
Commented out the `ctrl + c` and `ctrl + f` hotkeys

Fixes # (issue)
Hotkeys causing task status to update to 'fix_and_resubmit' and occasionally 'complete' when switching between inbox and task explorer. 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Testing Checklist:

- [ ] Tested in latest Chrome
- [ ] Tested in latest Safari
- [ ] Tested in latest Firefox

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have requested a review from @macite and @jakerenzella on the Pull Request
