### PR TITLE
feat/colour-vision-deficiency-accessibility: initial commit

### DIFF
--- a/src/app/api/models/user/user.ts
+++ b/src/app/api/models/user/user.ts
@@ -24,6 +24,7 @@ export class User extends Entity {
   authenticationToken: string;
   pronouns: string | null;
   acceptedTiiEula: boolean;
+  themePreference: 'default' | 'black-and-white';
 
   public override toJson<T extends Entity>(mappingData: EntityMapping<T>, ignoreKeys?: string[]): object {
     return {

--- a/src/app/common/edit-profile-form/edit-profile-form.component.html
+++ b/src/app/common/edit-profile-form/edit-profile-form.component.html
@@ -4,9 +4,8 @@
       <!-- avatar -->
       <div fxLayout="row" fxLayoutAlign="space-between center" style="margin-bottom: 25px">
         <a style="margin-left: 20px" href="https://gravatar.com/connect/?source=_signup/" target="_blank">
-          <user-icon [size]="80" [user]="user" style="margin-right: 25px"></user-icon
-        ></a>
-
+          <user-icon [size]="80" [user]="user" style="margin-right: 25px"></user-icon>
+        </a>
         <div fxLayout="column" fxLayoutAlign="space-around start">
           <h1>{{ initialFirstName }}</h1>
           Set up your {{ externalName.value }} profile
@@ -14,20 +13,9 @@
       </div>
 
       <div fxLayout="row" fxFlexFill>
-        <!-- <mat-form-field fxFlex="25" fxFlexAlign="start" appearance="outline">
-          <mat-label>Pronouns</mat-label>
-          <mat-select [(ngModel)]="formPronouns.pronouns" name="pronouns">
-            <mat-option value="">Do not show</mat-option>
-            <mat-option value="He/Him">He/Him</mat-option>
-            <mat-option value="She/Her">She/Her</mat-option>
-            <mat-option value="They/Them">They/Them</mat-option>
-            <mat-option value="__customPronouns">Custom</mat-option>
-          </mat-select>
-        </mat-form-field>
-        <div fxFlex="3"></div> -->
         <mat-form-field fxFlexFill appearance="outline">
           <mat-label>Username</mat-label>
-          <input matInput [(ngModel)]="user.username" name="username" [disabled]="!newUser"/>
+          <input matInput [(ngModel)]="user.username" name="username" [disabled]="!newUser" />
         </mat-form-field>
       </div>
 
@@ -46,17 +34,6 @@
       </div>
 
       <div fxLayout="row" fxFlexFill>
-        <!-- <mat-form-field fxFlex="25" fxFlexAlign="start" appearance="outline">
-          <mat-label>Pronouns</mat-label>
-          <mat-select [(ngModel)]="formPronouns.pronouns" name="pronouns">
-            <mat-option value="">Do not show</mat-option>
-            <mat-option value="He/Him">He/Him</mat-option>
-            <mat-option value="She/Her">She/Her</mat-option>
-            <mat-option value="They/Them">They/Them</mat-option>
-            <mat-option value="__customPronouns">Custom</mat-option>
-          </mat-select>
-        </mat-form-field>
-        <div fxFlex="3"></div> -->
         <mat-form-field fxFlexFill appearance="outline">
           <mat-label>Preferred Name</mat-label>
           <input matInput [(ngModel)]="user.nickname" name="preferred_name" />
@@ -100,32 +77,43 @@
       </mat-form-field>
       }
 
+      <mat-form-field fxFlexFill appearance="outline">
+        <mat-label>Theme Preference (Accessability Options)</mat-label>
+        <mat-select [(ngModel)]="selectedTheme" name="theme_preference">
+          <mat-option *ngFor="let theme of themes" [value]="theme">
+            {{ theme === 'default' ? 'Default Theme' : 'Black & White' }}
+          </mat-option>
+        </mat-select>
+      </mat-form-field>
+
       <section fxLayout="column" fxFlexFill fxLayoutAlign="center start">
-        <mat-checkbox class="" color="primary" [(ngModel)]="user.receiveFeedbackNotifications" name="feedback_n"
-          >Receive notifications for new messages</mat-checkbox
-        >
+        <mat-checkbox color="primary" [(ngModel)]="user.receiveFeedbackNotifications" name="feedback_n">
+          Receive notifications for new messages
+        </mat-checkbox>
         <div fxFlex></div>
-        <mat-checkbox color="primary" [(ngModel)]="user.receivePortfolioNotifications" name="portfolio_n"
-          >Receive notifications when your portfolio is ready</mat-checkbox
-        >
+        <mat-checkbox color="primary" [(ngModel)]="user.receivePortfolioNotifications" name="portfolio_n">
+          Receive notifications when your portfolio is ready
+        </mat-checkbox>
         <div fxFlex></div>
-        <mat-checkbox fxFlex color="primary" [(ngModel)]="user.receiveTaskNotifications" name="task_n"
-          >Receive notifications when new tasks are available</mat-checkbox
-        >
+        <mat-checkbox fxFlex color="primary" [(ngModel)]="user.receiveTaskNotifications" name="task_n">
+          Receive notifications when new tasks are available
+        </mat-checkbox>
       </section>
+
       <section fxLayout="row" fxFlexFill fxLayoutAlign="start center">
-        <mat-checkbox color="primary" [(ngModel)]="user.optInToResearch" name="optin"
-          >Send anonymous research statistics
+        <mat-checkbox color="primary" [(ngModel)]="user.optInToResearch" name="optin">
+          Send anonymous research statistics
         </mat-checkbox>
       </section>
 
       @if(tiiEnabled){
       <section fxLayout="row" fxFlexFill fxLayoutAlign="start center">
-        <mat-checkbox color="primary" [(ngModel)]="user.acceptedTiiEula" [disableRipple]="true" (click)="$event.preventDefault()" name="acceptedTiiEula" disabled
-          >Acceptted TurnItIn EULA
+        <mat-checkbox color="primary" [(ngModel)]="user.acceptedTiiEula" [disableRipple]="true" (click)="$event.preventDefault()" name="acceptedTiiEula" disabled>
+          Acceptted TurnItIn EULA
         </mat-checkbox>
       </section>
       }
+
       <div fxLayout="row" fxFlexFill style="padding-top: 12px">
         <button [hidden]="mode === 'edit' || mode === 'new'" fxFlexAlign="start" type="button" mat-stroked-button (click)="signOut()">
           Sign Out

--- a/src/app/common/edit-profile-form/edit-profile-form.component.ts
+++ b/src/app/common/edit-profile-form/edit-profile-form.component.ts
@@ -36,6 +36,9 @@ export class EditProfileFormComponent implements OnInit {
   public externalName = this.constants.ExternalName;
   public initialFirstName: string;
   public formPronouns = { pronouns: '' };
+  public themes = ['default', 'black-and-white'];
+  public selectedTheme: 'default' | 'black-and-white' = 'default';
+
   public get customPronouns(): boolean {
     return this.formPronouns.pronouns === '__customPronouns';
   }
@@ -48,6 +51,9 @@ export class EditProfileFormComponent implements OnInit {
     if (this.userService.isAnonymousUser()) {
       this.state.go('sign_in');
     }
+
+    this.selectedTheme = this.user.themePreference || 'default';
+    this.applyTheme(this.selectedTheme);
 
     this.user.optInToResearch = false;
     this.user.receiveFeedbackNotifications = true;
@@ -78,9 +84,16 @@ export class EditProfileFormComponent implements OnInit {
     return this.constants.IsTiiEnabled.value;
   }
 
+  public applyTheme(theme: 'default' | 'black-and-white'): void {
+    document.body.classList.remove('theme-default', 'theme-black-and-white');
+    document.body.classList.add(`theme-${theme}`);
+  }
+
   public submit(): void {
     this.user.pronouns = this.customPronouns ? this.user.pronouns : this.formPronouns.pronouns;
     this.user.hasRunFirstTimeSetup = true;
+    this.user.themePreference = this.selectedTheme;
+    this.applyTheme(this.selectedTheme);
 
     if (this.newUser) {
       this.userService.create(this.user).subscribe({

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -35,3 +35,86 @@
     }
   }
 }
+
+body.theme-black-and-white {
+  background-color: #ffffff;
+  color: #000000;
+
+  .mat-mdc-form-field,
+  .mat-mdc-input-element,
+  .mat-mdc-select,
+  .mat-mdc-option,
+  .mat-mdc-button,
+  .mat-mdc-raised-button,
+  .mat-mdc-flat-button {
+    background-color: #ffffff !important;
+    color: #000000 !important;
+  }
+
+  .mat-mdc-form-field-outline,
+  .mdc-notched-outline {
+    border-color: #000000 !important;
+  }
+
+  .mat-mdc-checkbox .mdc-checkbox__background {
+    border-color: #000000 !important;
+  }
+
+  .mat-mdc-checkbox .mdc-checkbox__checkmark-path {
+    stroke: #000000 !important;
+  }
+
+  .mat-mdc-button,
+  .mat-mdc-raised-button,
+  .mat-mdc-flat-button {
+    background-color: #eeeeee !important;
+    color: #000000 !important;
+  }
+
+  .mat-mdc-snack-bar-container {
+    background-color: #000000 !important;
+    color: #ffffff !important;
+  }
+
+  .mat-mdc-option.mat-mdc-selected {
+    background-color: #e0e0e0 !important;
+  }
+
+  .mat-mdc-option:hover {
+    background-color: #f0f0f0 !important;
+  }
+
+  .mat-mdc-label {
+    color: #000000 !important;
+  }
+
+  .mat-mdc-form-field-subscript-wrapper,
+  .mat-mdc-hint {
+    color: #666666 !important;
+  }
+  .cdk-overlay-container,
+.cdk-overlay-pane {
+  background-color: transparent !important;
+  color: #000000 !important;
+}
+
+.mat-mdc-select-panel {
+  background-color: #ffffff !important;
+  color: #000000 !important;
+  border: 1px solid #000000 !important;
+}
+
+.mat-mdc-option {
+  background-color: #ffffff !important;
+  color: #000000 !important;
+}
+
+.mat-mdc-option:hover {
+  background-color: #f0f0f0 !important;
+}
+
+.mat-mdc-option.mat-mdc-selected {
+  background-color: #e0e0e0 !important;
+  font-weight: 600;
+}
+}


### PR DESCRIPTION
# Description

This is a POC for the front end changes of colour vision accessability feature. There is a drop down menu under /edit_profile that switches themes between default, and black and white themes. we use the !important tag here to force css changes which while not elegant does soft an issue which is that style changes happen _everywhere_ 

documentation for this change have been pushed to astero and can be found https://github.com/thoth-tech/doubtfire-astro/pull/39 if not already merged 

Fixes # (issue)

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

pull down branch, navigate to /edit_profile as a user or staff, see drop down menu in same styling as rest of the page. note functionality relating to session persistance won't work until doubtfire-api pr is merged into branch 

## Testing Checklist:

- [x] Tested in latest Chrome
- [ ] Tested in latest Safari
- [x] Tested in latest Firefox

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have requested a review from @macite and @jakerenzella on the Pull Request
