### PR TITLE
Clickjacking (X-Frame-Options Header) security patch fix on doubtfire-web

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -1,24 +1,56 @@
 worker_processes 1;
 
-events {  }
+events { }
 
 http {
     include /etc/nginx/mime.types;
 
     sendfile on;
+
+    # Server block for port 80
     server {
         root /usr/share/nginx/html/;
         index index.html;
         listen 80;
 
-        add_header Content-Security-Policy "default-src https: 'unsafe-inline' 'unsafe-eval' blob: data: ws:" always;
-        # add_header Feature-Policy "microphone=(self),speaker=(self),fullscreen=(self),payment=(none);" always;
-        add_header Permissions-Policy "microphone=(self),speaker=(self),fullscreen=(self),payment=(none)" always;
+        add_header Content-Security-Policy "default-src https: 'unsafe-inline' 'unsafe-eval' blob: data:" always;
+        add_header Feature-Policy "microphone 'self';speaker 'self';fullscreen 'self';payment none;" always;
+        add_header Permissions-Policy "microphone=(self), fullscreen=(self), payment=()" always;
+
+        # X-Frame-Options header for clickjacking protection
+        add_header X-Frame-Options "DENY" always;
     }
 
+    # Server block for port 4200
+    server {
+        root /usr/share/nginx/html/;
+        index index.html;
+        listen 4200;
+
+        add_header Content-Security-Policy "default-src https: 'unsafe-inline' 'unsafe-eval' blob: data:" always;
+        add_header Feature-Policy "microphone 'self';speaker 'self';fullscreen 'self';payment none;" always;
+        add_header Permissions-Policy "microphone=(self), fullscreen=(self), payment=()" always;
+
+        # X-Frame-Options header for clickjacking protection
+        add_header X-Frame-Options "DENY" always;
+    }
+
+    # Server block for port 443
+    server {
+        root /usr/share/nginx/html/;
+        index index.html;
+        listen 443;
+
+        add_header Content-Security-Policy "default-src https: 'unsafe-inline' 'unsafe-eval' blob: data:" always;
+        add_header Feature-Policy "microphone 'self';speaker 'self';fullscreen 'self';payment none;" always;
+        add_header Permissions-Policy "microphone=(self), fullscreen=(self), payment=()" always;
+
+        # X-Frame-Options header for clickjacking protection
+        add_header X-Frame-Options "DENY" always;
+    }
+  
     gzip on;
     gzip_types text/css application/javascript;
     gzip_proxied any;
     gzip_buffers 32 8k;
-
 }


### PR DESCRIPTION
**See https://github.com/thoth-tech/doubtfire-web/pull/266**

## Summary
This PR applies a patch to address the `A01 Broken Access Control` vulnerability by adding the `X-Frame-Options` header to Nginx server responses. This fix ensures that the application is protected against clickjacking attacks.

---

## Changes Made

### File: `doubtfire-web/nginx.conf`
**Description**: The `X-Frame-Options` header has been added to the Nginx configuration to prevent the application from being embedded in iframes.

**Changes**:
```nginx

worker_processes 1;

events { }

http {
    include /etc/nginx/mime.types;

    sendfile on;

    # Server block for port 80
    server {
        root /usr/share/nginx/html/;
        index index.html;
        listen 80;

        add_header Content-Security-Policy "default-src https: 'unsafe-inline' 'unsafe-eval' blob: data:" always;
        add_header Feature-Policy "microphone 'self';speaker 'self';fullscreen 'self';payment none;" always;
        add_header Permissions-Policy "microphone=(self), fullscreen=(self), payment=()" always;

        # X-Frame-Options header for clickjacking protection
        add_header X-Frame-Options "DENY" always;
    }

    # Server block for port 4200
    server {
        root /usr/share/nginx/html/;
        index index.html;
        listen 4200;

        add_header Content-Security-Policy "default-src https: 'unsafe-inline' 'unsafe-eval' blob: data:" always;
        add_header Feature-Policy "microphone 'self';speaker 'self';fullscreen 'self';payment none;" always;
        add_header Permissions-Policy "microphone=(self), fullscreen=(self), payment=()" always;

        # X-Frame-Options header for clickjacking protection
        add_header X-Frame-Options "DENY" always;
    }

    # Server block for port 443
    server {
        root /usr/share/nginx/html/;
        index index.html;
        listen 443;

        add_header Content-Security-Policy "default-src https: 'unsafe-inline' 'unsafe-eval' blob: data:" always;
        add_header Feature-Policy "microphone 'self';speaker 'self';fullscreen 'self';payment none;" always;
        add_header Permissions-Policy "microphone=(self), fullscreen=(self), payment=()" always;

        # X-Frame-Options header for clickjacking protection
        add_header X-Frame-Options "DENY" always;
    }
  
    gzip on;
    gzip_types text/css application/javascript;
    gzip_proxied any;
    gzip_buffers 32 8k;
}
```

---

## Testing Plan

### Functional Testing
1. Verify that the `X-Frame-Options` header is present in all HTTP responses using the following command:
   ```bash
   curl -I http://localhost:4200/
   ```
   **Expected Output**:
   ```plaintext
   HTTP/1.1 200 OK
   X-Frame-Options: DENY
   ```
2. Ensure that the application continues to function normally after the changes.

### Security Testing
1. Create a test HTML page that attempts to embed the application in an iframe:
   ```html
   <iframe src="http://localhost:4200/" width="600" height="400"></iframe>
   ```
2. Open the test page in a browser and confirm the iframe is blocked.

### Regression Testing
1. Validate that adding the `X-Frame-Options` header does not affect existing functionality, such as asset loading and API responses.

---

## References
- [OWASP: Clickjacking](https://owasp.org/www-community/attacks/Clickjacking)
- [Mozilla Developer Network: X-Frame-Options](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options)