### PR TITLE
fix(upload-submission-modal): resolve upgraded modal dependency issue

### DIFF
--- a/src/app/projects/states/dashboard/directives/task-dashboard/directives/task-submission-card/task-submission-card.component.ts
+++ b/src/app/projects/states/dashboard/directives/task-dashboard/directives/task-submission-card/task-submission-card.component.ts
@@ -1,5 +1,4 @@
-import { Component, Inject, Input, OnChanges, OnInit, SimpleChanges } from '@angular/core';
-import { uploadSubmissionModal } from 'src/app/ajs-upgraded-providers';
+import { Component, Input, OnChanges, OnInit, SimpleChanges } from '@angular/core';
 import { Task } from 'src/app/api/models/task';
 import { TaskService } from 'src/app/api/services/task.service';
 import { FileDownloaderService } from 'src/app/common/file-downloader/file-downloader.service';
@@ -18,11 +17,11 @@ export class TaskSubmissionCardComponent implements OnChanges, OnInit {
   urls: { pdf: string; files: string };
 
   constructor(
-    private taskService: TaskService,
-    @Inject(uploadSubmissionModal) private UploadSubmissionModal,
-    private alerts: AlertService,
-    private fileDownloader: FileDownloaderService
-  ) {}
+  private taskService: TaskService,
+  private alerts: AlertService,
+  private fileDownloader: FileDownloaderService
+) {}
+
 
   ngOnInit(): void {
     if (this.task) {

--- a/src/app/tasks/modals/upload-submission-modal/upload-submission-modal.coffee
+++ b/src/app/tasks/modals/upload-submission-modal/upload-submission-modal.coffee
@@ -3,7 +3,7 @@ angular.module('doubtfire.tasks.modals.upload-submission-modal', [])
 #
 # A modal to run through uploading a submission
 #
-.factory('UploadSubmissionModal', ($modal, alertService) ->
+.factory('UploadSubmissionModal', ($uibModal, alertService) ->
   UploadSubmissionModal = {}
   #
   # Open a grade task modal with the provided task
@@ -20,7 +20,7 @@ angular.module('doubtfire.tasks.modals.upload-submission-modal', [])
       # task.project = -> project
       task.isTestSubmission = isTestSubmission
 
-    $modal.open
+    $uibModal.open
       templateUrl: 'tasks/modals/upload-submission-modal/upload-submission-modal.tpl.html'
       controller: 'UploadSubmissionModalCtrl'
       size: 'lg'


### PR DESCRIPTION
## Summary

Investigated and updated the `upload-submission-modal` dependency flow as part of the Angular 17 migration work.

## What Happened

This ticket originally involved three files:

- `upload-submission-modal.coffee`
- `upload-submission-modal.scss`
- `upload-submission-modal.tpl.html`

During investigation, the modal dependency was identified in the CoffeeScript file where the upload submission modal was opened using the legacy AngularJS modal service.

The initial migration updated the modal service usage from `$modal` to `$uibModal`.

After testing locally, a runtime Angular 17 dependency injection issue appeared:

- `Circular dependency in DI detected for InjectionToken uploadSubmissionModal`

Further investigation showed that the issue was coming from `task-submission-card.component.ts`, where `uploadSubmissionModal` was being injected into the Angular component but was not actually used.

## Changes Made

- Updated the upload submission modal dependency path.
- Investigated nested component usage inside the modal template.
- Traced the upgraded AngularJS provider through `ajs-upgraded-providers.ts`.
- Removed the unused `uploadSubmissionModal` injection from `task-submission-card.component.ts`.
- Removed the unused `uploadSubmissionModal` import.
- Kept the existing upload submission workflow unchanged.

## Files Changed

- `src/app/tasks/modals/upload-submission-modal/upload-submission-modal.coffee`
- `src/app/projects/states/dashboard/directives/task-dashboard/directives/task-submission-card/task-submission-card.component.ts`

## Verification

- Confirmed the web app builds successfully.
- Confirmed the page loads without the previous Angular 17 circular dependency console error.
- Confirmed the task submission card no longer directly injects the upgraded modal provider unnecessarily.
- Confirmed unrelated `JPlag-Report-Viewer` changes were not included in the commit.

## Notes

The template and SCSS files were reviewed but did not require changes because the issue was related to dependency injection, not UI structure or styling.