### PR TITLE
feat: migrate to jplag report viewer v6.3.0

### DIFF
--- a/src/app/projects/states/jplag/jplag-report-viewer.component.html
+++ b/src/app/projects/states/jplag/jplag-report-viewer.component.html
@@ -1,7 +1,6 @@
 <iframe
   [hidden]="hidden"
   #jplagIframe
-  src="/JPlag/"
   frameborder="0"
   style="overflow: hidden"
   class="w-full h-screen overflow-hidden"

--- a/src/app/projects/states/jplag/jplag-report-viewer.component.ts
+++ b/src/app/projects/states/jplag/jplag-report-viewer.component.ts
@@ -17,7 +17,7 @@ export class JplagReportViewerComponent {
     this.jplagIframe.nativeElement.src = `/JPlag/?file=${encodeURIComponent(blobUrl)}`;
   }
 
-  public openComparison(first: string, second: string) {
+  public openComparison(firstSubmissionId: string, secondSubmissionId: string) {
     const iframe = this.jplagIframe.nativeElement;
 
     const tryClick = () => {
@@ -25,8 +25,10 @@ export class JplagReportViewerComponent {
       if (!doc) return false;
 
       const el =
-        doc.querySelector(`a[href="/JPlag/comparison/${first}/${second}"]`) ||
-        doc.querySelector(`a[href="/JPlag/comparison/${second}/${first}"]`);
+        doc.querySelector(
+          `a[href="/JPlag/comparison/${firstSubmissionId}/${secondSubmissionId}"]`,
+        ) ||
+        doc.querySelector(`a[href="/JPlag/comparison/${secondSubmissionId}/${firstSubmissionId}"]`);
 
       if (el) {
         (el as HTMLElement).click();

--- a/src/app/projects/states/jplag/jplag-report-viewer.component.ts
+++ b/src/app/projects/states/jplag/jplag-report-viewer.component.ts
@@ -1,4 +1,5 @@
 import {Component, ElementRef, Input, ViewChild} from '@angular/core';
+import {AlertService} from 'src/app/common/services/alert.service';
 
 @Component({
   selector: 'f-jplag-report-viewer',
@@ -9,21 +10,46 @@ export class JplagReportViewerComponent {
 
   @Input() hidden: boolean = false;
 
+  constructor(private alertService: AlertService) {}
+
   public uploadReport(file: Blob) {
-    // Send the JPlag report to load
-    this.jplagIframe.nativeElement.contentWindow?.postMessage({
-      type: 'upload-jplag-report',
-      file: file,
-      name: 'report.jplag',
-    });
+    const blobUrl = URL.createObjectURL(file);
+    this.jplagIframe.nativeElement.src = `/JPlag/?file=${encodeURIComponent(blobUrl)}`;
   }
 
-  public openComparison(firstSubmissionId: string, secondSubmissionId: string) {
-    // Open comparisons between these two submissions (student usernames)
-    this.jplagIframe.nativeElement.contentWindow?.postMessage({
-      type: 'open-comparison',
-      firstSubmissionId,
-      secondSubmissionId,
-    });
+  public openComparison(first: string, second: string) {
+    const iframe = this.jplagIframe.nativeElement;
+
+    const tryClick = () => {
+      const doc = iframe.contentDocument;
+      if (!doc) return false;
+
+      const el =
+        doc.querySelector(`a[href="/JPlag/comparison/${first}/${second}"]`) ||
+        doc.querySelector(`a[href="/JPlag/comparison/${second}/${first}"]`);
+
+      if (el) {
+        (el as HTMLElement).click();
+        return true;
+      }
+
+      return false;
+    };
+
+    // Attempt to find the Vue component for 5 seconds
+    let elapsed = 0;
+    const interval = setInterval(() => {
+      if (tryClick()) {
+        clearInterval(interval);
+        return;
+      }
+
+      elapsed += 50;
+
+      if (elapsed >= 5000) {
+        clearInterval(interval);
+        this.alertService.error('Could not open JPlag comparison.', 6000);
+      }
+    }, 50);
   }
 }


### PR DESCRIPTION
- moves away from the modified jplag report viewer code
- we can now build our own JPlag report viewer from source

Steps to build report viewer:
- Edit [src/version.json](https://github.com/jplag/JPlag/blob/508e92605827d8ff3319fa9480c964a188c7f5b8/report-viewer/report-viewer/src/version/version.json) and change to 6.3.0 (or whatever the current is version)
- Run `npm run build -- --mode prod`
- Copy dist/** contents to https://github.com/doubtfire-lms/jplag-report-viewer-static