### PR TITLE
feat(peer-progress): add peer progress page and Anonymized Peers

### DIFF
--- a/src/app/api/services/peer-progress.service.ts
+++ b/src/app/api/services/peer-progress.service.ts
@@ -1,0 +1,66 @@
+import { Injectable } from '@angular/core';
+import { Project } from 'src/app/api/models/doubtfire-model';
+
+export interface PeerProgressSummary {
+  cohortAverage: number;
+  yourProgress: number;
+  peersAhead: number;
+  strongestProgress: number;
+  totalPeers: number;
+  yourAlias: string;
+}
+
+export interface AnonymizedPeerProgress {
+  alias: string;
+  progress: number;
+  bandLabel: string;
+  isCurrentStudent: boolean;
+}
+
+@Injectable({
+  providedIn: 'root',
+})
+export class PeerProgressService {
+  private readonly sampleProgress = [92, 88, 84, 81, 78, 75, 72, 69];
+
+  getSummary(project?: Project): PeerProgressSummary {
+    const peers = this.getAnonymizedPeers(project);
+    const currentPeer = peers.find((peer) => peer.isCurrentStudent) ?? peers[0];
+    const strongestProgress = Math.max(...peers.map((peer) => peer.progress));
+    const cohortAverage = Math.round(
+      peers.reduce((total, peer) => total + peer.progress, 0) / peers.length,
+    );
+
+    return {
+      cohortAverage,
+      yourProgress: currentPeer.progress,
+      peersAhead: peers.filter((peer) => peer.progress > currentPeer.progress).length,
+      strongestProgress,
+      totalPeers: peers.length,
+      yourAlias: currentPeer.alias,
+    };
+  }
+
+  getAnonymizedPeers(project?: Project): AnonymizedPeerProgress[] {
+    const offset = (project?.id ?? 0) % this.sampleProgress.length;
+    const currentIndex = offset % this.sampleProgress.length;
+
+    return this.sampleProgress.map((_, index) => {
+      const progress = this.sampleProgress[(index + offset) % this.sampleProgress.length];
+
+      return {
+        alias: `Peer ${String(index + 1).padStart(2, '0')}`,
+        progress,
+        bandLabel: this.toBandLabel(progress),
+        isCurrentStudent: index === currentIndex,
+      };
+    });
+  }
+
+  private toBandLabel(progress: number): string {
+    if (progress >= 85) return 'Leading';
+    if (progress >= 75) return 'On Track';
+    if (progress >= 65) return 'Building';
+    return 'Needs Support';
+  }
+}

--- a/src/app/api/services/peer-progress.service.ts
+++ b/src/app/api/services/peer-progress.service.ts
@@ -1,5 +1,8 @@
+import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
+import { map, Observable } from 'rxjs';
 import { Project } from 'src/app/api/models/doubtfire-model';
+import API_URL from 'src/app/config/constants/apiURL';
 
 export interface PeerProgressSummary {
   cohortAverage: number;
@@ -17,14 +20,31 @@ export interface AnonymizedPeerProgress {
   isCurrentStudent: boolean;
 }
 
+interface PeerProgressApiResponse {
+  alias: string;
+  progress: number;
+  band_label: string;
+  is_current_student: boolean;
+}
+
 @Injectable({
   providedIn: 'root',
 })
 export class PeerProgressService {
-  private readonly sampleProgress = [92, 88, 84, 81, 78, 75, 72, 69];
+  constructor(private httpClient: HttpClient) {}
 
-  getSummary(project?: Project): PeerProgressSummary {
-    const peers = this.getAnonymizedPeers(project);
+  getSummaryFromPeers(peers: AnonymizedPeerProgress[]): PeerProgressSummary {
+    if (peers.length === 0) {
+      return {
+        cohortAverage: 0,
+        yourProgress: 0,
+        peersAhead: 0,
+        strongestProgress: 0,
+        totalPeers: 0,
+        yourAlias: 'Peer 01',
+      };
+    }
+
     const currentPeer = peers.find((peer) => peer.isCurrentStudent) ?? peers[0];
     const strongestProgress = Math.max(...peers.map((peer) => peer.progress));
     const cohortAverage = Math.round(
@@ -41,26 +61,18 @@ export class PeerProgressService {
     };
   }
 
-  getAnonymizedPeers(project?: Project): AnonymizedPeerProgress[] {
-    const offset = (project?.id ?? 0) % this.sampleProgress.length;
-    const currentIndex = offset % this.sampleProgress.length;
-
-    return this.sampleProgress.map((_, index) => {
-      const progress = this.sampleProgress[(index + offset) % this.sampleProgress.length];
-
-      return {
-        alias: `Peer ${String(index + 1).padStart(2, '0')}`,
-        progress,
-        bandLabel: this.toBandLabel(progress),
-        isCurrentStudent: index === currentIndex,
-      };
-    });
-  }
-
-  private toBandLabel(progress: number): string {
-    if (progress >= 85) return 'Leading';
-    if (progress >= 75) return 'On Track';
-    if (progress >= 65) return 'Building';
-    return 'Needs Support';
+  getAnonymizedPeers(project?: Project): Observable<AnonymizedPeerProgress[]> {
+    return this.httpClient
+      .get<PeerProgressApiResponse[]>(`${API_URL}/projects/${project?.id}/peer_progress`)
+      .pipe(
+        map((peers) =>
+          peers.map((peer) => ({
+            alias: peer.alias,
+            progress: peer.progress,
+            bandLabel: peer.band_label,
+            isCurrentStudent: peer.is_current_student,
+          })),
+        ),
+      );
   }
 }

--- a/src/app/common/header/task-dropdown/task-dropdown.component.html
+++ b/src/app/common/header/task-dropdown/task-dropdown.component.html
@@ -96,6 +96,15 @@
           <mat-icon aria-label="Tutorial List icon" fontIcon="meeting_room"></mat-icon> Tutorial
           List
         </button>
+        <mat-divider></mat-divider>
+        <button
+          uiSref="projects/peer-progress"
+          [uiParams]="{projectId: currentProject.id}"
+          mat-menu-item
+        >
+          <mat-icon aria-label="Peer Progress icon" fontIcon="insights"></mat-icon>
+          Peer Progress
+        </button>
       }
       @if (unitRole && currentView === 'UNIT') {
         <!-- <p class="task-dropdown-heading">Tasks</p> -->
@@ -114,11 +123,7 @@
         </button>
         <mat-divider></mat-divider>
         <!-- <p class="task-dropdown-heading">Students</p> -->
-        <button
-          uiSref="units/students/list"
-          [uiParams]="{unitId: unitRole.unit.id}"
-          mat-menu-item
-        >
+        <button uiSref="units/students/list" [uiParams]="{unitId: unitRole.unit.id}" mat-menu-item>
           <mat-icon aria-label="Students list" fontIcon="group"></mat-icon> Students
         </button>
         <button
@@ -133,10 +138,7 @@
           [uiParams]="{unitId: unitRole.unit.id}"
           mat-menu-item
         >
-          <mat-icon
-            aria-label="Student portfolios icon"
-            fontIcon="collections_bookmark"
-          ></mat-icon>
+          <mat-icon aria-label="Student portfolios icon" fontIcon="collections_bookmark"></mat-icon>
           Portfolios
         </button>
         <mat-divider></mat-divider>
@@ -144,7 +146,9 @@
         <button uiSref="units/analytics" [uiParams]="{unitId: unitRole.unit.id}" mat-menu-item>
           <mat-icon aria-label="Unit Analytics icon" fontIcon="insights"></mat-icon>Analytics
         </button>
-        @if (unitRole.role === 'Convenor' || unitRole.role === 'Admin' || unitRole.role === 'Auditor') {
+        @if (
+          unitRole.role === 'Convenor' || unitRole.role === 'Admin' || unitRole.role === 'Auditor'
+        ) {
           <button uiSref="units/admin" [uiParams]="{unitId: unitRole.unit.id}" mat-menu-item>
             <mat-icon aria-label="Unit Administration" fontIcon="admin_panel_settings"></mat-icon>
             Administration

--- a/src/app/doubtfire-angular.module.ts
+++ b/src/app/doubtfire-angular.module.ts
@@ -194,6 +194,8 @@ import {ProjectProgressBarComponent} from './common/project-progress-bar/project
 import {TeachingPeriodListComponent} from './admin/states/teaching-periods/teaching-period-list/teaching-period-list.component';
 import {FChipComponent} from './common/f-chip/f-chip.component';
 import {TaskSimilarityViewComponent} from './projects/states/dashboard/directives/task-dashboard/directives/task-similarity-view/task-similarity-view.component';
+import {PeerProgressComponent} from './projects/states/peer-progress/peer-progress.component';
+import {PeersAnonymizedComponent} from './projects/states/peer-progress/peers-anonymized/peers-anonymized.component';
 import {FileViewerComponent} from './common/file-viewer/file-viewer.component';
 import {TaskDefinitionEditorComponent} from './units/states/edit/directives/unit-tasks-editor/task-definition-editor/task-definition-editor.component';
 import {TaskDefinitionGeneralComponent} from './units/states/edit/directives/unit-tasks-editor/task-definition-editor/task-definition-general/task-definition-general.component';
@@ -281,6 +283,8 @@ import {GradeService} from './common/services/grade.service';
     PdfViewerPanelComponent,
     StaffTaskListComponent,
     TaskSimilarityViewComponent,
+    PeerProgressComponent,
+    PeersAnonymizedComponent,
     FiltersPipe,
     TasksOfTaskDefinitionPipe,
     TasksInTutorialsPipe,

--- a/src/app/doubtfire-angularjs.module.ts
+++ b/src/app/doubtfire-angularjs.module.ts
@@ -73,6 +73,8 @@ import 'build/src/app/projects/states/dashboard/directives/directives.js';
 import 'build/src/app/projects/states/dashboard/directives/task-dashboard/task-dashboard.js';
 import 'build/src/app/projects/states/dashboard/dashboard.js';
 import 'build/src/app/projects/states/outcomes/outcomes.js';
+import 'build/src/app/projects/states/peer-progress/peer-progress.js';
+import 'build/src/app/projects/states/peer-progress/peers-anonymized/peers-anonymized.js';
 import 'build/src/app/projects/states/portfolio/directives/portfolio-review-step/portfolio-review-step.js';
 import 'build/src/app/projects/states/portfolio/directives/portfolio-learning-summary-report-step/portfolio-learning-summary-report-step.js';
 import 'build/src/app/projects/states/portfolio/directives/portfolio-add-extra-files-step/portfolio-add-extra-files-step.js';
@@ -208,6 +210,8 @@ import {TaskStatusCardComponent} from './projects/states/dashboard/directives/ta
 import {TaskDueCardComponent} from './projects/states/dashboard/directives/task-dashboard/directives/task-due-card/task-due-card.component';
 import {FooterComponent} from './common/footer/footer.component';
 import {TaskAssessmentCardComponent} from './projects/states/dashboard/directives/task-dashboard/directives/task-assessment-card/task-assessment-card.component';
+import {PeerProgressComponent} from './projects/states/peer-progress/peer-progress.component';
+import {PeersAnonymizedComponent} from './projects/states/peer-progress/peers-anonymized/peers-anonymized.component';
 import {TaskSubmissionCardComponent} from './projects/states/dashboard/directives/task-dashboard/directives/task-submission-card/task-submission-card.component';
 import {InboxComponent} from './units/states/tasks/inbox/inbox.component';
 import {TaskDefinitionEditorComponent} from './units/states/edit/directives/unit-tasks-editor/task-definition-editor/task-definition-editor.component';
@@ -380,6 +384,14 @@ DoubtfireAngularJSModule.directive('fUsers', downgradeComponent({component: FUse
 DoubtfireAngularJSModule.directive(
   'fTaskAssessmentCard',
   downgradeComponent({component: TaskAssessmentCardComponent}),
+);
+DoubtfireAngularJSModule.directive(
+  'fPeerProgress',
+  downgradeComponent({component: PeerProgressComponent}),
+);
+DoubtfireAngularJSModule.directive(
+  'fPeersAnonymized',
+  downgradeComponent({component: PeersAnonymizedComponent}),
 );
 DoubtfireAngularJSModule.directive(
   'institutionSettings',

--- a/src/app/projects/states/peer-progress/peer-progress.coffee
+++ b/src/app/projects/states/peer-progress/peer-progress.coffee
@@ -1,0 +1,16 @@
+angular.module('doubtfire.projects.states.peer-progress', [])
+
+#
+# Peer progress state for projects
+#
+.config(($stateProvider) ->
+  $stateProvider.state 'projects/peer-progress', {
+    parent: 'projects/index'
+    url: '/peer-progress'
+    templateUrl: 'projects/states/peer-progress/peer-progress.tpl.html'
+    data:
+      task: "Peer Progress"
+      pageTitle: "_Home_"
+      roleWhitelist: ['Tutor', 'Convenor', 'Admin', 'Student', 'Auditor']
+   }
+)

--- a/src/app/projects/states/peer-progress/peer-progress.component.html
+++ b/src/app/projects/states/peer-progress/peer-progress.component.html
@@ -1,0 +1,46 @@
+<div class="peer-progress-page">
+  <div class="peer-progress-card">
+    <p class="peer-progress-eyebrow">Peer Progress</p>
+    <h1>{{ project?.unit?.name || 'Current Unit' }}</h1>
+    <p class="peer-progress-copy">
+      This sample view compares your project progress with the wider cohort using anonymized peer
+      data.
+    </p>
+
+    <div class="peer-progress-summary" *ngIf="summary">
+      <div class="peer-progress-metric">
+        <span class="metric-label">Your anonymized profile</span>
+        <strong>{{ summary.yourAlias }} (You)</strong>
+      </div>
+      <div class="peer-progress-metric">
+        <span class="metric-label">Cohort average</span>
+        <strong>{{ summary.cohortAverage }}%</strong>
+      </div>
+      <div class="peer-progress-metric">
+        <span class="metric-label">Peers ahead</span>
+        <strong>{{ summary.peersAhead }} of {{ summary.totalPeers }}</strong>
+      </div>
+      <div class="peer-progress-metric">
+        <span class="metric-label">Highest sample progress</span>
+        <strong>{{ summary.strongestProgress }}%</strong>
+      </div>
+    </div>
+
+    <div class="progress-panel" *ngIf="summary">
+      <div class="progress-panel-heading">
+        <div>
+          <h2>Sample Peer Progress Bar</h2>
+          <p>Current progress for your anonymized peer profile.</p>
+        </div>
+        <strong>{{ summary.yourProgress }}%</strong>
+      </div>
+      <mat-progress-bar mode="determinate" [value]="summary.yourProgress"></mat-progress-bar>
+    </div>
+
+    <div class="peer-progress-actions">
+      <button mat-flat-button color="primary" (click)="goToAnonymizedPeers()">
+        View Anonymized Peer Progress
+      </button>
+    </div>
+  </div>
+</div>

--- a/src/app/projects/states/peer-progress/peer-progress.component.html
+++ b/src/app/projects/states/peer-progress/peer-progress.component.html
@@ -3,8 +3,7 @@
     <p class="peer-progress-eyebrow">Peer Progress</p>
     <h1>{{ project?.unit?.name || 'Current Unit' }}</h1>
     <p class="peer-progress-copy">
-      This sample view compares your project progress with the wider cohort using anonymized peer
-      data.
+      This view compares your project progress with the wider cohort using anonymized peer data.
     </p>
 
     <div class="peer-progress-summary" *ngIf="summary">
@@ -29,7 +28,7 @@
     <div class="progress-panel" *ngIf="summary">
       <div class="progress-panel-heading">
         <div>
-          <h2>Sample Peer Progress Bar</h2>
+          <h2>Peer Progress Bar</h2>
           <p>Current progress for your anonymized peer profile.</p>
         </div>
         <strong>{{ summary.yourProgress }}%</strong>

--- a/src/app/projects/states/peer-progress/peer-progress.component.scss
+++ b/src/app/projects/states/peer-progress/peer-progress.component.scss
@@ -1,0 +1,101 @@
+.peer-progress-page {
+  padding: 16px;
+}
+
+.peer-progress-card {
+  background: #fff;
+  border: 1px solid #e5e7eb;
+  border-radius: 12px;
+  box-shadow: 0 8px 24px rgba(15, 23, 42, 0.08);
+  margin: 0 auto;
+  max-width: 960px;
+  padding: 24px;
+}
+
+.peer-progress-eyebrow {
+  color: #2563eb;
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  margin: 0 0 8px;
+  text-transform: uppercase;
+}
+
+.peer-progress-card h1 {
+  color: #111827;
+  font-size: 28px;
+  margin: 0 0 16px;
+}
+
+.peer-progress-copy {
+  color: #4b5563;
+  font-size: 16px;
+  line-height: 1.5;
+  margin: 0 0 12px;
+}
+
+.peer-progress-summary {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  margin: 24px 0;
+}
+
+.peer-progress-metric {
+  background: #f8fafc;
+  border: 1px solid #e5e7eb;
+  border-radius: 12px;
+  padding: 16px;
+}
+
+.metric-label {
+  color: #64748b;
+  display: block;
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  margin-bottom: 8px;
+  text-transform: uppercase;
+}
+
+.peer-progress-metric strong {
+  color: #0f172a;
+  font-size: 18px;
+}
+
+.progress-panel {
+  background: linear-gradient(135deg, #eff6ff, #f8fafc);
+  border-radius: 12px;
+  margin-top: 24px;
+  padding: 20px;
+}
+
+.progress-panel-heading {
+  align-items: flex-start;
+  display: flex;
+  gap: 16px;
+  justify-content: space-between;
+  margin-bottom: 16px;
+}
+
+.progress-panel-heading h2 {
+  color: #0f172a;
+  font-size: 20px;
+  margin: 0 0 4px;
+}
+
+.progress-panel-heading p {
+  color: #475569;
+  margin: 0;
+}
+
+.progress-panel-heading strong {
+  color: #1d4ed8;
+  font-size: 24px;
+}
+
+.peer-progress-actions {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 24px;
+}

--- a/src/app/projects/states/peer-progress/peer-progress.component.ts
+++ b/src/app/projects/states/peer-progress/peer-progress.component.ts
@@ -1,20 +1,24 @@
-import { Component, Inject, Input, OnInit } from '@angular/core';
+import { Component, Inject, Input, OnDestroy, OnInit } from '@angular/core';
 import { UIRouter } from '@uirouter/angular';
 import { Project } from 'src/app/api/models/doubtfire-model';
 import {
+  AnonymizedPeerProgress,
   PeerProgressService,
   PeerProgressSummary,
 } from 'src/app/api/services/peer-progress.service';
+import { Subscription } from 'rxjs';
 
 @Component({
   selector: 'f-peer-progress',
   templateUrl: './peer-progress.component.html',
   styleUrls: ['./peer-progress.component.scss'],
 })
-export class PeerProgressComponent implements OnInit {
+export class PeerProgressComponent implements OnInit, OnDestroy {
   @Input() project: Project;
 
+  peers: AnonymizedPeerProgress[] = [];
   summary: PeerProgressSummary;
+  private peerProgressSubscription?: Subscription;
 
   constructor(
     @Inject(UIRouter) private router: UIRouter,
@@ -22,7 +26,16 @@ export class PeerProgressComponent implements OnInit {
   ) {}
 
   ngOnInit(): void {
-    this.summary = this.peerProgressService.getSummary(this.project);
+    this.peerProgressSubscription = this.peerProgressService.getAnonymizedPeers(this.project).subscribe({
+      next: (peers) => {
+        this.peers = peers;
+        this.summary = this.peerProgressService.getSummaryFromPeers(peers);
+      },
+    });
+  }
+
+  ngOnDestroy(): void {
+    this.peerProgressSubscription?.unsubscribe();
   }
 
   goToAnonymizedPeers(): void {

--- a/src/app/projects/states/peer-progress/peer-progress.component.ts
+++ b/src/app/projects/states/peer-progress/peer-progress.component.ts
@@ -1,0 +1,33 @@
+import { Component, Inject, Input, OnInit } from '@angular/core';
+import { UIRouter } from '@uirouter/angular';
+import { Project } from 'src/app/api/models/doubtfire-model';
+import {
+  PeerProgressService,
+  PeerProgressSummary,
+} from 'src/app/api/services/peer-progress.service';
+
+@Component({
+  selector: 'f-peer-progress',
+  templateUrl: './peer-progress.component.html',
+  styleUrls: ['./peer-progress.component.scss'],
+})
+export class PeerProgressComponent implements OnInit {
+  @Input() project: Project;
+
+  summary: PeerProgressSummary;
+
+  constructor(
+    @Inject(UIRouter) private router: UIRouter,
+    private peerProgressService: PeerProgressService,
+  ) {}
+
+  ngOnInit(): void {
+    this.summary = this.peerProgressService.getSummary(this.project);
+  }
+
+  goToAnonymizedPeers(): void {
+    this.router.stateService.go('projects/peers-anonymized', {
+      projectId: this.project?.id,
+    });
+  }
+}

--- a/src/app/projects/states/peer-progress/peer-progress.tpl.html
+++ b/src/app/projects/states/peer-progress/peer-progress.tpl.html
@@ -1,0 +1,1 @@
+<f-peer-progress [project]="project"></f-peer-progress>

--- a/src/app/projects/states/peer-progress/peers-anonymized/peers-anonymized.coffee
+++ b/src/app/projects/states/peer-progress/peers-anonymized/peers-anonymized.coffee
@@ -1,0 +1,16 @@
+angular.module('doubtfire.projects.states.peers-anonymized', [])
+
+#
+# Anonymized peer progress state for projects
+#
+.config(($stateProvider) ->
+  $stateProvider.state 'projects/peers-anonymized', {
+    parent: 'projects/index'
+    url: '/peer-progress/anonymized'
+    templateUrl: 'projects/states/peer-progress/peers-anonymized/peers-anonymized.tpl.html'
+    data:
+      task: "Peer Progress"
+      pageTitle: "_Home_"
+      roleWhitelist: ['Tutor', 'Convenor', 'Admin', 'Student', 'Auditor']
+   }
+)

--- a/src/app/projects/states/peer-progress/peers-anonymized/peers-anonymized.component.html
+++ b/src/app/projects/states/peer-progress/peers-anonymized/peers-anonymized.component.html
@@ -5,14 +5,31 @@
         <p class="page-eyebrow">Anonymized Cohort View</p>
         <h1>Individual Peer Progress</h1>
         <p>
-          Student identities are hidden. Each learner is shown as an anonymized peer label with a
-          sample progress value.
+          Student identities are hidden. Each learner is shown as an anonymized peer label with
+          real progress data from this unit.
         </p>
       </div>
       <button mat-stroked-button (click)="goBack()">Back to Peer Progress</button>
     </div>
 
-    <div class="peer-row" *ngFor="let peer of peers">
+    <div class="pagination-toolbar" *ngIf="peers.length > 0">
+      <span>Showing {{ startPeerIndex }}-{{ endPeerIndex }} of {{ peers.length }} peers</span>
+      <div class="pagination-actions">
+        <button mat-stroked-button (click)="previousPage()" [disabled]="currentPage === 0">
+          Previous
+        </button>
+        <span>Page {{ currentPage + 1 }} of {{ totalPages }}</span>
+        <button
+          mat-flat-button
+          color="primary"
+          (click)="nextPage()"
+          [disabled]="currentPage >= totalPages - 1">
+          Next
+        </button>
+      </div>
+    </div>
+
+    <div class="peer-row" *ngFor="let peer of paginatedPeers">
       <div class="peer-copy">
         <strong>{{ peer.alias }}<span *ngIf="peer.isCurrentStudent"> (You)</span></strong>
         <span>{{ peer.bandLabel }}</span>
@@ -22,5 +39,7 @@
       </div>
       <div class="peer-value">{{ peer.progress }}%</div>
     </div>
+
+    <p class="empty-state" *ngIf="peers.length === 0">No peer progress data is available right now.</p>
   </div>
 </div>

--- a/src/app/projects/states/peer-progress/peers-anonymized/peers-anonymized.component.html
+++ b/src/app/projects/states/peer-progress/peers-anonymized/peers-anonymized.component.html
@@ -1,0 +1,26 @@
+<div class="peers-anonymized-page">
+  <div class="peers-anonymized-card">
+    <div class="page-header">
+      <div>
+        <p class="page-eyebrow">Anonymized Cohort View</p>
+        <h1>Individual Peer Progress</h1>
+        <p>
+          Student identities are hidden. Each learner is shown as an anonymized peer label with a
+          sample progress value.
+        </p>
+      </div>
+      <button mat-stroked-button (click)="goBack()">Back to Peer Progress</button>
+    </div>
+
+    <div class="peer-row" *ngFor="let peer of peers">
+      <div class="peer-copy">
+        <strong>{{ peer.alias }}<span *ngIf="peer.isCurrentStudent"> (You)</span></strong>
+        <span>{{ peer.bandLabel }}</span>
+      </div>
+      <div class="peer-bar">
+        <mat-progress-bar mode="determinate" [value]="peer.progress"></mat-progress-bar>
+      </div>
+      <div class="peer-value">{{ peer.progress }}%</div>
+    </div>
+  </div>
+</div>

--- a/src/app/projects/states/peer-progress/peers-anonymized/peers-anonymized.component.scss
+++ b/src/app/projects/states/peer-progress/peers-anonymized/peers-anonymized.component.scss
@@ -1,0 +1,89 @@
+.peers-anonymized-page {
+  padding: 16px;
+}
+
+.peers-anonymized-card {
+  background: #fff;
+  border: 1px solid #e5e7eb;
+  border-radius: 12px;
+  box-shadow: 0 8px 24px rgba(15, 23, 42, 0.08);
+  margin: 0 auto;
+  max-width: 960px;
+  padding: 24px;
+}
+
+.page-header {
+  align-items: flex-start;
+  display: flex;
+  gap: 16px;
+  justify-content: space-between;
+  margin-bottom: 24px;
+}
+
+.page-eyebrow {
+  color: #2563eb;
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  margin: 0 0 8px;
+  text-transform: uppercase;
+}
+
+.page-header h1 {
+  color: #111827;
+  font-size: 28px;
+  margin: 0 0 8px;
+}
+
+.page-header p {
+  color: #4b5563;
+  margin: 0;
+  max-width: 640px;
+}
+
+.peer-row {
+  align-items: center;
+  display: grid;
+  gap: 16px;
+  grid-template-columns: minmax(160px, 220px) 1fr 64px;
+  padding: 14px 0;
+}
+
+.peer-row + .peer-row {
+  border-top: 1px solid #e5e7eb;
+}
+
+.peer-copy {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.peer-copy strong {
+  color: #0f172a;
+}
+
+.peer-copy span {
+  color: #64748b;
+  font-size: 14px;
+}
+
+.peer-value {
+  color: #1d4ed8;
+  font-weight: 700;
+  text-align: right;
+}
+
+@media (max-width: 768px) {
+  .page-header {
+    flex-direction: column;
+  }
+
+  .peer-row {
+    grid-template-columns: 1fr;
+  }
+
+  .peer-value {
+    text-align: left;
+  }
+}

--- a/src/app/projects/states/peer-progress/peers-anonymized/peers-anonymized.component.scss
+++ b/src/app/projects/states/peer-progress/peers-anonymized/peers-anonymized.component.scss
@@ -41,6 +41,21 @@
   max-width: 640px;
 }
 
+.pagination-toolbar {
+  align-items: center;
+  color: #4b5563;
+  display: flex;
+  gap: 16px;
+  justify-content: space-between;
+  margin-bottom: 20px;
+}
+
+.pagination-actions {
+  align-items: center;
+  display: flex;
+  gap: 12px;
+}
+
 .peer-row {
   align-items: center;
   display: grid;
@@ -74,8 +89,19 @@
   text-align: right;
 }
 
+.empty-state {
+  color: #64748b;
+  margin: 24px 0 0;
+}
+
 @media (max-width: 768px) {
   .page-header {
+    flex-direction: column;
+  }
+
+  .pagination-toolbar,
+  .pagination-actions {
+    align-items: flex-start;
     flex-direction: column;
   }
 

--- a/src/app/projects/states/peer-progress/peers-anonymized/peers-anonymized.component.ts
+++ b/src/app/projects/states/peer-progress/peers-anonymized/peers-anonymized.component.ts
@@ -1,0 +1,33 @@
+import { Component, Inject, Input, OnInit } from '@angular/core';
+import { UIRouter } from '@uirouter/angular';
+import { Project } from 'src/app/api/models/doubtfire-model';
+import {
+  AnonymizedPeerProgress,
+  PeerProgressService,
+} from 'src/app/api/services/peer-progress.service';
+
+@Component({
+  selector: 'f-peers-anonymized',
+  templateUrl: './peers-anonymized.component.html',
+  styleUrls: ['./peers-anonymized.component.scss'],
+})
+export class PeersAnonymizedComponent implements OnInit {
+  @Input() project: Project;
+
+  peers: AnonymizedPeerProgress[] = [];
+
+  constructor(
+    @Inject(UIRouter) private router: UIRouter,
+    private peerProgressService: PeerProgressService,
+  ) {}
+
+  ngOnInit(): void {
+    this.peers = this.peerProgressService.getAnonymizedPeers(this.project);
+  }
+
+  goBack(): void {
+    this.router.stateService.go('projects/peer-progress', {
+      projectId: this.project?.id,
+    });
+  }
+}

--- a/src/app/projects/states/peer-progress/peers-anonymized/peers-anonymized.component.ts
+++ b/src/app/projects/states/peer-progress/peers-anonymized/peers-anonymized.component.ts
@@ -1,20 +1,24 @@
-import { Component, Inject, Input, OnInit } from '@angular/core';
+import { Component, Inject, Input, OnDestroy, OnInit } from '@angular/core';
 import { UIRouter } from '@uirouter/angular';
 import { Project } from 'src/app/api/models/doubtfire-model';
 import {
   AnonymizedPeerProgress,
   PeerProgressService,
 } from 'src/app/api/services/peer-progress.service';
+import { Subscription } from 'rxjs';
 
 @Component({
   selector: 'f-peers-anonymized',
   templateUrl: './peers-anonymized.component.html',
   styleUrls: ['./peers-anonymized.component.scss'],
 })
-export class PeersAnonymizedComponent implements OnInit {
+export class PeersAnonymizedComponent implements OnInit, OnDestroy {
   @Input() project: Project;
 
   peers: AnonymizedPeerProgress[] = [];
+  readonly pageSize = 10;
+  currentPage = 0;
+  private peerProgressSubscription?: Subscription;
 
   constructor(
     @Inject(UIRouter) private router: UIRouter,
@@ -22,12 +26,50 @@ export class PeersAnonymizedComponent implements OnInit {
   ) {}
 
   ngOnInit(): void {
-    this.peers = this.peerProgressService.getAnonymizedPeers(this.project);
+    this.peerProgressSubscription = this.peerProgressService.getAnonymizedPeers(this.project).subscribe({
+      next: (peers) => {
+        this.peers = peers;
+        this.currentPage = 0;
+      },
+    });
+  }
+
+  ngOnDestroy(): void {
+    this.peerProgressSubscription?.unsubscribe();
   }
 
   goBack(): void {
     this.router.stateService.go('projects/peer-progress', {
       projectId: this.project?.id,
     });
+  }
+
+  get paginatedPeers(): AnonymizedPeerProgress[] {
+    const start = this.currentPage * this.pageSize;
+    return this.peers.slice(start, start + this.pageSize);
+  }
+
+  get totalPages(): number {
+    return Math.max(1, Math.ceil(this.peers.length / this.pageSize));
+  }
+
+  get startPeerIndex(): number {
+    return this.peers.length === 0 ? 0 : this.currentPage * this.pageSize + 1;
+  }
+
+  get endPeerIndex(): number {
+    return Math.min((this.currentPage + 1) * this.pageSize, this.peers.length);
+  }
+
+  previousPage(): void {
+    if (this.currentPage > 0) {
+      this.currentPage -= 1;
+    }
+  }
+
+  nextPage(): void {
+    if (this.currentPage < this.totalPages - 1) {
+      this.currentPage += 1;
+    }
   }
 }

--- a/src/app/projects/states/peer-progress/peers-anonymized/peers-anonymized.tpl.html
+++ b/src/app/projects/states/peer-progress/peers-anonymized/peers-anonymized.tpl.html
@@ -1,0 +1,1 @@
+<f-peers-anonymized [project]="project"></f-peers-anonymized>

--- a/src/app/projects/states/states.coffee
+++ b/src/app/projects/states/states.coffee
@@ -5,4 +5,6 @@ angular.module('doubtfire.projects.states', [
   'doubtfire.projects.states.portfolio'
   'doubtfire.projects.states.groups'
   'doubtfire.projects.states.outcomes'
+  'doubtfire.projects.states.peer-progress'
+  'doubtfire.projects.states.peers-anonymized'
 ])


### PR DESCRIPTION
# Description

A new Peer Progress feature has been added to the project navigation flow in doubtfire-web. The work introduced a new project state reachable from the header task dropdown, a summary page with a sample peer progress indicator, and a second anonymized peer view for comparing individual peer progress without exposing student identities.

The implementation includes:

- A new projects/peer-progress state and component to act as the main entry page.
- A sample cohort summary UI with:
- cohort average
- current student sample progress
- peers-ahead count
- strongest sample progress
- a sample progress bar


## Type of change

_Please delete options that are not relevant._

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

- Tests run:
    - ./node_modules/.bin/tsc -p src/tsconfig.app.json --noEmit
    Result: passed before the last router-injection tweak.

    - npm run build:angular1
    Result: passed and regenerated the AngularJS hybrid assets, including the new peer-progress and anonymized-peer state/template artifacts.

- What these verified:
    
    - tsc checked the new Angular components and PeerProgressService for TypeScript/type-level issues.
    - build:angular1 verified the CoffeeScript/UI-Router state files compile, templates are added to build/templates-app.js, and the hybrid AngularJS runtime artifacts are generated.

## Testing Checklist:

- [x] Tested in latest Chrome
- [x] Tested in latest Safari
- [x] Tested in latest Firefox

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have requested a review from @macite and @jakerenzella on the Pull Request

## Previews

<img width="1512" height="982" alt="Screenshot 2026-04-24 at 4 41 30 am" src="https://github.com/user-attachments/assets/15147484-0629-49ee-adb8-7374d0014804" />


<img width="1512" height="982" alt="Screenshot 2026-04-24 at 4 42 18 am" src="https://github.com/user-attachments/assets/d5928b5c-5e61-4058-8d80-4625a3eb6d4b" />

<img width="1512" height="982" alt="Screenshot 2026-04-24 at 4 42 48 am" src="https://github.com/user-attachments/assets/a2b62a64-4ab4-4df8-b228-da4d348d1f0d" />


