### PR TITLE
fix: space block-level markdown in comment bubbles via CSS

### DIFF
--- a/src/app/tasks/task-comments-viewer/discuss-timeout-comment/discuss-timeout-comment.component.scss
+++ b/src/app/tasks/task-comments-viewer/discuss-timeout-comment/discuss-timeout-comment.component.scss
@@ -1,5 +1,0 @@
-.discuss-timeout-comment__body {
-  ::ng-deep p {
-    margin: 0;
-  }
-}

--- a/src/app/tasks/task-comments-viewer/discuss-timeout-comment/discuss-timeout-comment.component.ts
+++ b/src/app/tasks/task-comments-viewer/discuss-timeout-comment/discuss-timeout-comment.component.ts
@@ -4,7 +4,6 @@ import {TaskComment} from 'src/app/api/models/doubtfire-model';
 @Component({
   selector: 'f-discuss-timeout-comment',
   templateUrl: './discuss-timeout-comment.component.html',
-  styleUrls: ['./discuss-timeout-comment.component.scss'],
   changeDetection: ChangeDetectionStrategy.Eager,
   standalone: false,
 })

--- a/src/app/tasks/task-comments-viewer/scorm-comment/scorm-comment.component.html
+++ b/src/app/tasks/task-comments-viewer/scorm-comment/scorm-comment.component.html
@@ -1,9 +1,9 @@
 <hr class="hr-text my-2" data-content="Knowledge Check Summary" [hidden]="!comment.firstInSeries" />
 <div class="flex w-full flex-col justify-center">
   @if (!user.isStaff && !task.definition.scormAllowReview) {
-    <div class="markdown-to-html m-auto my-0.5 text-center" [innerHTML]="comment.text"></div>
+    <div class="m-auto my-0.5 text-center" [innerHTML]="comment.text"></div>
   } @else {
-    <div class="markdown-to-html grow text-center" [innerHTML]="comment.text"></div>
+    <div class="grow text-center" [innerHTML]="comment.text"></div>
   }
   <div class="relative flex w-full items-center justify-center py-4">
     <button

--- a/src/app/tasks/task-comments-viewer/task-comments-viewer.component.scss
+++ b/src/app/tasks/task-comments-viewer/task-comments-viewer.component.scss
@@ -5,10 +5,6 @@
   min-width: 230px;
 }
 
-::ng-deep .text-bubble .comment-text .markdown-to-html p {
-  margin: 0 0 0 0px !important;
-}
-
 $comment-bubble-color: #3939ff;
 $comment-bubble-color-darker: color.adjust($comment-bubble-color, $lightness: -10%);
 $comment-bubble-color-other-user: rgb(241, 240, 240);
@@ -341,17 +337,12 @@ $comment-inner-border-radius: 4px;
     background: $comment-bubble-color;
 
     .comment-text,
-    .comment-pdf,
-    .markdown-to-html p {
+    .comment-pdf {
       padding-right: 6px;
       padding-left: 4px;
       word-break: break-word;
       -webkit-font-smoothing: antialiased;
       margin-bottom: 0 !important;
-    }
-
-    .comment-text .markdown-to-html p {
-      margin: 0 0 0 0 !important;
     }
 
     .comment-audio {
@@ -382,18 +373,6 @@ $comment-inner-border-radius: 4px;
       color: white;
       margin-bottom: 0px;
     }
-
-    ::ng-deep .text-bubble .comment-text .markdown-to-html p {
-      margin: 0 0 0 0px !important;
-    }
-
-    .markdown-to-html p > *:last-child {
-      margin-bottom: 0px;
-    }
-
-    .markdown-to-html p > pre:last-child {
-      margin-bottom: 0em;
-    }
   }
 
   .pdf-bubble {
@@ -414,10 +393,6 @@ $comment-inner-border-radius: 4px;
       width: 80%;
       margin-right: 0;
       padding-right: 0;
-    }
-
-    .markdown-to-html > *:last-child {
-      margin-bottom: 0px;
     }
   }
 

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -4,6 +4,7 @@
 @use 'theme' as *;
 @use 'styles/common/typeface';
 @use 'tailwindcss';
+@use 'styles/common/markdown';
 @config '../tailwind.config.js';
 
 @include mat.elevation-classes();

--- a/src/styles/common/markdown.scss
+++ b/src/styles/common/markdown.scss
@@ -1,0 +1,18 @@
+// Block-level markdown rendered from the `marked` pipe (`.markdown-to-html`) or
+// exported to PDF (`.markdown-to-pdf`). Tailwind's Preflight resets the margins
+// on paragraphs, headings, lists, code blocks, blockquotes and tables, so
+// consecutive markdown blocks would otherwise collapse onto each other with no
+// separation. Restore vertical rhythm between blocks without adding margin above
+// the first block or below the last, so the surrounding container controls the
+// outer edges.
+.markdown-to-html,
+.markdown-to-pdf {
+  > * {
+    margin-top: 0;
+    margin-bottom: 0.75em;
+  }
+
+  > *:last-child {
+    margin-bottom: 0;
+  }
+}


### PR DESCRIPTION
# Description

The `marked` pipe previously turned every newline into `<br />`, so a comment always rendered as a single `<p>`. The SCSS force-zeroed paragraph margins to stop that lone paragraph inflating the bubble. Since #1433, `marked` emits real block-level elements, that blanket zeroing collapsed the spacing between consecutive blocks.

This PR replaces the `<p>`-targeted margin reset with block spacing on the container's direct children: a uniform bottom margin between blocks, a zeroed top margin to avoid collapse surprises, and no trailing margin on the last child so the bubble stays tight. This PR also remove dead remnants of the old hack that could no longer take effect under the component's emulated encapsulation.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Load up the development server locally and leave comments on a student task using combinations of 1 and 2 line breaks.

<img width="282" height="199" alt="Screenshot 2026-08-09 at 4 04 56 pm" src="https://github.com/user-attachments/assets/4b59c8e5-1940-4cb3-a38f-cebac47d1e60" />

## Testing Checklist:

- [x] Tested in latest Chrome
- [x] Tested in latest Safari
- [x] Tested in latest Firefox

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have formatted my changes with `npm run format`
- [x] I have run `npm run lint` with no errors
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have requested a review from @macite and @jakerenzella on the Pull Request
