### PR TITLE
feat: tutorial self enrolment task

### DIFF
--- a/src/app/api/models/task-definition.ts
+++ b/src/app/api/models/task-definition.ts
@@ -37,6 +37,7 @@ export class TaskDefinition extends Entity {
   scormBypassTest: boolean;
   scormTimeDelayEnabled: boolean;
   scormAttemptLimit: number = 0;
+  tutorialSelfEnrolmentEnabled: boolean;
   hasTaskAssessmentResources: boolean;
   isGraded: boolean;
   maxQualityPts: number;

--- a/src/app/doubtfire-angular.module.ts
+++ b/src/app/doubtfire-angular.module.ts
@@ -241,6 +241,7 @@ import {ScormExtensionCommentComponent} from './tasks/task-comments-viewer/scorm
 import {ScormExtensionModalComponent} from './common/modals/scorm-extension-modal/scorm-extension-modal.component';
 import { D2lTransferComponent, D2lTransferModal } from './units/states/portfolios/d2l-transfer-modal/d2l-transfer.component';
 import { SuccessCloseComponent } from './common/success-close/success-close.component';
+import { TaskDefinitionTutorialEnrolmentComponent } from './units/states/edit/directives/unit-tasks-editor/task-definition-editor/task-definition-tutorial-enrolment/task-definition-tutorial-enrolment.component';
 
 // See https://stackoverflow.com/questions/55721254/how-to-change-mat-datepicker-date-format-to-dd-mm-yyyy-in-simplest-way/58189036#58189036
 const MY_DATE_FORMAT = {
@@ -296,6 +297,7 @@ const MY_DATE_FORMAT = {
     TaskDefinitionResourcesComponent,
     TaskDefinitionOverseerComponent,
     TaskDefinitionScormComponent,
+    TaskDefinitionTutorialEnrolmentComponent,
     UnitAnalyticsComponent,
     StudentTutorialSelectComponent,
     StudentCampusSelectComponent,

--- a/src/app/units/states/edit/directives/unit-tasks-editor/task-definition-editor/task-definition-editor.component.html
+++ b/src/app/units/states/edit/directives/unit-tasks-editor/task-definition-editor/task-definition-editor.component.html
@@ -152,6 +152,29 @@
           8
         </div>
       </div>
+      <div class="w-full">
+        <h3 class="mb-1 text-2xl font-bold tracking-tight text-gray-900">
+          Tutorial enrolment form
+        </h3>
+        <p class="font-normal text-gray-700">
+          Select the tutorial stream(s) that allow students to enrol in tutorials from
+        </p>
+        <div class="bg-white border border-gray-200 rounded-xl shadow p-6">
+          <f-task-definition-tutorial-enrolment
+            [taskDefinition]="taskDefinition"
+          ></f-task-definition-tutorial-enrolment>
+        </div>
+      </div>
+    </div>
+
+    <div class="flex mt-10">
+      <div class="mr-6">
+        <div
+          class="font-bold text-formatif-blue text-3xl rounded-full bg-formatif-blue-lighter flex items-center justify-center w-16 h-16"
+        >
+          9
+        </div>
+      </div>
 
       <div class="w-full">
         <h3 class="mb-1 text-2xl font-bold tracking-tight text-gray-900">Optional settings</h3>

--- a/src/app/units/states/edit/directives/unit-tasks-editor/task-definition-editor/task-definition-tutorial-enrolment/task-definition-tutorial-enrolment.component.html
+++ b/src/app/units/states/edit/directives/unit-tasks-editor/task-definition-editor/task-definition-tutorial-enrolment/task-definition-tutorial-enrolment.component.html
@@ -1,0 +1,25 @@
+<div class="flex flex-col gap-4">
+  <mat-checkbox matInput required [(ngModel)]="taskDefinition.tutorialSelfEnrolmentEnabled">
+    Enable tutorial self enrolment for task
+  </mat-checkbox>
+
+  @if (taskDefinition.tutorialSelfEnrolmentEnabled) {
+    <div class="flex-grow flex flex-row gap-4 pt-4">
+      <mat-form-field appearance="outline" class="w-full">
+        <mat-label
+          >Tutorial Streams - Which stream students can enrol into a tutorial from?</mat-label
+        >
+        <mat-select [formControl]="tutoralStreamControl" multiple>
+          @for (stream of unit.tutorialStreams; track stream) {
+            <mat-option [value]="stream.key"
+              >{{ stream.name }} — ({{
+                stream.tutorialsIn(taskDefinition.unit).length
+              }}
+              tutorials)</mat-option
+            >
+          }
+        </mat-select>
+      </mat-form-field>
+    </div>
+  }
+</div>

--- a/src/app/units/states/edit/directives/unit-tasks-editor/task-definition-editor/task-definition-tutorial-enrolment/task-definition-tutorial-enrolment.component.ts
+++ b/src/app/units/states/edit/directives/unit-tasks-editor/task-definition-editor/task-definition-tutorial-enrolment/task-definition-tutorial-enrolment.component.ts
@@ -1,0 +1,40 @@
+import {Component, Input, OnInit} from '@angular/core';
+import {FormControl, Validators} from '@angular/forms';
+import {AlertService} from 'src/app/common/services/alert.service';
+import {TaskDefinition} from 'src/app/api/models/task-definition';
+import {Unit} from 'src/app/api/models/unit';
+import {TaskDefinitionService} from 'src/app/api/services/task-definition.service';
+import {TutorialStream} from 'src/app/api/models/doubtfire-model';
+
+@Component({
+  selector: 'f-task-definition-tutorial-enrolment',
+  templateUrl: 'task-definition-tutorial-enrolment.component.html',
+  styleUrls: ['task-definition-tutorial-enrolment.component.scss'],
+})
+export class TaskDefinitionTutorialEnrolmentComponent implements OnInit {
+  @Input() taskDefinition: TaskDefinition;
+
+  public _tutorialStreams: TutorialStream[] = [];
+
+  public _selectedTutorialStreams: TutorialStream[] = [];
+
+  tutoralStreamControl =  new FormControl<TutorialStream | null>(null, Validators.required);
+
+  public ngOnInit(): void {
+    const tutorialStreams = this.taskDefinition.unit.tutorialStreamsCache.currentValues;
+    console.log(tutorialStreams);
+    for (const stream of tutorialStreams) {
+      console.log(stream);
+      this._tutorialStreams.push(stream);
+    }
+  }
+
+  constructor(
+    private alerts: AlertService,
+    private taskDefinitionService: TaskDefinitionService,
+  ) {}
+
+  public get unit(): Unit {
+    return this.taskDefinition?.unit;
+  }
+}


### PR DESCRIPTION
# Description

This feature will allow staff to enable the "Tutorial self enrolment" feature for a designated task. Staff will select which tutorial stream(s) to fetch the tutorials from, and students will be prompted with the list of tutorials they must choose from to complete the task.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

todo

## Testing Checklist:

- [ ] Tested in latest Chrome
- [ ] Tested in latest Safari
- [ ] Tested in latest Firefox

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have requested a review from @macite and @jakerenzella on the Pull Request
