### PR TITLE
enhance: data pagination

### DIFF
--- a/src/app/doubtfire-angular.module.ts
+++ b/src/app/doubtfire-angular.module.ts
@@ -224,7 +224,7 @@ import {FTaskSheetViewComponent} from './units/states/tasks/viewer/directives/f-
 import {TasksViewerComponent} from './units/states/tasks/tasks-viewer/tasks-viewer.component';
 import {UnitCodeComponent} from './common/unit-code/unit-code.component';
 import {GradeService} from './common/services/grade.service';
-
+import { TargetGradeHistoryComponent } from './projects/states/dashboard/directives/progress-dashboard/target-grade-history/target-grade-history.component';
 @NgModule({
   // Components we declare
   declarations: [
@@ -325,6 +325,7 @@ import {GradeService} from './common/services/grade.service';
     FUsersComponent,
     FTaskBadgeComponent,
     FUnitsComponent,
+    TargetGradeHistoryComponent,
   ],
   // Services we provide
   providers: [

--- a/src/app/doubtfire-angularjs.module.ts
+++ b/src/app/doubtfire-angularjs.module.ts
@@ -225,6 +225,9 @@ import {FUnitsComponent} from './admin/states/f-units/f-units.component';
 import {MarkedPipe} from './common/pipes/marked.pipe';
 import {AlertService} from './common/services/alert.service';
 import {GradeService} from './common/services/grade.service';
+
+import {TargetGradeHistoryComponent} from './projects/states/dashboard/directives/progress-dashboard/target-grade-history/target-grade-history.component';
+
 export const DoubtfireAngularJSModule = angular.module('doubtfire', [
   'doubtfire.config',
   'doubtfire.sessions',
@@ -464,6 +467,12 @@ DoubtfireAngularJSModule.directive(
 );
 DoubtfireAngularJSModule.directive('newFUnits', downgradeComponent({component: FUnitsComponent}));
 
+DoubtfireAngularJSModule.directive(
+  'targetGradeHistory',
+  downgradeComponent({
+    component: TargetGradeHistoryComponent
+  })
+);
 // Global configuration
 
 // If the user enters a URL that doesn't match any known URL (state), send them to `/home`

--- a/src/app/projects/states/dashboard/directives/progress-dashboard/progress-dashboard.coffee
+++ b/src/app/projects/states/dashboard/directives/progress-dashboard/progress-dashboard.coffee
@@ -1,19 +1,17 @@
 angular.module('doubtfire.projects.states.dashboard.directives.progress-dashboard', [])
-#
-# Summary dashboard showing some graphs and way to change the
-# current target grade
-#
-.directive('progressDashboard', ->
+.directive 'progressDashboard', ->
   restrict: 'E'
   templateUrl: 'projects/states/dashboard/directives/progress-dashboard/progress-dashboard.tpl.html'
   scope:
     project: '='
     onUpdateTargetGrade: '='
-  controller: ($scope, $stateParams, newProjectService, gradeService, analyticsService, alertService) ->
+  controller: ($scope, $stateParams, newProjectService, gradeService, analyticsService, alertService, $http, DoubtfireConstants) ->
+
     # Is the current user a tutor?
     $scope.tutor = $stateParams.tutor
+
     # Number of tasks completed and remaining
-    updateTaskCompletionValues  = ->
+    updateTaskCompletionValues = ->
       completedTasks = $scope.project.numberTasks("complete")
       $scope.numberOfTasks =
         completed: completedTasks
@@ -25,6 +23,15 @@ angular.module('doubtfire.projects.states.dashboard.directives.progress-dashboar
       names: gradeService.grades
       values: gradeService.gradeValues
 
+    # Fetch Target Grade History
+    $scope.targetGradeHistory = []
+
+    $http.get("#{DoubtfireConstants.API_URL}/projects/#{$scope.project.id}")
+      .then (response) ->
+        $scope.targetGradeHistory = response.data.target_grade_histories
+      .catch (error) ->
+        alertService.error("Failed to load target grade history", 4000)
+
     $scope.updateTargetGrade = (newGrade) ->
       $scope.project.targetGrade = newGrade
       newProjectService.update($scope.project).subscribe(
@@ -35,10 +42,21 @@ angular.module('doubtfire.projects.states.dashboard.directives.progress-dashboar
           updateTaskCompletionValues()
           $scope.renderTaskStatusPieChart?()
           $scope.onUpdateTargetGrade?()
-          analyticsService.event("Student Project View - Progress Dashboard", "Grade Changed", $scope.grades.names[newGrade])
-          alertService.success( "Updated target grade successfully", 2000)
+          analyticsService.event(
+            "Student Project View - Progress Dashboard",
+            "Grade Changed",
+            $scope.grades.names[newGrade]
+          )
 
-        (failure) ->
-          alertService.error( "Failed to update target grade", 4000)
+          # Fetch updated target grade history
+          $http.get("#{DoubtfireConstants.API_URL}/projects/#{$scope.project.id}")
+            .then (response) ->
+              $scope.targetGradeHistory = response.data.target_grade_histories
+            .catch (error) ->
+              alertService.error("Failed to reload target grade history", 4000)
+
+          alertService.success("Updated target grade successfully", 2000)
+
+        , (failure) ->
+          alertService.error("Failed to update target grade", 4000)
       )
-)

--- a/src/app/projects/states/dashboard/directives/progress-dashboard/progress-dashboard.tpl.html
+++ b/src/app/projects/states/dashboard/directives/progress-dashboard/progress-dashboard.tpl.html
@@ -5,54 +5,90 @@
     </h4>
   </div><!--/panel-heading-->
   <div class="panel-body">
-    <div class="col-sm-12 col-xl-6">
-      <div class="card card-default card-sm card-target-grade">
-        <div class="card-heading">
-          <h4>Target Grade</h4>
-        </div><!--/target-grade-heading-->
-        <div class="card-body">
-          <select
-            class="form-control input-lg"
-            ng-model="project.targetGrade"
-            ng-options="grade as grades.names[grade] for grade in grades.values"
-            ng-if="$index != 4"
-            ng-change="updateTargetGrade(project.targetGrade)"></select>
-        </div><!--/target-grade-body-->
-      </div><!--/target-grade-card-->
-      <div class="card card-default card-lg card-burndown">
-        <div class="card-heading">
-          <h4>Progress Burndown</h4>
-          <div class="text-muted">
-            The burndown chart shows how much work remains for you to achieve your target grade.
+    <div class="row">
+      <!-- Left Column -->
+      <div class="col-sm-12 col-xl-6">
+        <!-- Target Grade Card -->
+        <div class="card card-default card-sm card-target-grade">
+          <div class="card-heading">
+            <h4>Target Grade</h4>
+          </div><!--/target-grade-heading-->
+          <div class="card-body">
+            <select
+              class="form-control input-lg"
+              ng-model="project.targetGrade"
+              ng-options="grade as grades.names[grade] for grade in grades.values"
+              ng-change="updateTargetGrade(project.targetGrade)">
+            </select>
+          </div><!--/target-grade-body-->
+        </div><!--/target-grade-card-->
+
+        <!-- Progress Burndown Card -->
+        <div class="card card-default card-lg card-burndown">
+          <div class="card-heading">
+            <h4>Progress Burndown</h4>
+            <div class="text-muted">
+              The burndown chart shows how much work remains for you to achieve your target grade.
+            </div>
+          </div><!--/burndown-heading-->
+          <div class="card-body">
+            <progress-burndown-chart project="project" unit="project.unit"></progress-burndown-chart>
+          </div><!--/burndown-body-->
+          <div class="card-footer">
+            Aim to keep your
+            <strong style="color: #e01b5d">Complete</strong>
+            line close to or ahead of the
+            <strong class="text-muted">Target</strong>
+            line to keep on track.
+          </div><!--/burndown-footer-->
+        </div><!--/burndown-card-->
+      </div><!--/left-column-->
+
+      <!-- Right Column -->
+      <div class="col-sm-12 col-xl-6">
+        <!-- Task Statuses Pie Chart Card -->
+        <div class="card card-default card-lg card-pie-chart">
+          <div class="card-heading">
+            <h4>Task Statuses</h4>
+            <div class="text-muted">
+              Breakdown summary of each of your task statuses.
+            </div>
+          </div><!--/pie-chart-heading-->
+          <div class="card-body">
+            <student-task-status-pie-chart
+              project="project"
+              update-data="renderTaskStatusPieChart">
+            </student-task-status-pie-chart>
+          </div><!--/pie-chart-body-->
+        </div><!--/pie-chart-card-->
+
+        <!-- Target Grade Change History Card -->
+        <div class="card card-default card-sm card-target-grade-history">
+          <div class="card-heading">
+            <h4>Target Grade Change History</h4>
           </div>
-        </div><!--/burndown-heading-->
-        <div class="card-body">
-          <progress-burndown-chart project="project" unit="project.unit"></progress-burndown-chart>
-        </div><!--/burndown-body-->
-        <div class="card-footer">
-          Aim to keep your
-          <strong style="color: #e01b5d">Complete</strong>
-          line close to or ahead of the
-          <strong class="text-muted">Target</strong>
-          line to keep on track.
-        </div><!--/burndown-footer-->
-      </div><!--/burndown-card-->
-    </div><!--/burndown-column-->
-    <div class="col-sm-12 col-xl-6">
-      <div class="card card-default card-lg card-pie-chart">
-        <div class="card-heading">
-          <h4>Task Statuses</h4>
-          <div class="text-muted">
-            Breakdown summary of each of your task statuses.
+          <div class="card-body">
+            <table class="table table-striped">
+              <thead>
+                <tr>
+                  <th>Changed At</th>
+                  <th>Previous Grade</th>
+                  <th>New Grade</th>
+                  <th>Changed By</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr ng-repeat="history in targetGradeHistory">
+                  <td>{{ history.changed_at | date:'medium' }}</td>
+                  <td>{{ grades.names[history.previous_grade.toString()] }}</td>
+                  <td>{{ grades.names[history.new_grade.toString()] }}</td>
+                  <td>{{ history.changed_by.first_name }} {{ history.changed_by.last_name }}</td>
+                </tr>
+              </tbody>
+            </table>
           </div>
-        </div><!--/pie-chart-heading-->
-        <div class="card-body">
-          <student-task-status-pie-chart
-            project="project"
-            update-data="renderTaskStatusPieChart">
-          </student-task-status-pie-chart>
-        </div><!--/pie-chart-body-->
-      </div><!--/pie-chart-card-->
-    </div><!--/pie-chart-column-->
+        </div><!--/target-grade-history-card-->
+      </div><!--/right-column-->
+    </div><!--/row-->
   </div><!--/panel-body-->
 </div>

--- a/src/app/projects/states/dashboard/directives/progress-dashboard/progress-dashboard.tpl.html
+++ b/src/app/projects/states/dashboard/directives/progress-dashboard/progress-dashboard.tpl.html
@@ -63,32 +63,10 @@
         </div><!--/pie-chart-card-->
 
         <!-- Target Grade Change History Card -->
-        <div class="card card-default card-sm card-target-grade-history">
-          <div class="card-heading">
-            <h4>Target Grade Change History</h4>
-          </div>
-          <div class="card-body">
-            <table class="table table-striped">
-              <thead>
-                <tr>
-                  <th>Changed At</th>
-                  <th>Previous Grade</th>
-                  <th>New Grade</th>
-                  <th>Changed By</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr ng-repeat="history in targetGradeHistory">
-                  <td>{{ history.changed_at | date:'medium' }}</td>
-                  <td>{{ grades.names[history.previous_grade.toString()] }}</td>
-                  <td>{{ grades.names[history.new_grade.toString()] }}</td>
-                  <td>{{ history.changed_by.first_name }} {{ history.changed_by.last_name }}</td>
-                </tr>
-              </tbody>
-            </table>
-          </div>
-        </div><!--/target-grade-history-card-->
-      </div><!--/right-column-->
+        <target-grade-history [project-id]="project.id">
+          
+        </target-grade-history>
+    </div><!--/right-column-->
     </div><!--/row-->
   </div><!--/panel-body-->
 </div>

--- a/src/app/projects/states/dashboard/directives/progress-dashboard/progress-dashboard.tpl.html
+++ b/src/app/projects/states/dashboard/directives/progress-dashboard/progress-dashboard.tpl.html
@@ -57,16 +57,21 @@
           <div class="card-body">
             <student-task-status-pie-chart
               project="project"
-              update-data="renderTaskStatusPieChart">
+              update-data="renderTaskStatusPieChart"
+            >
             </student-task-status-pie-chart>
           </div><!--/pie-chart-body-->
         </div><!--/pie-chart-card-->
 
         <!-- Target Grade Change History Card -->
-        <target-grade-history [project-id]="project.id">
-          
+        <!-- We now pass project.id and project.targetGrade again -->
+        <target-grade-history
+          [project-id]="project.id"
+          [target-grade]="project.targetGrade"
+        >
         </target-grade-history>
-    </div><!--/right-column-->
+
+      </div><!--/right-column-->
     </div><!--/row-->
   </div><!--/panel-body-->
 </div>

--- a/src/app/projects/states/dashboard/directives/progress-dashboard/target-grade-history/target-grade-history.component.html
+++ b/src/app/projects/states/dashboard/directives/progress-dashboard/target-grade-history/target-grade-history.component.html
@@ -1,0 +1,59 @@
+<div class="card card-default card-sm card-target-grade-history">
+  <div class="card-heading">
+    <h4>Target Grade Change History</h4>
+  </div>
+  <div class="card-body">
+    <div *ngIf="loading" class="text-center">Loading history...</div>
+    <div *ngIf="error" class="alert alert-danger">
+      {{ error }}
+    </div>
+    <div *ngIf="!loading && !error && !paginatedGradeHistory?.length" class="text-muted">
+      No grade history available
+    </div>
+    <table
+      class="table table-striped"
+      *ngIf="!loading && !error && paginatedGradeHistory?.length > 0"
+    >
+      <thead>
+        <tr>
+          <th>Changed At</th>
+          <th>Previous Grade</th>
+          <th>New Grade</th>
+          <th>Changed By</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr *ngFor="let history of paginatedGradeHistory">
+          <td>{{ history.changed_at | date: 'medium' }}</td>
+          <td>{{ history.previous_grade }}</td>
+          <td>{{ history.new_grade }}</td>
+          <td>{{ history.changed_by?.first_name }} {{ history.changed_by?.last_name }}</td>
+        </tr>
+      </tbody>
+    </table>
+    <div *ngIf="!loading && !error && totalPages > 1" class="pagination-controls mt-3">
+      <button
+        class="btn btn-primary btn-sm me-2"
+        (click)="goToPage(currentPage - 1)"
+        [disabled]="currentPage === 1"
+      >
+        Previous
+      </button>
+      <button
+        class="btn btn-secondary btn-sm me-1"
+        *ngFor="let page of [].constructor(totalPages); let i = index"
+        [class.active]="i + 1 === currentPage"
+        (click)="goToPage(i + 1)"
+      >
+        {{ i + 1 }}
+      </button>
+      <button
+        class="btn btn-primary btn-sm ms-2"
+        (click)="goToPage(currentPage + 1)"
+        [disabled]="currentPage === totalPages"
+      >
+        Next
+      </button>
+    </div>
+  </div>
+</div>

--- a/src/app/projects/states/dashboard/directives/progress-dashboard/target-grade-history/target-grade-history.component.spec.ts
+++ b/src/app/projects/states/dashboard/directives/progress-dashboard/target-grade-history/target-grade-history.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { TargetGradeHistoryComponent } from './target-grade-history.component';
+
+describe('TargetGradeHistoryComponent', () => {
+  let component: TargetGradeHistoryComponent;
+  let fixture: ComponentFixture<TargetGradeHistoryComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TargetGradeHistoryComponent]
+    })
+    .compileComponents();
+    
+    fixture = TestBed.createComponent(TargetGradeHistoryComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/projects/states/dashboard/directives/progress-dashboard/target-grade-history/target-grade-history.component.ts
+++ b/src/app/projects/states/dashboard/directives/progress-dashboard/target-grade-history/target-grade-history.component.ts
@@ -1,9 +1,9 @@
-import {Component, Input, OnInit, OnDestroy} from '@angular/core';
-import {HttpClient} from '@angular/common/http';
-import {catchError} from 'rxjs/operators';
-import {of, interval, Subscription} from 'rxjs';
-import {GradeService} from 'src/app/common/services/grade.service';
-import {DoubtfireConstants} from 'src/app/config/constants/doubtfire-constants';
+import { Component, Input, OnInit, OnChanges, SimpleChanges } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { catchError } from 'rxjs/operators';
+import { of } from 'rxjs';
+import { GradeService } from 'src/app/common/services/grade.service';
+import { DoubtfireConstants } from 'src/app/config/constants/doubtfire-constants';
 
 interface User {
   id: number;
@@ -26,8 +26,9 @@ interface TargetGradeHistory {
   templateUrl: './target-grade-history.component.html',
   styleUrls: ['./target-grade-history.component.scss'],
 })
-export class TargetGradeHistoryComponent implements OnInit, OnDestroy {
+export class TargetGradeHistoryComponent implements OnInit, OnChanges {
   @Input() projectId!: number;
+  @Input() targetGrade!: string; // <-- so we can detect changes in targetGrade
 
   targetGradeHistory: TargetGradeHistory[] = [];
   paginatedGradeHistory: TargetGradeHistory[] = [];
@@ -37,24 +38,32 @@ export class TargetGradeHistoryComponent implements OnInit, OnDestroy {
   currentPage = 1;
   itemsPerPage = 10;
   totalPages = 1;
-  private gradeCheckSubscription!: Subscription;
 
   constructor(
     private http: HttpClient,
     private gradeService: GradeService,
-    private constants: DoubtfireConstants,
+    private constants: DoubtfireConstants
   ) {}
 
   ngOnInit(): void {
     if (this.projectId) {
       this.loadTargetGradeHistory();
-      this.startGradeChangeListener();
     }
   }
 
-  ngOnDestroy(): void {
-    if (this.gradeCheckSubscription) {
-      this.gradeCheckSubscription.unsubscribe();
+  /**
+   * Detect input changes (projectId or targetGrade). 
+   * If 'targetGrade' changes, we may re-fetch the data.
+   */
+  ngOnChanges(changes: SimpleChanges): void {
+    // If projectId changes (and not the first time), reload.
+    if (changes.projectId && !changes.projectId.firstChange) {
+      this.loadTargetGradeHistory();
+    }
+
+    // If targetGrade changes (and not the first time), reload TGH
+    if (changes.targetGrade && !changes.targetGrade.firstChange) {
+      this.loadTargetGradeHistory();
     }
   }
 
@@ -76,22 +85,23 @@ export class TargetGradeHistoryComponent implements OnInit, OnDestroy {
         catchError((error) => {
           console.error('Error fetching target grade history:', error);
           this.error = 'Failed to load target grade history';
-          return of({target_grade_histories: []});
-        }),
+          return of({ target_grade_histories: [] });
+        })
       )
       .subscribe({
         next: (response) => {
-          this.targetGradeHistory = response.target_grade_histories
+          const rawHistories = response.target_grade_histories || [];
+          this.targetGradeHistory = rawHistories
             .filter(
               (history: TargetGradeHistory) =>
-                history.previous_grade !== undefined && history.new_grade !== undefined,
+                history.previous_grade !== undefined && history.new_grade !== undefined
             )
             .map((history: TargetGradeHistory) => ({
               ...history,
               previous_grade: this.gradeService.grades[history.previous_grade] || 'N/A',
               new_grade: this.gradeService.grades[history.new_grade] || 'N/A',
             }))
-            .sort((a, b) => new Date(b.changed_at).getTime() - new Date(a.changed_at).getTime()); // Sort newest first
+            .sort((a, b) => new Date(b.changed_at).getTime() - new Date(a.changed_at).getTime()); // newest first
 
           this.updatePagination();
           this.loading = false;
@@ -100,43 +110,6 @@ export class TargetGradeHistoryComponent implements OnInit, OnDestroy {
           this.error = 'Failed to load target grade history';
           this.loading = false;
         },
-      });
-  }
-
-  private startGradeChangeListener(): void {
-    const checkInterval = 3000; // 3 seconds
-    this.gradeCheckSubscription = interval(checkInterval).subscribe(() => {
-      this.checkForGradeChange();
-    });
-  }
-
-  private checkForGradeChange(): void {
-    const url = `${this.constants.API_URL}/projects/${this.projectId}`;
-    this.http
-      .get<any>(url)
-      .pipe(
-        catchError((error) => {
-          console.error('Error checking for grade change:', error);
-          return of(null);
-        }),
-      )
-      .subscribe((response) => {
-        if (response && response.target_grade_histories) {
-          const latestHistory = response.target_grade_histories.map(
-            (history: TargetGradeHistory) => ({
-              ...history,
-              previous_grade: this.gradeService.grades[history.previous_grade] || 'N/A',
-              new_grade: this.gradeService.grades[history.new_grade] || 'N/A',
-            }),
-          );
-
-          if (JSON.stringify(this.targetGradeHistory) !== JSON.stringify(latestHistory)) {
-            this.targetGradeHistory = latestHistory.sort(
-              (a, b) => new Date(b.changed_at).getTime() - new Date(a.changed_at).getTime(),
-            );
-            this.updatePagination();
-          }
-        }
       });
   }
 

--- a/src/app/projects/states/dashboard/directives/progress-dashboard/target-grade-history/target-grade-history.component.ts
+++ b/src/app/projects/states/dashboard/directives/progress-dashboard/target-grade-history/target-grade-history.component.ts
@@ -1,0 +1,160 @@
+import {Component, Input, OnInit, OnDestroy} from '@angular/core';
+import {HttpClient} from '@angular/common/http';
+import {catchError} from 'rxjs/operators';
+import {of, interval, Subscription} from 'rxjs';
+import {GradeService} from 'src/app/common/services/grade.service';
+import {DoubtfireConstants} from 'src/app/config/constants/doubtfire-constants';
+
+interface User {
+  id: number;
+  email: string;
+  first_name: string;
+  last_name: string;
+  username: string;
+  nickname: string;
+}
+
+interface TargetGradeHistory {
+  previous_grade: string | number;
+  new_grade: string | number;
+  changed_at: string;
+  changed_by: User;
+}
+
+@Component({
+  selector: 'f-target-grade-history',
+  templateUrl: './target-grade-history.component.html',
+  styleUrls: ['./target-grade-history.component.scss'],
+})
+export class TargetGradeHistoryComponent implements OnInit, OnDestroy {
+  @Input() projectId!: number;
+
+  targetGradeHistory: TargetGradeHistory[] = [];
+  paginatedGradeHistory: TargetGradeHistory[] = [];
+  loading = false;
+  error: string | null = null;
+
+  currentPage = 1;
+  itemsPerPage = 10;
+  totalPages = 1;
+  private gradeCheckSubscription!: Subscription;
+
+  constructor(
+    private http: HttpClient,
+    private gradeService: GradeService,
+    private constants: DoubtfireConstants,
+  ) {}
+
+  ngOnInit(): void {
+    if (this.projectId) {
+      this.loadTargetGradeHistory();
+      this.startGradeChangeListener();
+    }
+  }
+
+  ngOnDestroy(): void {
+    if (this.gradeCheckSubscription) {
+      this.gradeCheckSubscription.unsubscribe();
+    }
+  }
+
+  private loadTargetGradeHistory(): void {
+    if (!this.projectId) {
+      console.error('No projectId provided');
+      this.error = 'Project ID is required';
+      return;
+    }
+
+    this.loading = true;
+    this.error = null;
+
+    const url = `${this.constants.API_URL}/projects/${this.projectId}`;
+
+    this.http
+      .get<any>(url)
+      .pipe(
+        catchError((error) => {
+          console.error('Error fetching target grade history:', error);
+          this.error = 'Failed to load target grade history';
+          return of({target_grade_histories: []});
+        }),
+      )
+      .subscribe({
+        next: (response) => {
+          this.targetGradeHistory = response.target_grade_histories
+            .filter(
+              (history: TargetGradeHistory) =>
+                history.previous_grade !== undefined && history.new_grade !== undefined,
+            )
+            .map((history: TargetGradeHistory) => ({
+              ...history,
+              previous_grade: this.gradeService.grades[history.previous_grade] || 'N/A',
+              new_grade: this.gradeService.grades[history.new_grade] || 'N/A',
+            }))
+            .sort((a, b) => new Date(b.changed_at).getTime() - new Date(a.changed_at).getTime()); // Sort newest first
+
+          this.updatePagination();
+          this.loading = false;
+        },
+        error: () => {
+          this.error = 'Failed to load target grade history';
+          this.loading = false;
+        },
+      });
+  }
+
+  private startGradeChangeListener(): void {
+    const checkInterval = 3000; // 3 seconds
+    this.gradeCheckSubscription = interval(checkInterval).subscribe(() => {
+      this.checkForGradeChange();
+    });
+  }
+
+  private checkForGradeChange(): void {
+    const url = `${this.constants.API_URL}/projects/${this.projectId}`;
+    this.http
+      .get<any>(url)
+      .pipe(
+        catchError((error) => {
+          console.error('Error checking for grade change:', error);
+          return of(null);
+        }),
+      )
+      .subscribe((response) => {
+        if (response && response.target_grade_histories) {
+          const latestHistory = response.target_grade_histories.map(
+            (history: TargetGradeHistory) => ({
+              ...history,
+              previous_grade: this.gradeService.grades[history.previous_grade] || 'N/A',
+              new_grade: this.gradeService.grades[history.new_grade] || 'N/A',
+            }),
+          );
+
+          if (JSON.stringify(this.targetGradeHistory) !== JSON.stringify(latestHistory)) {
+            this.targetGradeHistory = latestHistory.sort(
+              (a, b) => new Date(b.changed_at).getTime() - new Date(a.changed_at).getTime(),
+            );
+            this.updatePagination();
+          }
+        }
+      });
+  }
+
+  private updatePagination(): void {
+    this.totalPages = Math.ceil(this.targetGradeHistory.length / this.itemsPerPage);
+    this.updatePaginatedGradeHistory();
+  }
+
+  private updatePaginatedGradeHistory(): void {
+    const startIndex = (this.currentPage - 1) * this.itemsPerPage;
+    const endIndex = startIndex + this.itemsPerPage;
+    this.paginatedGradeHistory = this.targetGradeHistory.slice(startIndex, endIndex);
+  }
+
+  public goToPage(page: number): void {
+    if (page >= 1 && page <= this.totalPages) {
+      this.currentPage = page;
+      this.updatePaginatedGradeHistory();
+    }
+  }
+}


### PR DESCRIPTION
# Description
## Added Data Pagination

Now, instead of loading all the data histories at once, the backend just gives the data based on the webpage and a limited number or data. For example, If there are 30 records, and if the page 1 has 10 records, this will only give the 10 records in the backend with the total number of records (needed for page count).  

When the user goes to page 2 for example, the next set of data will be loaded. This way, if there are 500 histories for example, everything will not be loaded at once. 

This will help boost webpage load times

<img width="315" alt="Screenshot 2024-12-23 at 2 29 02 am" src="https://github.com/user-attachments/assets/0df7a3af-21d6-43b1-935c-9a9f6e9de6d1" />



- [x] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

Login as any user
Go to the dashboard (where all the target history is been shown)
Go to the inspect page in the browser.
Go to the Network tab, and see how the data is loaded every time when the user is navigated to a new page

## Testing Checklist:

- [x] Tested in latest Chrome
- [x] Tested in latest Safari
- [x] Tested in latest Firefox

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have requested a review from @macite and @jakerenzella on the Pull Request

Back end pull: https://github.com/doubtfire-lms/doubtfire-api/pull/455/
