### PR TITLE
chore: update service worker font handling

### DIFF
--- a/ngsw-config.json
+++ b/ngsw-config.json
@@ -1,8 +1,7 @@
 {
   "$schema": "./node_modules/@angular/service-worker/config/schema.json",
   "index": "/index.html",
-  "dataGroups":
-  [
+  "dataGroups": [
     {
       "name": "api",
       "urls": ["/api"],
@@ -11,6 +10,16 @@
         "maxAge": "0u",
         "strategy": "freshness"
       }
+    },
+    {
+      "name": "google-fonts-cache",
+      "urls": ["https://fonts.gstatic.com/**"],
+      "cacheConfig": {
+        "strategy": "freshness",
+        "maxSize": 10,
+        "maxAge": "7d",
+        "timeout": "5s"
+      }
     }
   ],
   "assetGroups": [
@@ -18,15 +27,10 @@
       "name": "app",
       "installMode": "prefetch",
       "resources": {
-        "files": [
-          "/favicon.ico",
-          "/index.html",
-          "/manifest.webmanifest",
-          "/*.css",
-          "/*.js"
-        ]
+        "files": ["/favicon.ico", "/index.html", "/manifest.webmanifest", "/*.css", "/*.js"]
       }
-    }, {
+    },
+    {
       "name": "assets",
       "installMode": "lazy",
       "updateMode": "prefetch",
@@ -36,12 +40,12 @@
           "/*.(eot|svg|cur|jpg|png|png?default=blank&size=25webp|gif|otf|ttf|woff|woff2|ani)"
         ]
       }
-    }, {
+    },
+    {
       "name": "external_assets",
       "resources": {
         "urls": [
           "https://maxcdn.bootstrapcdn.com/bootstrap/**",
-          "https://fonts.googleapis.com/**",
           "https://www.gravatar.com/avatar/**"
         ]
       }


### PR DESCRIPTION
Attempt to address issue with DLI loading of fonts. This should allow the service working to load these now.

Currently the service worker fails to load these fonts on reload for the DLI installation. This should allow the client to access these as required.