### PR TITLE
Allow prediction flag on units

### DIFF
--- a/src/app/api/models/project.ts
+++ b/src/app/api/models/project.ts
@@ -404,7 +404,7 @@ export class Project extends Entity {
     const targetTasks = this.unit.taskDefinitionsForGrade(this.targetGrade);
 
     // get total value of all tasks assigned to this project
-    const total = targetTasks.map((td) => td.weighting).reduce((prev, current, idx, array) => prev + current, 0);
+    const total = targetTasks.map((td) => td.estimated_hours).reduce((prev, current, idx, array) => prev + current, 0);
 
     // exit if no tasks or no weights
     if (targetTasks.length === 0 || total === 0) {
@@ -444,7 +444,7 @@ export class Project extends Entity {
       const weeksElapsed = MappingFunctions.weeksBetween(this.unit.startDate, today);
       if (weeksElapsed > 0) {
         const completedTasksWeight = readyOrCompleteTasks
-          .map((t) => t.definition.weighting)
+          .map((t) => t.definition.estimated_hours)
           .reduce((prev, current, idx, arr) => prev + current, 0);
         completionRate = completedTasksWeight / weeksElapsed;
       }
@@ -465,7 +465,7 @@ export class Project extends Entity {
         date.getTime(),
         (targetTasks
           .filter((taskDef) => taskDef.targetDate >= date)
-          .map((td) => td.weighting)
+          .map((td) => td.estimated_hours)
           .reduce((prev, current) => prev + current, 0) || 0) / total,
       ];
 
@@ -475,7 +475,7 @@ export class Project extends Entity {
         (total -
           doneTasks
             .filter((task) => task.submissionDate && task.submissionDate <= date)
-            .map((task) => task.definition.weighting)
+            .map((task) => task.definition.estimated_hours)
             .reduce((prev, current) => prev + current, 0)) /
           total,
       ];
@@ -486,7 +486,7 @@ export class Project extends Entity {
         (total -
           completedTasks
             .filter((task) => task.completionDate <= date)
-            .map((task) => task.definition.weighting)
+            .map((task) => task.definition.estimated_hours)
             .reduce((prev, current) => prev + current, 0)) /
           total,
       ];

--- a/src/app/api/models/task-definition.ts
+++ b/src/app/api/models/task-definition.ts
@@ -27,7 +27,7 @@ export class TaskDefinition extends Entity {
   abbreviation: string;
   name: string;
   description: string;
-  weighting: number;
+  estimated_hours: number;
   targetGrade: number;
   targetDate: Date;
   dueDate: Date;

--- a/src/app/api/models/task-definition.ts
+++ b/src/app/api/models/task-definition.ts
@@ -28,6 +28,7 @@ export class TaskDefinition extends Entity {
   name: string;
   description: string;
   estimated_hours: number;
+  predicted_effort: number;
   targetGrade: number;
   targetDate: Date;
   dueDate: Date;
@@ -329,5 +330,8 @@ export class TaskDefinition extends Entity {
 
   public projectTask(project?: Project): Task | undefined {
     return project?.tasks?.find((p) => p.definition.id === this.id);
+  }
+  public get predictEffortUrl(): string {
+    return `${AppInjector.get(DoubtfireConstants).API_URL}/units/${this.unit.id}/task_definitions/${this.id}/predict_effort`;
   }
 }

--- a/src/app/api/models/unit.ts
+++ b/src/app/api/models/unit.ts
@@ -81,6 +81,8 @@ export class Unit extends Entity {
 
   d2lMapping: D2lAssessmentMapping;
 
+  allowEffortPredictions: boolean;
+
   public readonly learningOutcomesCache: EntityCache<LearningOutcome> =
     new EntityCache<LearningOutcome>();
   public readonly tutorialStreamsCache: EntityCache<TutorialStream> =

--- a/src/app/api/services/task-definition.service.ts
+++ b/src/app/api/services/task-definition.service.ts
@@ -34,7 +34,7 @@ export class TaskDefinitionService extends CachedEntityService<TaskDefinition> {
       'abbreviation',
       'name',
       'description',
-      'weighting',
+      'estimated_hours',
       'targetGrade',
       'similarityLanguage',
       'hasJplagReport',

--- a/src/app/api/services/task-definition.service.ts
+++ b/src/app/api/services/task-definition.service.ts
@@ -35,6 +35,7 @@ export class TaskDefinitionService extends CachedEntityService<TaskDefinition> {
       'name',
       'description',
       'estimated_hours',
+      'predicted_effort',
       'targetGrade',
       'similarityLanguage',
       'hasJplagReport',
@@ -272,5 +273,11 @@ export class TaskDefinitionService extends CachedEntityService<TaskDefinition> {
     const url = `${AppInjector.get(DoubtfireConstants).API_URL}/submission/units/${taskDefinition.unit.id}/task_definitions/${taskDefinition.id}/student_pdfs/zip`;
     const httpClient = AppInjector.get(HttpClient);
     return httpClient.get<SidekiqJob>(url);
+  }
+
+  public predictEffort(taskDefinition: TaskDefinition): Observable<SidekiqJob> {
+    const http = AppInjector.get(HttpClient);
+
+    return http.post<SidekiqJob>(taskDefinition.predictEffortUrl, {});
   }
 }

--- a/src/app/api/services/unit.service.ts
+++ b/src/app/api/services/unit.service.ts
@@ -257,6 +257,7 @@ export class UnitService extends CachedEntityService<Unit> {
       // 'groupMemberships', - map to group memberships
       'feedbackWarningThresholdDays',
       'feedbackOverflowThresholdDays',
+      'allowEffortPredictions',
     );
 
     this.mapping.addJsonKey(
@@ -288,6 +289,7 @@ export class UnitService extends CachedEntityService<Unit> {
       'allowStudentChangeTutorial',
       'feedbackWarningThresholdDays',
       'feedbackOverflowThresholdDays',
+      'allowEffortPredictions',
     );
   }
 

--- a/src/app/doubtfire-angular.module.ts
+++ b/src/app/doubtfire-angular.module.ts
@@ -323,6 +323,7 @@ import {TutorNotesModalComponent} from './common/modals/tutor-notes-modal/tutor-
 import {FeedbackAppealModalComponent} from './tasks/modals/feedback-appeal-modal/feedback-appeal-modal.component';
 import {ConfirmModerationModalComponent} from './units/states/tasks/inbox/directives/moderation/confirm-moderation-modal/confirm-moderation-modal.component';
 import {TaskClaimComponent} from './units/states/tasks/inbox/directives/task-claim/task-claim.component';
+import { TaskDefinitionEffortComponent } from './units/states/edit/directives/unit-tasks-editor/task-definition-editor/task-definition-effort/task-definition-effort.component';
 
 // See https://stackoverflow.com/questions/55721254/how-to-change-mat-datepicker-date-format-to-dd-mm-yyyy-in-simplest-way/58189036#58189036
 const MY_DATE_FORMAT = {
@@ -407,6 +408,7 @@ const GANTT_CHART_CONFIG = {
     TaskDefinitionResourcesComponent,
     TaskDefinitionOverseerComponent,
     TaskDefinitionScormComponent,
+    TaskDefinitionEffortComponent,
     UnitAnalyticsComponent,
     StudentTutorialSelectComponent,
     StudentCampusSelectComponent,

--- a/src/app/units/states/edit/directives/unit-details-editor/unit-details-editor.component.html
+++ b/src/app/units/states/edit/directives/unit-details-editor/unit-details-editor.component.html
@@ -201,6 +201,11 @@
       <mat-slide-toggle [(ngModel)]="unit.active">Active</mat-slide-toggle>
       <p>Set to false to hide unit from students and tutors.</p>
     </div>
+
+    <div>
+      <mat-slide-toggle [(ngModel)]="unit.allowEffortPredictions">Allow AI Effort Prediction</mat-slide-toggle>
+      <p>Set to false to disable running AI effort predictions on tasks belonging to this unit.</p>
+    </div>
   </mat-card>
 
   @if (overseerEnabled.value) {

--- a/src/app/units/states/edit/directives/unit-tasks-editor/task-definition-editor/task-definition-editor.component.html
+++ b/src/app/units/states/edit/directives/unit-tasks-editor/task-definition-editor/task-definition-editor.component.html
@@ -114,6 +114,20 @@
     <section
       class="mb-0 rounded-xl bg-white p-4 scroll-mt-28"
       #sectionElement
+      data-section-id="effort-prediction"
+    >
+      <h3>Effort Prediction</h3>
+      <p class="font-normal text-gray-500 pb-2">
+        Use a regression model to determine the effort required for a task based on task definition values
+      </p>
+      <f-task-definition-effort [taskDefinition]="taskDefinition" [staffView]="true">
+      </f-task-definition-effort>
+    </section>
+
+    <mat-divider class="my-[25px]"></mat-divider>
+    <section
+      class="mb-0 rounded-xl bg-white p-4 scroll-mt-28"
+      #sectionElement
       data-section-id="discussion-prompts"
     >
       <h3>Discussion Prompts</h3>

--- a/src/app/units/states/edit/directives/unit-tasks-editor/task-definition-editor/task-definition-editor.component.ts
+++ b/src/app/units/states/edit/directives/unit-tasks-editor/task-definition-editor/task-definition-editor.component.ts
@@ -27,6 +27,7 @@ type TaskDefinitionSectionId =
   | 'upload-requirements'
   | 'task-resources'
   | 'prerequisite-tasks'
+  | 'effort-prediction'
   | 'discussion-prompts'
   | 'task-assessment-automation'
   | 'scorm-test'
@@ -58,6 +59,7 @@ export class TaskDefinitionEditorComponent implements OnInit, AfterViewInit, OnC
     {id: 'upload-requirements', label: 'Upload Requirements'},
     {id: 'task-resources', label: 'Task Resources'},
     {id: 'prerequisite-tasks', label: 'Prerequisite Tasks'},
+    {id: 'effort-prediction', label: 'Effort Prediction'},
     {id: 'discussion-prompts', label: 'Discussion Prompts'},
     {id: 'task-assessment-automation', label: 'Task Assessment Automation'},
     {id: 'scorm-test', label: 'SCORM Test'},

--- a/src/app/units/states/edit/directives/unit-tasks-editor/task-definition-editor/task-definition-effort/task-definition-effort.component.html
+++ b/src/app/units/states/edit/directives/unit-tasks-editor/task-definition-editor/task-definition-effort/task-definition-effort.component.html
@@ -1,0 +1,32 @@
+<!-- Row 1: Enable prediction -->
+<div class="mb-4">
+  <mat-checkbox [(ngModel)]="enablePrediction">Enable effort prediction</mat-checkbox>
+</div>
+
+<!-- Row 2: Button -->
+<div class="mb-4">
+  <button
+    mat-raised-button
+    color="primary"
+    (click)="runPrediction()"
+    [disabled]="!enablePrediction"
+  >
+    Run prediction
+  </button>
+</div>
+
+<!-- Row 3: Manual input -->
+<div class="mb-4 gap-4">
+  <mat-form-field appearance="outline" class="w-full">
+    <mat-label>Predicted Effort</mat-label>
+
+    <input
+      matInput
+      type="number"
+      [(ngModel)]="taskDefinition.predicted_effort"
+      [disabled]="enablePrediction"
+      min="1"
+      max="100"
+    />
+  </mat-form-field>
+</div>

--- a/src/app/units/states/edit/directives/unit-tasks-editor/task-definition-editor/task-definition-effort/task-definition-effort.component.ts
+++ b/src/app/units/states/edit/directives/unit-tasks-editor/task-definition-editor/task-definition-effort/task-definition-effort.component.ts
@@ -1,0 +1,33 @@
+import { Component, Input } from '@angular/core';
+import { TaskDefinition } from 'src/app/api/models/task-definition';
+import { Unit } from 'src/app/api/models/unit';
+import { TaskDefinitionService } from 'src/app/api/services/task-definition.service';
+
+@Component({
+  selector: 'f-task-definition-effort',
+  templateUrl: 'task-definition-effort.component.html',
+  styleUrls: ['task-definition-effort.component.scss'],
+})
+export class TaskDefinitionEffortComponent {
+  @Input() taskDefinition: TaskDefinition;
+  @Input() staffView: boolean;
+  constructor(private TaskDefinitionService: TaskDefinitionService) {}
+  enablePrediction = true;
+
+  public get unit(): Unit {
+    return this.taskDefinition?.unit;
+  }
+
+  runPrediction() {
+    if (!this.taskDefinition || !this.taskDefinition.id) return;
+
+    this.TaskDefinitionService.predictEffort(this.taskDefinition).subscribe({
+      next: () => {
+        console.log('Prediction queued');
+      },
+      error: (err) => {
+        console.error('Prediction failed', err);
+      },
+    });
+  }
+}

--- a/src/app/units/states/edit/directives/unit-tasks-editor/task-definition-editor/task-definition-general/task-definition-general.component.html
+++ b/src/app/units/states/edit/directives/unit-tasks-editor/task-definition-editor/task-definition-general/task-definition-general.component.html
@@ -14,8 +14,8 @@
   </mat-form-field>
 
   <mat-form-field appearance="outline" class="flex-grow">
-    <mat-label>Weight - Effort relative to other tasks.</mat-label>
-    <input matInput type="number" [(ngModel)]="taskDefinition.weighting" required />
+    <mat-label>Estimated hours required for completion.</mat-label>
+    <input matInput type="number" [(ngModel)]="taskDefinition.estimated_hours" required />
   </mat-form-field>
 </div>
 

--- a/src/app/units/states/edit/directives/unit-tasks-editor/unit-task-editor.component.ts
+++ b/src/app/units/states/edit/directives/unit-tasks-editor/unit-task-editor.component.ts
@@ -278,7 +278,7 @@ export class UnitTaskEditorComponent implements AfterViewInit {
     task.startDate = new Date();
     task.targetDate = addWeeks(new Date(), 2);
     task.uploadRequirements = [];
-    task.weighting = 4;
+    task.estimated_hours = 4;
     task.targetGrade = 0;
     task.restrictStatusUpdates = false;
     task.plagiarismWarnPct = 80;


### PR DESCRIPTION
# Description

Adds toggle to unit details form

<img width="711" height="452" alt="image" src="https://github.com/user-attachments/assets/b3032f9d-2cd4-4e83-8485-e607df676f2e" />


Fixes # (issue)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

## Testing Checklist:

- [x] Tested in latest Chrome

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
