### PR TITLE
Tutor effort input

### DIFF
--- a/src/app/api/models/task-definition.ts
+++ b/src/app/api/models/task-definition.ts
@@ -17,6 +17,8 @@ export class TaskDefinition extends Entity {
   name: string;
   description: string;
   weighting: number;
+  estimated_days: number = null;
+  estimated_hours: number = null;
   targetGrade: number;
   targetDate: Date;
   dueDate: Date;
@@ -56,7 +58,7 @@ export class TaskDefinition extends Entity {
    */
   public save(): Observable<TaskDefinition> {
     const svc = AppInjector.get(TaskDefinitionService);
-
+    console.log(this);
     if (this.isNew) {
       // TODO: add progress modal
       return svc.create(

--- a/src/app/api/models/task-definition.ts
+++ b/src/app/api/models/task-definition.ts
@@ -58,7 +58,6 @@ export class TaskDefinition extends Entity {
    */
   public save(): Observable<TaskDefinition> {
     const svc = AppInjector.get(TaskDefinitionService);
-    console.log(this);
     if (this.isNew) {
       // TODO: add progress modal
       return svc.create(

--- a/src/app/api/services/task-definition.service.ts
+++ b/src/app/api/services/task-definition.service.ts
@@ -20,6 +20,8 @@ export class TaskDefinitionService extends CachedEntityService<TaskDefinition> {
       'name',
       'description',
       'weighting',
+      'estimated_days',
+      'estimated_hours',
       'targetGrade',
       'mossLanguage',
       {

--- a/src/app/units/states/edit/directives/unit-tasks-editor/task-definition-editor/task-definition-general/task-definition-general.component.html
+++ b/src/app/units/states/edit/directives/unit-tasks-editor/task-definition-editor/task-definition-general/task-definition-general.component.html
@@ -28,3 +28,31 @@
   <mat-label>Task description</mat-label>
   <textarea matInput [(ngModel)]="taskDefinition.description" required> </textarea>
 </mat-form-field>
+
+<div class="space-y-2">
+  <div>Expected duration</div>
+  <div class="flex gap-2">
+    <mat-form-field appearance="outline" class="flex flex-grow">
+      <mat-label>Days</mat-label>
+      <input
+        matInput
+        type="number"
+        placeholder="0"
+        [(ngModel)]="taskDefinition.estimated_days"
+        [min]="0"
+      />
+    </mat-form-field>
+
+    <mat-form-field appearance="outline" class="flex flex-grow">
+      <mat-label>Hours</mat-label>
+      <input
+        matInput
+        type="number"
+        placeholder="0"
+        [(ngModel)]="taskDefinition.estimated_hours"
+        [min]="0"
+        [max]="23"
+      />
+    </mat-form-field>
+  </div>
+</div>


### PR DESCRIPTION
# Description

Adds estimated days and hours inputs to task definition form. Frontend sends and receives successfully to and from the backend.

<img width="1481" height="648" alt="image" src="https://github.com/user-attachments/assets/85241914-7aa3-4b20-b498-809369f2f331" />


Fixes # (issue)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Manually test that data is stored in the database when post/put request made on task definition. Also manually confirm that the  saved data is displayed correctly to the user when the page has been reloaded/visited again in the future.

## Testing Checklist:

- [x] Tested in latest Chrome
- [ ] Tested in latest Safari
- [ ] Tested in latest Firefox

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
