### PR TITLE
Upstream PR CourseFlow to Doubtfire-web

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "bootstrap-sass": "~3.4",
     "canvas-confetti": "^1.6.0",
     "codemirror": "5.65.0",
+    "commitlint": "^19.3.0",
     "core-js": "^3.21.1",
     "d3": "3.5.17",
     "es5-shim": "^4.5.12",

--- a/src/app/common/header/header.component.html
+++ b/src/app/common/header/header.component.html
@@ -77,6 +77,10 @@
         <mat-icon matListItemIcon aria-label="Edit calendar">calendar_month</mat-icon>
         Calendar
       </button>
+      <button mat-menu-item (click)="openCourseFlow()">
+        <mat-icon matListItemIcon aria-label="courseflow">courseflow</mat-icon>
+        CourseFlow
+      </button>
       <button mat-menu-item (click)="openAboutModal()">
         <mat-icon matListItemIcon aria-label="About">info</mat-icon>
         About

--- a/src/app/common/header/header.component.ts
+++ b/src/app/common/header/header.component.ts
@@ -137,10 +137,6 @@ export class HeaderComponent implements OnInit, OnDestroy {
     this.CalendarModal.show();
   }
 
-  openCourseFlow(): void {
-    this.router.navigate(['/courseflow']);  // Method to navigate to the CourseFlow component
-  }
-
   signOut(): void {
     this.authService.signOut();
   }

--- a/src/app/common/header/header.component.ts
+++ b/src/app/common/header/header.component.ts
@@ -8,6 +8,7 @@ import { UserService } from 'src/app/api/services/user.service';
 import { AuthenticationService, Project, Task, Unit, UnitRole, User } from 'src/app/api/models/doubtfire-model';
 import { Subscription } from 'rxjs';
 import { MediaObserver } from 'ng-flex-layout';
+import { Router } from '@angular/router'; //courseflow
 
 @Component({
   selector: 'app-header',
@@ -41,6 +42,7 @@ export class HeaderComponent implements OnInit, OnDestroy {
     private userService: UserService,
     private authService: AuthenticationService,
     protected media: MediaObserver,
+    private router: Router, //courseflow
   ) {}
 
   ngOnInit(): void {
@@ -133,6 +135,10 @@ export class HeaderComponent implements OnInit, OnDestroy {
 
   openCalendar(): void {
     this.CalendarModal.show();
+  }
+
+  openCourseFlow(): void {
+    this.router.navigate(['/courseflow']);  // Method to navigate to the CourseFlow component
   }
 
   signOut(): void {

--- a/src/app/config/constants/doubtfire-constants.ts
+++ b/src/app/config/constants/doubtfire-constants.ts
@@ -43,6 +43,7 @@ export class DoubtfireConstants {
   public IsTiiEnabled: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(false);
 
   private readonly settingsUrl: string = `${this.API_URL}/settings`;
+  SomeConstant: string;
 
   constructor(handler: HttpBackend) {
     // Don't use interceptors for Doubtfire Constants

--- a/src/app/courseflow/courseflow.component.html
+++ b/src/app/courseflow/courseflow.component.html
@@ -1,0 +1,2 @@
+<p>CourseFlow</p>
+

--- a/src/app/courseflow/courseflow.component.spec.ts
+++ b/src/app/courseflow/courseflow.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { CourseFlowComponent } from './courseflow.component';
+
+describe('CourseFlowComponent', () => {
+  let component: CourseFlowComponent;
+  let fixture: ComponentFixture<CourseFlowComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ CourseFlowComponent ]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(CourseFlowComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/courseflow/courseflow.component.ts
+++ b/src/app/courseflow/courseflow.component.ts
@@ -1,0 +1,17 @@
+import { Component, OnInit } from '@angular/core';
+import { DoubtfireConstants } from 'src/app/config/constants/doubtfire-constants';
+
+@Component({
+  selector: 'f-courseflow',
+  templateUrl: './courseflow.component.html',
+  styleUrls: ['./courseflow.component.scss'],
+})
+export class CourseFlowComponent implements OnInit {
+  public someProperty: string;
+
+  constructor(private constants: DoubtfireConstants) {}
+
+  ngOnInit(): void {
+    this.someProperty = this.constants.SomeConstant;
+  }
+}

--- a/src/app/doubtfire-angular.module.ts
+++ b/src/app/doubtfire-angular.module.ts
@@ -492,6 +492,12 @@ export class DoubtfireAngularModule implements DoBootstrap {
       'formatif-logo',
       this.domSanitizer.bypassSecurityTrustResourceUrl('assets/images/logo.svg'),
     );
+
+    this.matIconRegistry.addSvgIcon(
+      'courseflow',
+      this.domSanitizer.bypassSecurityTrustResourceUrl('assets/icons/courseflow-icon.svg')
+    );
+
   }
 
   ngDoBootstrap(): void {

--- a/src/app/doubtfire-angular.module.ts
+++ b/src/app/doubtfire-angular.module.ts
@@ -1,7 +1,6 @@
 import {interval} from 'rxjs';
 import {take} from 'rxjs/operators';
 
-import {RouterModule} from '@angular/router'; //courseflow
 import {NgModule, Injector, DoBootstrap} from '@angular/core';
 import {BrowserModule, DomSanitizer, Title} from '@angular/platform-browser';
 import {UpgradeModule} from '@angular/upgrade/static';
@@ -463,9 +462,6 @@ import {CourseFlowComponent} from './courseflow/courseflow.component';
     MatDatepickerModule,
     MatNativeDateModule,
     MatDialogModuleNew,
-    RouterModule.forRoot([
-      { path: 'courseflow', component: CourseFlowComponent} //courseflow
-    ]),
   ],
 })
 

--- a/src/app/doubtfire-angular.module.ts
+++ b/src/app/doubtfire-angular.module.ts
@@ -1,6 +1,7 @@
 import {interval} from 'rxjs';
 import {take} from 'rxjs/operators';
 
+import {RouterModule} from '@angular/router'; //courseflow
 import {NgModule, Injector, DoBootstrap} from '@angular/core';
 import {BrowserModule, DomSanitizer, Title} from '@angular/platform-browser';
 import {UpgradeModule} from '@angular/upgrade/static';
@@ -224,6 +225,7 @@ import {FTaskSheetViewComponent} from './units/states/tasks/viewer/directives/f-
 import {TasksViewerComponent} from './units/states/tasks/tasks-viewer/tasks-viewer.component';
 import {UnitCodeComponent} from './common/unit-code/unit-code.component';
 import {GradeService} from './common/services/grade.service';
+import {CourseFlowComponent} from './courseflow/courseflow.component';
 
 @NgModule({
   // Components we declare
@@ -325,6 +327,7 @@ import {GradeService} from './common/services/grade.service';
     FUsersComponent,
     FTaskBadgeComponent,
     FUnitsComponent,
+    CourseFlowComponent, //courseflow
   ],
   // Services we provide
   providers: [
@@ -460,6 +463,9 @@ import {GradeService} from './common/services/grade.service';
     MatDatepickerModule,
     MatNativeDateModule,
     MatDialogModuleNew,
+    RouterModule.forRoot([
+      { path: 'courseflow', component: CourseFlowComponent} //courseflow
+    ]),
   ],
 })
 

--- a/src/app/doubtfire.states.ts
+++ b/src/app/doubtfire.states.ts
@@ -8,6 +8,7 @@ import {TeachingPeriodListComponent} from './admin/states/teaching-periods/teach
 import {AcceptEulaComponent} from './eula/accept-eula/accept-eula.component';
 import {FUsersComponent} from './admin/states/f-users/f-users.component';
 import {FUnitsComponent} from './admin/states/f-units/f-units.component';
+import {CourseFlowComponent} from './courseflow/courseflow.component';
 
 /*
  * Use this file to store any states that are sourced by angular components.
@@ -266,13 +267,28 @@ const AdministerUnits: NgHybridStateDeclaration = {
   data: {
     pageTitle: 'Administer units',
     roleWhiteList: ['Admin'],
-  },
+  }
 };
+
+const CourseFlowState: NgHybridStateDeclaration = {
+  name: 'courseflow',
+  url: '/courseflow',
+  views: {
+    main: {
+      component: CourseFlowComponent,
+    },
+  },
+  data: {
+    pageTitle: 'Course Flow',
+    roleWhitelist: ['Student', 'Tutor', 'Convenor', 'Admin']
+  },
+}
 
 
 const ViewAllUnits: NgHybridStateDeclaration = {
   name: 'view-all-units',
   url: '/view-all-units',
+
   // passes 'mode' as @Input to the component
   resolve: {
     'mode': function () {
@@ -306,4 +322,5 @@ export const doubtfireStates = [
   ViewAllProjectsState,
   ViewAllUnits,
   AdministerUnits,
+  CourseFlowState, //cf
 ];

--- a/src/app/doubtfire.states.ts
+++ b/src/app/doubtfire.states.ts
@@ -267,7 +267,7 @@ const AdministerUnits: NgHybridStateDeclaration = {
   data: {
     pageTitle: 'Administer units',
     roleWhiteList: ['Admin'],
-  }
+  },
 };
 
 const CourseFlowState: NgHybridStateDeclaration = {

--- a/src/assets/icons/courseflow-icon.svg
+++ b/src/assets/icons/courseflow-icon.svg
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="1080" height="1080" viewBox="0 0 1080 1080" xml:space="preserve">
+<desc>Created with Fabric.js 5.2.4</desc>
+<defs>
+</defs>
+<g transform="matrix(1 0 0 1 540 540)" id="b2a41df5-36ee-4d54-8a5f-834390d7a443"  >
+<rect style="stroke: none; stroke-width: 1; stroke-dasharray: none; stroke-linecap: butt; stroke-dashoffset: 0; stroke-linejoin: miter; stroke-miterlimit: 4; fill: rgb(255,255,255); fill-rule: nonzero; opacity: 1; visibility: hidden;" vector-effect="non-scaling-stroke"  x="-540" y="-540" rx="0" ry="0" width="1080" height="1080" />
+</g>
+<g transform="matrix(1 0 0 1 540 540)" id="d96b25a5-f53c-40ad-a926-e708fdc15fc2"  >
+</g>
+<g transform="matrix(1 0 0 1 540 540)" id="575ccad7-6f4d-499c-bb8f-4e1fe6e9d9fd"  >
+<path style="stroke: rgb(0,0,0); stroke-width: 0; stroke-dasharray: none; stroke-linecap: butt; stroke-dashoffset: 0; stroke-linejoin: miter; stroke-miterlimit: 4; fill: rgb(0,0,0); fill-rule: nonzero; opacity: 1;" vector-effect="non-scaling-stroke"  transform=" translate(-480, 480)" d="M 480 -120 L 200 -272 L 200 -512 L 40 -600 L 480 -840 L 920 -600 L 920 -280 L 840 -280 L 840 -556 L 760 -512 L 760 -272 L 480 -120 Z M 480 -452 L 754 -600 L 480 -748 L 206 -600 L 480 -452 Z M 480 -211 L 680 -319 L 680 -470 L 480 -360 L 280 -470 L 280 -319 L 480 -211 Z M 480 -452 Z M 480 -362 Z M 480 -362 Z" stroke-linecap="round" />
+</g>
+</svg>


### PR DESCRIPTION

before:
![before](https://github.com/thoth-tech/doubtfire-web/assets/101180020/db40fe0f-5e5c-4c78-a128-96b002504c23)
after:
![after1](https://github.com/thoth-tech/doubtfire-web/assets/101180020/2a324050-970e-4bad-8ba8-d854294f16f1)


# Description

added courseflow component at doubtfire-web/src/app/courseflow, router courseflow component at header, profile section, in the third button of drop down menu. 
there isnt any logos for courseflow yet, so it is just a button with text that links to courseflow component.

Fixes # (issue)

## Type of change

_Please delete options that are not relevant._

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

i test it by logging into ontrack server, enter in student/aconvenor account and navigate to the user profile section, drop down menu to see if the courseflow component exists there.
once successful, you should see a button named courseflow as the third option under profile drop-down menu.

## Testing Checklist:

- [x] Tested in latest Chrome
- [x] Tested in latest Safari
- [x] Tested in latest Firefox

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have requested a review from @macite and @jakerenzella on the Pull Request
