### PR TITLE
Feature/Custom start page property for f-pdf-viewer

### DIFF
--- a/src/app/common/pdf-viewer/pdf-viewer.component.html
+++ b/src/app/common/pdf-viewer/pdf-viewer.component.html
@@ -58,7 +58,7 @@
         [render-text]="true"
         [original-size]="false"
         (after-load-complete)="onLoaded()"
-        (page-rendered)="loaded = true"
+        (page-rendered)="onPageRendered()"
       ></pdf-viewer>
     }
   } @else {

--- a/src/app/common/pdf-viewer/pdf-viewer.component.ts
+++ b/src/app/common/pdf-viewer/pdf-viewer.component.ts
@@ -24,6 +24,8 @@ export class fPdfViewerComponent implements OnDestroy, OnChanges, AfterViewInit 
   public useNativePdfViewer = false;
 
   @Input() pdfUrl: string;
+  @Input() startPage: number = 1;
+
   @ViewChild(PdfViewerComponent) private pdfComponent: PdfViewerComponent;
   pdfSearchString: string;
   zoomValue = 1;
@@ -75,6 +77,14 @@ export class fPdfViewerComponent implements OnDestroy, OnChanges, AfterViewInit 
     });
   }
 
+  scrollToPage(pageNumber: number) {
+    if (pageNumber <= this.pdfComponent.pdfViewer.pagesCount) {
+      this.pdfComponent.pdfViewer.scrollPageIntoView({
+        pageNumber,
+      });
+    }
+  }
+
   public zoomIn() {
     if (this.zoomValue < 2.5) {
       this.zoomValue += 0.1;
@@ -110,5 +120,12 @@ export class fPdfViewerComponent implements OnDestroy, OnChanges, AfterViewInit 
   onLoaded() {
     this.loaded = true;
     window.dispatchEvent(new Event('resize'));
+  }
+
+  onPageRendered() {
+    this.loaded = true;
+    if (this.startPage > 1) {
+      this.scrollToPage(this.startPage);
+    }
   }
 }

--- a/src/app/projects/states/dashboard/directives/task-dashboard/task-dashboard.component.html
+++ b/src/app/projects/states/dashboard/directives/task-dashboard/task-dashboard.component.html
@@ -1,11 +1,15 @@
 <div class="w-full h-full overflow-auto">
   <ng-container [ngSwitch]="currentView">
     <ng-template [ngSwitchCase]="DashboardViews.task">
-      <ng-container *ngIf="selectedTaskService.hasTaskSheet; then pdfViewer; else noPdfUrl"></ng-container>
+      <ng-container
+        *ngIf="selectedTaskService.hasTaskSheet; then pdfViewer; else noPdfUrl"
+      ></ng-container>
     </ng-template>
 
     <ng-template [ngSwitchCase]="DashboardViews.submission">
-      <ng-container *ngIf="selectedTaskService.hasSubmissionPdf; then pdfViewer; else noPdfUrl"></ng-container>
+      <ng-container
+        *ngIf="selectedTaskService.hasSubmissionPdf; then pdfViewer; else noPdfUrl"
+      ></ng-container>
     </ng-template>
 
     <ng-template [ngSwitchCase]="DashboardViews.similarity">
@@ -15,7 +19,7 @@
 
   <!-- The PDF Viewer -->
   <ng-template #pdfViewer>
-    <f-pdf-viewer [pdfUrl]="pdfUrl"></f-pdf-viewer>
+    <f-pdf-viewer [pdfUrl]="pdfUrl" [startPage]="2"></f-pdf-viewer>
   </ng-template>
 
   <!-- Render if no PDF URL is available for the current view -->


### PR DESCRIPTION
# Description

Implements an optional `[startPage]` input property to the `f-pdf-viewer` component that accepts a page number that the pdf viewer will scroll to when it renders.

This PR adds `[startPage]="2"` to only the f-pdf-viewer used in the tutor inbox section, so that tutors no longer have to scroll past the initial page in every submission.

Example:
```html
    <f-pdf-viewer [pdfUrl]="pdfUrl" [startPage]="2"></f-pdf-viewer>
```

Notes:
The `startPage` property will default to `1` if it's not passed in the component.
However, if `startPage` is `1`, the initial `scrollToPage(this.startPage)` function will not be called in `onPageRendered()` since users could already be scrolling down before this is called - and `onLoaded()` is called too soon to use `scrollToPage()`. (Overall behaviour remains the same)

## Type of change

- [x] New feature (non-breaking change which adds functionality)


# How Has This Been Tested?

- *Testing this requires a multi-page PDF, so you can temporarily copy over `doubtfire-api/test_files/submissions/1.2P.pdf` into the `doubtfire-api/test_files/unit_files/` directory and rename it to `sample-student-submission.pdf` to override the original single page PDF*
- *Alternatively, login as a student and upload a multi-page PDF to a task that `atutor` has access to, then run `rake submission:generate_pdfs` in `doubtfire-api`*
- Login as `atutor` and select any unit, then select either the `Inbox` or `Task Explorer` dropdown
- Ensure you're not using the native PDF viewer by keeping the toggle icon (next to the download icon) in the off position.
- When selecting a submission from the list, the pdf-viewer will automatically load the PDF submission from the second page

## Testing Checklist:

- [x] Tested in latest Chrome
- [x] Tested in latest Safari
- [x] Tested in latest Firefox

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings