### PR TITLE
fix: render block-level markdown in comments

### DIFF
--- a/src/app/common/pipes/marked.pipe.spec.ts
+++ b/src/app/common/pipes/marked.pipe.spec.ts
@@ -6,4 +6,47 @@ describe('MarkedPipe', () => {
     const pipe = new MarkedPipe();
     expect(pipe).toBeTruthy();
   });
+
+  it.each([
+    {
+      name: 'renders indented code blocks',
+      input: '    const x = 1;\n    const y = 2;',
+      expected: '<pre><code>const x = 1;\nconst y = 2;\n</code></pre>\n',
+    },
+    {
+      name: 'renders fenced code blocks',
+      input: '```\nconst x = 1;\nconst y = 2;\n```',
+      expected: '<pre><code>const x = 1;\nconst y = 2;\n</code></pre>\n',
+    },
+    {
+      name: 'renders tables',
+      input: '| x | y |\n| --- | --- |\n| 1 | 2 |',
+      expected:
+        '<table>\n<thead>\n<tr>\n<th>x</th>\n<th>y</th>\n</tr>\n</thead>\n' +
+        '<tbody><tr>\n<td>1</td>\n<td>2</td>\n</tr>\n</tbody></table>\n',
+    },
+    {
+      name: 'renders multi-line blockquotes',
+      input: '> first line\n> second line',
+      expected: '<blockquote>\n<p>first line<br>second line</p>\n</blockquote>\n',
+    },
+    {
+      name: 'renders multi-line lists',
+      input: '- one\n- two\n- three',
+      expected: '<ul>\n<li>one</li>\n<li>two</li>\n<li>three</li>\n</ul>\n',
+    },
+    {
+      name: 'keeps single newlines within a paragraph as line breaks',
+      input: 'first line\nsecond line',
+      expected: '<p>first line<br>second line</p>\n',
+    },
+    {
+      name: 'normalises CRLF and CR line endings',
+      input: '```\r\nfirst line\rsecond line\r\n```',
+      expected: '<pre><code>first line\nsecond line\n</code></pre>\n',
+    },
+  ])('$name', ({input, expected}) => {
+    const pipe = new MarkedPipe();
+    expect(pipe.transform(input)).toBe(expected);
+  });
 });

--- a/src/app/common/pipes/marked.pipe.ts
+++ b/src/app/common/pipes/marked.pipe.ts
@@ -18,7 +18,7 @@ export class MarkedPipe implements PipeTransform {
 
   transform(value: string): string {
     if (value && value.length > 0) {
-      return marked.parse(value.replaceAll(/\r\n|\r|\n/g, '<br />'), {async: false}) as string;
+      return marked.parse(value.replaceAll(/\r\n|\r/g, '\n'), {async: false}) as string;
     }
     return value;
   }


### PR DESCRIPTION
# Description

The marked pipe replaced every newline with `<br />` before parsing, which stripped the line breaks that block-level markdown depends on. Fenced and indented code blocks, tables, multi-line lists, and multi-line blockquotes therefore collapsed onto a single line and rendered as literal text.

This PR normalises line endings only (`\r\n` and `\r` to `\n`) and passes real newlines through to marked, so its block-level tokenizer sees them. Single in-paragraph newlines are still rendered as `<br>` via the existing `breaks: true` option, so ordinary messages are unaffected. Output continues to flow through Angular's `[innerHTML]` sanitizer, so this adds no new XSS surface.

This PR also adds tests covering fenced and indented code blocks, tables, multi-line lists, multi-line blockquotes, single-newline line breaks, and CRLF/CR normalisation.

Fixes #1432

## Type of change

_Please delete options that are not relevant._

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Load up the development server locally and leave comments on a student task using the various multi-line GitHub Flavored Markdown features.

<img width="290" height="125" alt="Screenshot 2026-08-07 at 2 04 30 am" src="https://github.com/user-attachments/assets/b1ebaca4-bdeb-4f5f-a64c-ab35a622ef7b" />

Note that not all features of GitHub Flavored Markdown (e.g. blockquotes) have appropriate styling in place. I have treated that as out of scope for this PR since it might require further discussion. The focus here is just on ensuring the markup is not mangled. 

## Testing Checklist:

- [x] Tested in latest Chrome
- [x] Tested in latest Safari
- [x] Tested in latest Firefox

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have formatted my changes with `npm run format`
- [x] I have run `npm run lint` with no errors
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have requested a review from @macite and @jakerenzella on the Pull Request
