### PR TITLE
feat: display list of tasks still being processed in portfolio creation

### DIFF
--- a/src/app/api/models/project.ts
+++ b/src/app/api/models/project.ts
@@ -567,6 +567,15 @@ export class Project extends Entity {
     return httpClient.get<number[]>(this.tasksIncludedInPortfolioUrl());
   }
 
+  public tasksStillProcessingUrl(): string {
+    return `${AppInjector.get(DoubtfireConstants).API_URL}/projects/${this.id}/tasks_processing`;
+  }
+
+  public getTasksStillProcessing(): Observable<number[]> {
+    const httpClient = AppInjector.get(HttpClient);
+    return httpClient.get<number[]>(this.tasksStillProcessingUrl());
+  }
+
   public resetTargetDates(): Observable<Project> {
     const projectService: ProjectService = AppInjector.get(ProjectService);
     return projectService.update(

--- a/src/app/projects/states/portfolio/directives/portfolio-review-step/portfolio-included-tasks/portfolio-included-tasks.component.html
+++ b/src/app/projects/states/portfolio/directives/portfolio-review-step/portfolio-included-tasks/portfolio-included-tasks.component.html
@@ -1,4 +1,4 @@
-@if (loading) {
+@if (loadingIncludedTasks) {
   <div class="flex min-h-[150px] w-full flex-col items-center justify-center gap-3">
     <div>Loading tasks...</div>
     <mat-progress-spinner mode="indeterminate"> </mat-progress-spinner>
@@ -22,5 +22,34 @@
         </li>
       }
     </ol>
+  }
+  @if (tasksStillProcessing.length > 0) {
+    <div class="my-4 rounded-md border border-amber-200 bg-amber-50 p-4">
+      <div class="mb-3 flex items-start gap-3">
+        <mat-icon class="text-amber-600">hourglass_top</mat-icon>
+        <div>
+          <p class="font-medium text-amber-900">Tasks still processing</p>
+          <p class="mt-1 text-sm text-amber-800">
+            Please wait until these tasks have finished processing before creating your portfolio to
+            ensure they are included.
+          </p>
+        </div>
+      </div>
+      <ol class="divide-y divide-amber-200 border-t border-amber-200">
+        @for (task of tasksStillProcessing; track task) {
+          <li class="flex items-center justify-between gap-3 py-3">
+            <div class="text-sm text-amber-950">
+              {{ task.definition.abbreviation }} &mdash; {{ task.definition.name }}
+            </div>
+            <div class="shrink-0">
+              <mat-progress-spinner diameter="20" mode="indeterminate"></mat-progress-spinner>
+            </div>
+          </li>
+        }
+      </ol>
+      <p class="mt-4 px-4 py-3 text-center text-sm text-amber-800">
+        This list will automatically refresh as tasks finish processing.
+      </p>
+    </div>
   }
 }

--- a/src/app/projects/states/portfolio/directives/portfolio-review-step/portfolio-included-tasks/portfolio-included-tasks.component.ts
+++ b/src/app/projects/states/portfolio/directives/portfolio-review-step/portfolio-included-tasks/portfolio-included-tasks.component.ts
@@ -1,7 +1,8 @@
+import {Subscription, interval} from 'rxjs';
 import {Project} from 'src/app/api/models/project';
 import {Task} from 'src/app/api/models/task';
 import {AlertService} from 'src/app/common/services/alert.service';
-import {Component, Input, OnInit} from '@angular/core';
+import {Component, EventEmitter, Input, OnDestroy, OnInit, Output} from '@angular/core';
 
 @Component({
   selector: 'f-portfolio-included-tasks',
@@ -9,29 +10,93 @@ import {Component, Input, OnInit} from '@angular/core';
   styleUrls: ['portfolio-included-tasks.component.scss'],
   standalone: false,
 })
-export class PortfolioIncludedTasksComponent implements OnInit {
+export class PortfolioIncludedTasksComponent implements OnInit, OnDestroy {
   @Input() project: Project;
+  @Output() canCreatePortfolioChange: EventEmitter<boolean> = new EventEmitter();
 
   constructor(private alertService: AlertService) {}
 
-  loading: boolean = false;
+  loadingIncludedTasks: boolean = false;
+  loadingProcessingTasks: boolean = false;
+  hasTasksStillProcessing: boolean = false;
 
   tasksInPortfolio: Task[] = [];
+  tasksStillProcessing: Task[] = [];
+
+  private processingTasksPoll?: Subscription;
+
   ngOnInit() {
-    this.loading = true;
+    this.getTasksIncludedInPortfolio();
+    this.getProcessingTasks();
+  }
+
+  ngOnDestroy(): void {
+    this.processingTasksPoll?.unsubscribe();
+  }
+
+  public getTasksIncludedInPortfolio() {
+    this.loadingIncludedTasks = true;
+    this.canCreatePortfolioChange.emit(false);
     this.project.getTasksIncludedInPortfolio().subscribe({
       next: (tasks) => {
-        for (const taskId of tasks) {
-          const task = this.project.tasks.find((t) => t.id === taskId);
-          if (task) {
-            this.tasksInPortfolio.push(task);
-          }
-        }
-        this.loading = false;
+        this.tasksInPortfolio = this.getProjectTasks(tasks);
+
+        this.loadingIncludedTasks = false;
+        this.updateCanCreatePortfolio();
       },
       error: (error) => {
         this.alertService.error(`Failed to get tasks for portfolio: ${error}`, 6000);
       },
     });
+  }
+
+  public getProcessingTasks(refreshIncludedTasksOnCountChange: boolean = false) {
+    this.loadingProcessingTasks = true;
+    this.canCreatePortfolioChange.emit(false);
+    this.project.getTasksStillProcessing().subscribe({
+      next: (tasks) => {
+        const processingTaskCountChanged = tasks.length !== this.tasksStillProcessing.length;
+
+        this.hasTasksStillProcessing = tasks.length > 0;
+        this.tasksStillProcessing = this.getProjectTasks(tasks);
+
+        if (refreshIncludedTasksOnCountChange && processingTaskCountChanged) {
+          this.getTasksIncludedInPortfolio();
+        }
+
+        this.updateProcessingTasksPoll();
+        this.loadingProcessingTasks = false;
+        this.updateCanCreatePortfolio();
+      },
+      error: (error) => {
+        this.alertService.error(`Failed to get tasks for portfolio: ${error}`, 6000);
+      },
+    });
+  }
+
+  private getProjectTasks(taskIds: number[]): Task[] {
+    return taskIds
+      .map((taskId) => this.project.tasks.find((task) => task.id === taskId))
+      .filter((task): task is Task => task !== undefined);
+  }
+
+  private updateProcessingTasksPoll(): void {
+    if (this.hasTasksStillProcessing && !this.processingTasksPoll) {
+      this.processingTasksPoll = interval(30_000).subscribe(() => {
+        this.getProcessingTasks(true);
+      });
+      return;
+    }
+
+    if (!this.hasTasksStillProcessing) {
+      this.processingTasksPoll?.unsubscribe();
+      this.processingTasksPoll = undefined;
+    }
+  }
+
+  private updateCanCreatePortfolio(): void {
+    this.canCreatePortfolioChange.emit(
+      !this.loadingIncludedTasks && !this.loadingProcessingTasks && !this.hasTasksStillProcessing,
+    );
   }
 }

--- a/src/app/projects/states/portfolio/directives/portfolio-review-step/portfolio-review-step.component.html
+++ b/src/app/projects/states/portfolio/directives/portfolio-review-step/portfolio-review-step.component.html
@@ -87,7 +87,10 @@
       </p>
 
       <p>The following tasks will be included automatically in this order:</p>
-      <f-portfolio-included-tasks [project]="project"></f-portfolio-included-tasks>
+      <f-portfolio-included-tasks
+        [project]="project"
+        (canCreatePortfolioChange)="canCreatePortfolio = $event"
+      ></f-portfolio-included-tasks>
 
       <mat-card appearance="outlined" class="p-1">
         <mat-card-header>
@@ -110,6 +113,7 @@
           <button
             mat-raised-button
             color="primary"
+            [disabled]="!canCreatePortfolio"
             (click)="createPortfolio()"
             class="m-3 mx-auto w-full max-w-4xl"
           >

--- a/src/app/projects/states/portfolio/directives/portfolio-review-step/portfolio-review-step.component.ts
+++ b/src/app/projects/states/portfolio/directives/portfolio-review-step/portfolio-review-step.component.ts
@@ -21,6 +21,7 @@ export class PortfolioReviewStepComponent implements OnInit {
   @Input() onAdvanceActiveTab?: (index: 1 | -1) => void;
 
   public externalName: string = 'OnTrack';
+  public canCreatePortfolio: boolean = false;
 
   public readonly icons: Record<string, string> = {
     document: 'article_outlined',


### PR DESCRIPTION
seems like often enough students will make last minute changes to a few tasks, submit the tasks, then instantly move to portfolio creation, leading to forum posts about "certain tasks not appearing in the portfolio task list", which then appear after the PDFs finish compiling

this change now fetches tasks that are within their target grade, dont have a pdf, but are still being processed. this will prevent them from clicking on the create portfolio button. if there are tasks that are still being processed, the component will refresh the list every 30 seconds so that once all tasks have finished processing, the student can continue and click create