### PR TITLE
fix: repair flaky search and stale unit data in student and group views

### DIFF
--- a/src/app/api/models/campus/campus.ts
+++ b/src/app/api/models/campus/campus.ts
@@ -24,9 +24,6 @@ export class Campus extends Entity {
    * @param matchText the text to match
    */
   public matches(matchText: string): boolean {
-    return (
-      this.name.toLowerCase().indexOf(matchText) >= 0 ||
-      this.abbreviation.toLowerCase().indexOf(matchText) >= 0
-    );
+    return [this.name, this.abbreviation].some((value) => value?.toLowerCase().includes(matchText));
   }
 }

--- a/src/app/api/models/project.ts
+++ b/src/app/api/models/project.ts
@@ -79,7 +79,7 @@ export class Project extends Entity {
 
   public matches(text: string): boolean {
     return (
-      this.student.matches(text) ||
+      this.student?.matches(text) ||
       this.campus?.matches(text) ||
       this.matchesTutorialEnrolments(text) ||
       this.matchesGroup(text)
@@ -87,18 +87,16 @@ export class Project extends Entity {
   }
 
   public matchesTutorialEnrolments(matchText): boolean {
-    return (
-      this.tutorials.filter(
-        (enrol) =>
-          enrol.abbreviation.toLowerCase().indexOf(matchText) >= 0 ||
-          enrol.tutorName.toLowerCase().indexOf(matchText) >= 0,
-      ).length > 0
+    return this.tutorials.some(
+      (enrol) =>
+        enrol?.abbreviation?.toLowerCase().includes(matchText) ||
+        enrol?.tutorName?.toLowerCase().includes(matchText),
     );
   }
 
   // Search through the student's groups for a match
   public matchesGroup(matchText: string): boolean {
-    return this.groups.find((grp) => grp.name.toLowerCase().indexOf(matchText) >= 0) !== undefined;
+    return this.groups.some((grp) => grp?.name?.toLowerCase().includes(matchText));
   }
 
   public groupForGroupSet(gs: GroupSet) {

--- a/src/app/api/models/unit.ts
+++ b/src/app/api/models/unit.ts
@@ -1,6 +1,6 @@
 import {Entity, EntityCache, EntityMapping} from 'ngx-entity-service';
 import {HttpClient, HttpParams} from '@angular/common/http';
-import {Observable, tap} from 'rxjs';
+import {Observable, shareReplay, switchMap, tap} from 'rxjs';
 import {AppInjector} from 'src/app/app-injector';
 import {FileDownloaderService} from 'src/app/common/file-downloader/file-downloader.service';
 import {AlertService} from 'src/app/common/services/alert.service';
@@ -572,9 +572,24 @@ export class Unit extends Entity {
       );
   }
 
-  public refreshStudents(includeWithdrawnStudents: boolean = false) {
+  public refreshStudents(includeWithdrawnStudents: boolean = false): Observable<Project[]> {
     const projectService: ProjectService = AppInjector.get(ProjectService);
-    projectService.loadStudents(this, includeWithdrawnStudents, true);
+    const alerts = AppInjector.get(AlertService);
+    // loadStudents asks for either the enrolled or the withdrawn students, so both are
+    // needed to refresh the whole cohort.
+    const enrolled = projectService.loadStudents(this, false, true);
+    const result = (
+      includeWithdrawnStudents
+        ? enrolled.pipe(switchMap(() => projectService.loadStudents(this, true, true)))
+        : enrolled
+    ).pipe(shareReplay({bufferSize: 1, refCount: false}));
+
+    // Subscribe here so that the refresh runs even when the caller ignores the result.
+    result.subscribe({
+      error: (message) => alerts.error(message, 6000),
+    });
+
+    return result;
   }
 
   public findProjectForUsername(username: string): Project {

--- a/src/app/api/models/unit.ts
+++ b/src/app/api/models/unit.ts
@@ -578,7 +578,7 @@ export class Unit extends Entity {
   }
 
   public findProjectForUsername(username: string): Project {
-    return this.students.find((s) => s.student.username === username);
+    return this.students.find((s) => s.student?.username === username);
   }
 
   public get groupSets(): readonly GroupSet[] {
@@ -600,8 +600,7 @@ export class Unit extends Entity {
 
   private addStudentTypeAheadData(students: readonly Project[], appendTo: string[]): void {
     students.forEach((project) => {
-      appendTo.push(project.student.name);
-      appendTo.push(project.student.username);
+      appendTo.push(project.student?.name, project.student?.username);
     });
   }
 
@@ -617,7 +616,9 @@ export class Unit extends Entity {
 
     this.addStudentTypeAheadData(this.activeStudents, result);
 
-    return result;
+    // Students and tutorials can be missing any of these details, so drop the gaps
+    // rather than offering blank suggestions.
+    return result.filter(Boolean);
   }
 
   public studentsForGroupTypeAhead(group: Group): Project[] {

--- a/src/app/api/models/user/user.ts
+++ b/src/app/api/models/user/user.ts
@@ -59,15 +59,21 @@ export class User extends Entity {
     return firstName;
   }
 
+  /**
+   * Does any of the user's details contain the passed in text?
+   *
+   * @param text the search text, in lower case
+   */
   public matches(text: string): boolean {
-    return (
-      this.studentId?.toLowerCase().indexOf(text) >= 0 ||
-      this.name.toLowerCase().indexOf(text) >= 0 ||
-      this.firstName.toLowerCase().indexOf(text) >= 0 ||
-      this.lastName.toLowerCase().indexOf(text) >= 0 ||
-      this.email.toLowerCase().indexOf(text) >= 0 ||
-      this.nickname?.toLowerCase().indexOf(text) >= 0
-    );
+    return [
+      this.studentId,
+      this.name,
+      this.firstName,
+      this.lastName,
+      this.email,
+      this.nickname,
+      this.username,
+    ].some((value) => value?.toLowerCase().includes(text));
   }
 
   public acceptTiiEula(): Observable<boolean> {

--- a/src/app/api/services/project.service.ts
+++ b/src/app/api/services/project.service.ts
@@ -159,7 +159,15 @@ export class ProjectService extends CachedEntityService<Project> {
           data[key]?.forEach((tutorialEnrolment: {tutorial_id: number}) => {
             if (tutorialEnrolment.tutorial_id) {
               const tutorial = unit.tutorialsCache.get(tutorialEnrolment.tutorial_id);
-              project.tutorialEnrolmentsCache.add(tutorial);
+              // The unit's tutorials may not have loaded yet - project mappings can run
+              // against a unit stub, as the progressive route resolution creates. Dropping
+              // the enrolment leaves this project without a tutorial until it is mapped
+              // again, which hides it behind the "My Tutorials" filter, but failing here
+              // would abort the mapping of this project and every project after it in the
+              // response.
+              if (tutorial) {
+                project.tutorialEnrolmentsCache.add(tutorial);
+              }
             }
           });
         },

--- a/src/app/groups/group-selector/group-selector.component.ts
+++ b/src/app/groups/group-selector/group-selector.component.ts
@@ -105,7 +105,7 @@ export class GroupSelectorComponent
       .filter(
         (g) =>
           this.staffTutorialFilter === 'all' ||
-          (this.unitRole && g.tutorial.tutor.id === this.unitRole.user.id),
+          (this.unitRole && g.tutorial?.tutor?.id === this.unitRole.user.id),
       )
       .filter(
         (g) => !this.newGroupName || g.name.toLowerCase().includes(this.newGroupName.toLowerCase()),

--- a/src/app/groups/group-set-manager/group-set-manager.component.ts
+++ b/src/app/groups/group-set-manager/group-set-manager.component.ts
@@ -1,4 +1,11 @@
-import {ChangeDetectionStrategy, Component, Input, OnInit} from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  Input,
+  OnChanges,
+  OnInit,
+  SimpleChanges,
+} from '@angular/core';
 import {FormControl} from '@angular/forms';
 import {Observable, map, startWith} from 'rxjs';
 import {Group, GroupSet, Project, Unit, UnitRole} from 'src/app/api/models/doubtfire-model';
@@ -12,7 +19,7 @@ import {AlertService} from 'src/app/common/services/alert.service';
   changeDetection: ChangeDetectionStrategy.Eager,
   standalone: false,
 })
-export class GroupSetManagerComponent implements OnInit {
+export class GroupSetManagerComponent implements OnInit, OnChanges {
   @Input() project: Project;
   @Input() unit: Unit;
   @Input() selectedGroupSet: GroupSet;
@@ -37,6 +44,23 @@ export class GroupSetManagerComponent implements OnInit {
       startWith(''),
       map((value) => this._filter(value)),
     );
+  }
+
+  ngOnChanges(changes: SimpleChanges): void {
+    // Groups belong to a group set within a unit, so a selected group cannot outlive
+    // a change to either of them.
+    if (changes['unit'] || changes['selectedGroupSet']) {
+      // A rename in progress has already been applied to the cached group, so put it back
+      // before letting go of it.
+      if (this.editingGroupName && this.selectedGroup) {
+        this.selectedGroup.name = this.originalGroupName;
+      }
+
+      this.selectedGroup = null;
+      this.projects = [];
+      this.editingGroupName = false;
+      this.control.setValue('');
+    }
   }
 
   get groupSelectHandler() {

--- a/src/app/groups/group-set-manager/group-set-manager.component.ts
+++ b/src/app/groups/group-set-manager/group-set-manager.component.ts
@@ -23,13 +23,13 @@ export class GroupSetManagerComponent implements OnInit {
 
   editingGroupName = false;
 
-  control = new FormControl('');
+  readonly control = new FormControl('');
   projects: Project[] = [];
   filteredProjects: Observable<Project[]>;
 
   constructor(
-    private groupService: GroupService,
-    private alertService: AlertService,
+    private readonly groupService: GroupService,
+    private readonly alertService: AlertService,
   ) {}
 
   ngOnInit(): void {
@@ -44,7 +44,7 @@ export class GroupSetManagerComponent implements OnInit {
   }
 
   displayFn(project: Project): string {
-    return project && project.student.name ? project.student.name : '';
+    return project?.student?.name ?? '';
   }
 
   newGroupSelected(group: Group) {
@@ -68,7 +68,7 @@ export class GroupSetManagerComponent implements OnInit {
     const filterValue = value.toLowerCase();
     return this.projects.filter(
       (project) =>
-        project.student.name.toLowerCase().includes(filterValue.toLowerCase()) && // Find by name
+        project.student?.name?.toLowerCase().includes(filterValue) && // Find by name
         !this.selectedGroup.projects.find((p) => project.id === p.id), // Not already assigned to the group
     );
   }

--- a/src/app/units/states/groups/unit-groups/unit-groups.component.ts
+++ b/src/app/units/states/groups/unit-groups/unit-groups.component.ts
@@ -1,6 +1,6 @@
 import {ChangeDetectionStrategy, Component, Input, OnDestroy, OnInit} from '@angular/core';
 import {ActivatedRoute} from '@angular/router';
-import {Observable, Subscription, of} from 'rxjs';
+import {Observable, Subscription, distinctUntilChanged, filter, map} from 'rxjs';
 import {GroupSet, Unit, UnitRole, UserService} from 'src/app/api/models/doubtfire-model';
 import {GlobalStateService, ViewType} from 'src/app/projects/states/index/global-state.service';
 
@@ -21,6 +21,7 @@ export class UnitGroupsComponent implements OnInit, OnDestroy {
   @Input() selectedGroupSet: GroupSet;
 
   private unitSub?: Subscription;
+  private shownUnitId?: number;
 
   constructor(
     private globalStateService: GlobalStateService,
@@ -29,16 +30,28 @@ export class UnitGroupsComponent implements OnInit, OnDestroy {
   ) {}
 
   ngOnInit(): void {
-    this.unit$ = this.unit$ ?? of(this.route.parent.snapshot.data.unit);
-    this.unitSub = this.unit$?.subscribe((unit) => {
-      if (!unit) {
-        return;
-      }
+    // The route reuses this component when switching between units, so follow the resolved
+    // unit rather than reading it once from the route snapshot.
+    const unit$ = this.unit$ ?? this.route.parent.data.pipe(map((data) => data.unit as Unit));
 
-      this.unit = unit;
-      this.unitRole = this.findUnitRole(unit.id);
-      this.selectedGroupSet = this.selectedGroupSet ?? unit.groupSets?.[0];
-    });
+    this.unitSub = unit$
+      .pipe(
+        filter((unit) => !!unit),
+        distinctUntilChanged((previous, current) => previous.id === current.id),
+      )
+      .subscribe((unit) => {
+        // Group sets belong to a unit, so only the first unit shown can keep one that was
+        // supplied by a parent component.
+        const isUnitChange = this.shownUnitId !== undefined;
+
+        this.shownUnitId = unit.id;
+        this.unit = unit;
+        this.unitRole = this.findUnitRole(unit.id);
+
+        if (isUnitChange || !this.selectedGroupSet) {
+          this.selectedGroupSet = unit.groupSets?.[0];
+        }
+      });
   }
 
   ngOnDestroy(): void {

--- a/src/app/units/states/portfolios/portfolios.component.ts
+++ b/src/app/units/states/portfolios/portfolios.component.ts
@@ -1,7 +1,15 @@
 import {ChangeDetectionStrategy, Component, Input, OnDestroy, OnInit} from '@angular/core';
 import {MatTabChangeEvent} from '@angular/material/tabs';
 import {ActivatedRoute, ParamMap, Router} from '@angular/router';
-import {BehaviorSubject, Observable, Subscription, distinctUntilChanged, map} from 'rxjs';
+import {
+  BehaviorSubject,
+  Observable,
+  Subscription,
+  distinctUntilChanged,
+  finalize,
+  first,
+  map,
+} from 'rxjs';
 import {Project} from 'src/app/api/models/project';
 import {Unit} from 'src/app/api/models/unit';
 import {ProjectService} from 'src/app/api/services/project.service';
@@ -159,15 +167,26 @@ export class PortfoliosComponent implements OnInit, OnDestroy {
   }
 
   private loadStudents(): void {
-    this.projectService.loadStudents(this.unit, false).subscribe({
-      next: () => {
-        this.loadingStudents = false;
-      },
-      error: (error) => {
-        this.alertService.error(`Failed to load unit: ${error}`, 6000);
-        this.router.navigateByUrl('/home');
-      },
-    });
+    const unit = this.unit;
+
+    // Students already in the cache can be shown while the current details load, but they may
+    // have been cached in another view minutes ago - so always ask the server for them again.
+    this.loadingStudents = unit.activeStudents.length === 0;
+    this.projectService
+      .loadStudents(unit, false, true)
+      .pipe(
+        first(),
+        finalize(() => {
+          if (this.unit === unit) {
+            this.loadingStudents = false;
+          }
+        }),
+      )
+      .subscribe({
+        error: (error) => {
+          this.alertService.error(`Failed to load students: ${error}`, 6000);
+        },
+      });
   }
 
   private updatePortfolioListFiltersFromQueryParams(params: ParamMap): void {

--- a/src/app/units/states/portfolios/portfolios.component.ts
+++ b/src/app/units/states/portfolios/portfolios.component.ts
@@ -1,7 +1,7 @@
 import {ChangeDetectionStrategy, Component, Input, OnDestroy, OnInit} from '@angular/core';
 import {MatTabChangeEvent} from '@angular/material/tabs';
 import {ActivatedRoute, ParamMap, Router} from '@angular/router';
-import {BehaviorSubject, Observable, Subscription, first, of} from 'rxjs';
+import {BehaviorSubject, Observable, Subscription, distinctUntilChanged, map} from 'rxjs';
 import {Project} from 'src/app/api/models/project';
 import {Unit} from 'src/app/api/models/unit';
 import {ProjectService} from 'src/app/api/services/project.service';
@@ -57,34 +57,56 @@ export class PortfoliosComponent implements OnInit, OnDestroy {
   ) {}
 
   public ngOnInit(): void {
-    this.unit$ = this.unit$ ?? of(this.route.parent.snapshot.data.unit);
+    // The route reuses this component when switching between units, so follow the resolved
+    // unit rather than reading it once from the route snapshot.
+    const unit$ = this.unit$ ?? this.route.parent.data.pipe(map((data) => data.unit as Unit));
+
     this.subscriptions.push(
-      this.unit$.pipe(first()).subscribe({
-        next: (unit) => {
-          this.unit = unit;
-
-          if (
-            this.userService.currentUser.systemRole === 'Admin' ||
-            this.userService.currentUser.systemRole === 'Convenor'
-          ) {
-            this.unit.loadD2lMapping().subscribe();
-          }
-
-          this.loadStudents();
-          this.subscriptions.push(
-            this.route.paramMap.subscribe((params) => {
-              this.updateCurrentTabFromState(params.get('tab'), params.get('projectId'));
-            }),
-            this.route.queryParamMap.subscribe((params) => {
-              this.updatePortfolioListFiltersFromQueryParams(params);
-            }),
-          );
-        },
-        error: (error) => {
-          this.alertService.error(`Failed to load unit: ${error}`, 6000);
-          this.router.navigateByUrl('/home');
-        },
+      unit$
+        .pipe(distinctUntilChanged((previous, current) => previous?.id === current?.id))
+        .subscribe({
+          next: (unit) => this.showUnit(unit),
+          error: (error) => {
+            this.alertService.error(`Failed to load unit: ${error}`, 6000);
+            this.router.navigateByUrl('/home');
+          },
+        }),
+      this.route.paramMap.subscribe((params) => {
+        this.updateCurrentTabFromState(params.get('tab'), params.get('projectId'));
       }),
+      this.route.queryParamMap.subscribe((params) => {
+        this.updatePortfolioListFiltersFromQueryParams(params);
+      }),
+    );
+  }
+
+  private showUnit(unit: Unit): void {
+    this.unit = unit;
+
+    // Any student selected in the previous unit is no longer relevant.
+    this.selectedProjectId = null;
+    this.selectedProject = null;
+    this.selectedProject$.next(null);
+
+    if (!unit) {
+      this.loadingStudents = false;
+      return;
+    }
+
+    if (
+      this.userService.currentUser.systemRole === 'Admin' ||
+      this.userService.currentUser.systemRole === 'Convenor'
+    ) {
+      unit.loadD2lMapping().subscribe();
+    }
+
+    this.loadStudents();
+
+    // The route may already name a student to show, and the paramMap subscription can have
+    // reported it before this unit arrived.
+    this.updateCurrentTabFromState(
+      this.route.snapshot.paramMap.get('tab'),
+      this.route.snapshot.paramMap.get('projectId'),
     );
   }
 
@@ -210,7 +232,8 @@ export class PortfoliosComponent implements OnInit, OnDestroy {
       return;
     }
 
-    if (this.selectedProject?.id === projectId) {
+    // Already showing, or already loading, this student.
+    if (this.selectedProject?.id === projectId || this.selectedProjectId === projectId) {
       return;
     }
 
@@ -230,6 +253,11 @@ export class PortfoliosComponent implements OnInit, OnDestroy {
   }
 
   private loadProject(projectId: number): void {
+    if (!this.unit) {
+      // The unit is still resolving. It will apply the route state once it arrives.
+      return;
+    }
+
     this.selectedProjectId = projectId;
 
     this.projectService.loadProject(projectId, this.unit).subscribe({

--- a/src/app/units/states/students-list/students-list.component.spec.ts
+++ b/src/app/units/states/students-list/students-list.component.spec.ts
@@ -1,4 +1,5 @@
 import {describe, expect, it} from 'vitest';
+import {BehaviorSubject, of} from 'rxjs';
 import {Project, Unit, User} from 'src/app/api/models/doubtfire-model';
 import {StudentsListComponent} from './students-list.component';
 
@@ -47,16 +48,44 @@ describe('StudentsListComponent', () => {
 
     expect(component.filteredSuggestions).toEqual([noUsername.student.name]);
   });
+
+  it('follows the unit when the router reuses the component', () => {
+    const firstUnit = buildUnit(1, 'Ann');
+    const secondUnit = buildUnit(2, 'Bob');
+    const routeData = new BehaviorSubject({unit: firstUnit});
+    const component = buildComponent(null, {
+      route: {parent: {data: routeData}},
+      projectService: {loadStudents: () => of([])},
+    });
+
+    component.ngOnInit();
+    expect(component.unit).toBe(firstUnit);
+    expect(component['filteredProjects']()).toEqual(firstUnit.activeStudents);
+
+    routeData.next({unit: secondUnit});
+    expect(component.unit).toBe(secondUnit);
+    expect(component['filteredProjects']()).toEqual(secondUnit.activeStudents);
+  });
 });
 
-function buildComponent(unit: Unit): StudentsListComponent {
+function buildUnit(id: number, studentName: string): Unit {
+  const unit = new Unit();
+  unit.id = id;
+  unit.studentCache.add(buildProject(unit, id, true, studentName));
+  return unit;
+}
+
+function buildComponent(
+  unit: Unit,
+  overrides: {route?: unknown; projectService?: unknown} = {},
+): StudentsListComponent {
   const component = new StudentsListComponent(
     {} as never,
     {} as never,
-    {} as never,
+    (overrides.route ?? {}) as never,
     {currentUser: new User()} as never,
     {} as never,
-    {} as never,
+    (overrides.projectService ?? {}) as never,
   );
   component.unit = unit;
   return component;

--- a/src/app/units/states/students-list/students-list.component.spec.ts
+++ b/src/app/units/states/students-list/students-list.component.spec.ts
@@ -10,21 +10,57 @@ describe('StudentsListComponent', () => {
     unit.studentCache.add(enrolledProject);
     unit.studentCache.add(withdrawnProject);
 
-    const component = new StudentsListComponent(
-      {} as never,
-      {} as never,
-      {} as never,
-      {currentUser: new User()} as never,
-      {} as never,
-      {} as never,
-    );
-    component.unit = unit;
+    const component = buildComponent(unit);
 
     expect(component['filteredProjects']()).toEqual([enrolledProject]);
     expect(unit.studentFilterTypeAheadData).toContain(enrolledProject.student.name);
     expect(unit.studentFilterTypeAheadData).not.toContain(withdrawnProject.student.name);
   });
+
+  it('searches over students with incomplete details', () => {
+    const unit = new Unit();
+    const noEmail = buildProject(unit, 1, true, 'Ann');
+    noEmail.student.email = null;
+    const noLastName = buildProject(unit, 2, true, 'Bob');
+    noLastName.student.lastName = null;
+    const noStudent = buildProject(unit, 3, true, 'Cat');
+    noStudent.student = undefined;
+    unit.studentCache.add(noEmail);
+    unit.studentCache.add(noLastName);
+    unit.studentCache.add(noStudent);
+
+    const component = buildComponent(unit);
+    component.searchText = 'bob';
+
+    expect(component['filteredProjects']()).toEqual([noLastName]);
+  });
+
+  it('suggests students with incomplete details without failing', () => {
+    const unit = new Unit();
+    const noUsername = buildProject(unit, 1, true, 'Ann');
+    noUsername.student.username = undefined;
+    unit.studentCache.add(noUsername);
+
+    const component = buildComponent(unit);
+    component.searchText = 'ann';
+    component['updateSuggestions']();
+
+    expect(component.filteredSuggestions).toEqual([noUsername.student.name]);
+  });
 });
+
+function buildComponent(unit: Unit): StudentsListComponent {
+  const component = new StudentsListComponent(
+    {} as never,
+    {} as never,
+    {} as never,
+    {currentUser: new User()} as never,
+    {} as never,
+    {} as never,
+  );
+  component.unit = unit;
+  return component;
+}
 
 function buildProject(unit: Unit, id: number, enrolled: boolean, firstName: string): Project {
   const student = new User();

--- a/src/app/units/states/students-list/students-list.component.ts
+++ b/src/app/units/states/students-list/students-list.component.ts
@@ -11,7 +11,7 @@ import {MatPaginator} from '@angular/material/paginator';
 import {MatSort, Sort} from '@angular/material/sort';
 import {MatTableDataSource} from '@angular/material/table';
 import {ActivatedRoute, Router} from '@angular/router';
-import {Observable, Subscription, finalize, first, of} from 'rxjs';
+import {Observable, Subscription, distinctUntilChanged, finalize, first, map} from 'rxjs';
 import {
   Project,
   ProjectService,
@@ -55,6 +55,8 @@ export class StudentsListComponent implements OnInit, AfterViewInit, OnDestroy {
   unit: Unit;
 
   private subscriptions: Subscription[] = [];
+  private studentCacheSubscription: Subscription;
+  private studentLoadSubscription: Subscription;
   public sortState: Sort = {active: 'name', direction: 'asc'};
 
   constructor(
@@ -67,39 +69,14 @@ export class StudentsListComponent implements OnInit, AfterViewInit, OnDestroy {
   ) {}
 
   ngOnInit(): void {
-    this.unit$ = this.unit$ ?? of(this.route.parent.snapshot.data.unit);
+    // The route reuses this component when switching between units, so follow the resolved
+    // unit rather than reading it once from the route snapshot.
+    const unit$ = this.unit$ ?? this.route.parent.data.pipe(map((data) => data.unit as Unit));
+
     this.subscriptions.push(
-      this.unit$?.pipe(first()).subscribe((unit) => {
-        if (!unit) {
-          this.loadingStudents = false;
-          return;
-        }
-
-        this.unit = unit;
-        this.staffFilter = unit.myRole === 'Tutor' ? 'mine' : 'all';
-
-        // Reveal cached students right away
-        this.loadingStudents = this.unit.activeStudents.length === 0;
-
-        this.subscriptions.push(
-          this.unit.studentCache.values.subscribe(() => {
-            this.updateSuggestions();
-            this.updateDataSource();
-          }),
-        );
-
-        this.updateSuggestions();
-        this.updateDataSource();
-        this.projectService
-          .loadStudents(this.unit)
-          .pipe(
-            first(),
-            finalize(() => {
-              this.loadingStudents = false;
-            }),
-          )
-          .subscribe();
-      }),
+      unit$
+        .pipe(distinctUntilChanged((previous, current) => previous?.id === current?.id))
+        .subscribe((unit) => this.showUnit(unit)),
     );
   }
 
@@ -109,7 +86,48 @@ export class StudentsListComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   ngOnDestroy(): void {
+    this.studentCacheSubscription?.unsubscribe();
+    this.studentLoadSubscription?.unsubscribe();
     this.subscriptions.forEach((subscription) => subscription.unsubscribe());
+  }
+
+  private showUnit(unit: Unit): void {
+    this.studentCacheSubscription?.unsubscribe();
+    this.studentLoadSubscription?.unsubscribe();
+    this.unit = unit;
+    this.searchText = '';
+
+    if (!unit) {
+      this.loadingStudents = false;
+      this.filteredSuggestions = [];
+      this.updateDataSource(true);
+      return;
+    }
+
+    this.staffFilter = unit.myRole === 'Tutor' ? 'mine' : 'all';
+
+    this.studentCacheSubscription = unit.studentCache.values.subscribe(() => {
+      this.updateSuggestions();
+      this.updateDataSource();
+    });
+
+    this.updateSuggestions();
+    this.updateDataSource(true);
+
+    // Reveal cached students right away
+    this.loadingStudents = unit.activeStudents.length === 0;
+    this.studentLoadSubscription = this.projectService
+      .loadStudents(unit)
+      .pipe(
+        first(),
+        finalize(() => {
+          // A request for the unit we have moved on from must not clear this unit's skeleton.
+          if (this.unit === unit) {
+            this.loadingStudents = false;
+          }
+        }),
+      )
+      .subscribe();
   }
 
   public onSearchChange(): void {

--- a/src/app/units/states/students-list/students-list.component.ts
+++ b/src/app/units/states/students-list/students-list.component.ts
@@ -175,7 +175,7 @@ export class StudentsListComponent implements OnInit, AfterViewInit, OnDestroy {
     const suggestions = Array.from(new Set(this.unit?.studentFilterTypeAheadData ?? []));
 
     this.filteredSuggestions = suggestions
-      .filter((item) => !searchValue || item.toLowerCase().includes(searchValue))
+      .filter((item) => !searchValue || item?.toLowerCase().includes(searchValue))
       .slice(0, 8);
   }
 
@@ -199,14 +199,8 @@ export class StudentsListComponent implements OnInit, AfterViewInit, OnDestroy {
 
     return [...(this.unit?.activeStudents ?? [])]
       .filter((project) => (this.staffFilter === 'mine' ? project.hasTutor(currentUser) : true))
-      .filter((project) => (searchValue ? this.matchesSearch(project, searchValue) : true))
+      .filter((project) => (searchValue ? project.matches(searchValue) : true))
       .sort((a, b) => this.compareProjects(a, b));
-  }
-
-  private matchesSearch(project: Project, searchValue: string): boolean {
-    return (
-      project.matches(searchValue) || project.student.username?.toLowerCase().includes(searchValue)
-    );
   }
 
   private compareProjects(a: Project, b: Project): number {
@@ -232,9 +226,9 @@ export class StudentsListComponent implements OnInit, AfterViewInit, OnDestroy {
   private sortValue(project: Project, active: string): number | string {
     switch (active) {
       case 'username':
-        return project.student.username?.toLowerCase() || '';
+        return project.student?.username?.toLowerCase() || '';
       case 'name':
-        return project.student.name?.toLowerCase() || '';
+        return project.student?.name?.toLowerCase() || '';
       case 'stats':
         return project.orderScale ?? 0;
       case 'grade':
@@ -248,7 +242,7 @@ export class StudentsListComponent implements OnInit, AfterViewInit, OnDestroy {
       case 'tutorial':
         return project.shortTutorialDescription().toLowerCase();
       default:
-        return project.student.name?.toLowerCase() || '';
+        return project.student?.name?.toLowerCase() || '';
     }
   }
 
@@ -266,9 +260,9 @@ export class StudentsListComponent implements OnInit, AfterViewInit, OnDestroy {
 
   private csvRow(project: Project): string[] {
     const row = [
-      project.student.username || '',
-      project.student.name || '',
-      project.student.email || '',
+      project.student?.username || '',
+      project.student?.name || '',
+      project.student?.email || '',
       String(project.portfolioStatus ?? ''),
     ];
 

--- a/src/app/units/states/students-list/students-list.component.ts
+++ b/src/app/units/states/students-list/students-list.component.ts
@@ -114,10 +114,11 @@ export class StudentsListComponent implements OnInit, AfterViewInit, OnDestroy {
     this.updateSuggestions();
     this.updateDataSource(true);
 
-    // Reveal cached students right away
+    // Students already in the cache can be shown while the current details load, but they may
+    // have been cached in another view minutes ago - so always ask the server for them again.
     this.loadingStudents = unit.activeStudents.length === 0;
     this.studentLoadSubscription = this.projectService
-      .loadStudents(unit)
+      .loadStudents(unit, false, true)
       .pipe(
         first(),
         finalize(() => {


### PR DESCRIPTION
# Description

This PR fixes four defects that made /units/:id/students, /units/:id/students/portfolios, and /units/:id/students/groups behave unpredictably. The search would sometimes stop responding, and the list would sometimes show a different set of students than expected.

## Type of change

_Please delete options that are not relevant._

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration_

## Testing Checklist:

- [ ] Tested in latest Chrome
- [ ] Tested in latest Safari
- [ ] Tested in latest Firefox

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have formatted my changes with `npm run format`
- [x] I have run `npm run lint` with no errors
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have requested a review from @macite and @jakerenzella on the Pull Request
