### PR TITLE
Fix: enable unit name text wrapping

### DIFF
--- a/src/app/home/states/home/home.component.scss
+++ b/src/app/home/states/home/home.component.scss
@@ -42,8 +42,8 @@
 
   .f-card-title {
     font-size: 18px;
-    max-height: 30px;
-    white-space: nowrap;
+    min-height: 65px; // Ensures consistent card height while allowing text to wrap
+    white-space: wrap;
     text-overflow: ellipsis;
     width: 100%;
     overflow: hidden;


### PR DESCRIPTION
# Description

Increases the `min-height` of the card titles to support text wrapping for units with long titles, while also maintaining consistent card heights.

Before:
![image](https://github.com/user-attachments/assets/8bbd9752-22e0-405e-b800-f4aaa283abff)

After:
![image](https://github.com/user-attachments/assets/eb6dc5b1-3a7f-4727-a604-00721b39d6e4)
