### PR TITLE
Fix task due date formatting error

### DIFF
--- a/src/app/api/models/task.ts
+++ b/src/app/api/models/task.ts
@@ -276,7 +276,7 @@ export class Task extends Entity {
         return `${diff} ${data.period.charAt(0).toUpperCase() + data.period.substring(1)}`;
       } else if (diff === 1 && data.period !== 'weeks') {
         return `1 ${
-          data.period.charAt(0).toUpperCase() + data.period.substring(1, data.period.length - 2)
+          data.period.charAt(0).toUpperCase() + data.period.slice(1, -1)
         }`;
       }
     }


### PR DESCRIPTION
# Description

Currently, when a single day (or other time period) is remaining before the due date, the following is displayed:
<img width="808" alt="image" src="https://github.com/user-attachments/assets/5740d30d-e258-4b37-935e-8f509bb0462f" />
This is due to a small mistake in the description generation code, which strips off an additional character than necessary. I have fixed this issue.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)