### PR TITLE
refactor: replace flex-layout with tailwindcss in welcome page

### DIFF
--- a/src/app/welcome/welcome.component.html
+++ b/src/app/welcome/welcome.component.html
@@ -1,20 +1,14 @@
-<section class="welcome" fxFlex fxLayout="row">
-  <f-hero-sidebar fxFlexAlign="start" fxHide.lt-md></f-hero-sidebar>
-  <!-- <section class="content" fxFlex.gt-sm  > -->
-  <section class="content" fxFlex.gt-sm fxLayout.gt-sm="column" [ngClass.gt-sm]="'large'">
+<section class="welcome flex h-screen flex-row">
+  <f-hero-sidebar class="max-fl-md:hidden self-start"></f-hero-sidebar>
+  <!-- <section class="content" fxFlex.gt-sm > -->
+  <section class="content fl-md:flex-1 fl-md:overflow-auto flex flex-col">
     <div class="m-auto w-full max-w-md p-4">
       <div class="subcontainer">
-        <div
-          class="wordmark"
-          fxFlexAlign="start"
-          fxHide.gt-sm
-          fxLayout="row"
-          fxLayoutAlign="start center"
-        >
+        <div class="wordmark flex-row items-center justify-start self-start">
           <img alt="Homepage Logo" src="../../../assets/images/logo-bw.svg" width="40px" />
           <p>{{ externalName.value }}</p>
         </div>
-        <h1 class="welcome-heading" fxFlexAlign="start">Welcome to {{ externalName.value }}</h1>
+        <h1 class="welcome-heading self-start">Welcome to {{ externalName.value }}</h1>
         @if (!loading) {
           <f-edit-profile-form mode="create"></f-edit-profile-form>
         }


### PR DESCRIPTION
# Description

Migrated `src/app/welcome/welcome.component.html` off `ng-flex-layout` directives to native Tailwind utility classes.

**Changes made:**

- Converted `welcome.component.html`: replaced `fxLayout="row"` on the root .welcome section (line 1) with `flex flex-row`
- Replaced bare `fxFlex` on the same element with `h-screen` rather than `flex-1 - fxFlex` makes the directive flex-ify its parent, which is what silently gave the f-welcome host display: flex and let the partial's :host { height: 100vh } cascade into `.welcome`. Giving `.welcome` the 100vh directly reproduces the same box without runtime host mutation, and matches the pattern already shipped in `sign-in.component.html` (custom-md-h-screen)
- Replaced `fxHide.lt-md` on `<f-hero-sidebar>` (line 2) with `max-fl-md:hidden`, and `fxFlexAlign="start"` with `self-start`
- Replaced `fxFlex.gt-sm` on `.content` (line 4) with `fl-md:flex-1`, and `fxLayout.gt-sm="column"` with `flex flex-col`
- Replaced `[ngClass.gt-sm]="'large'"` with `fl-md:overflow-auto`. This is an `ng-flex-layout` extended-module directive rather than an fx* one, so it blocks removing the library too. `.content.large` declares only overflow: auto, and 'large' is referenced nowhere else in the codebase
- Dropped `fxLayout="row"` and `fxHide.gt-sm` from the `.wordmark` block (lines 7–13) without replacement. Kept `flex-row items-center justify-start` for direction and `fxLayoutAlign="start center"`, and `self-start for fxFlexAlign="start"`
- Replaced `fxFlexAlign="start"`on the `<h1>` (line 17) with `self-start`
- No `.scss` changes required

Part of [doubtfire-lms#1187](https://github.com/doubtfire-lms/doubtfire-web/issues/1187)
## Type of change

- [x] Refactor (non-breaking change which restructures existing code without changing functionality)

# How Has This Been Tested?

**Automated tests from `doubtfire-web/`:**

- npx prettier --check src/app/welcome/welcome.component.html
- npm run lint
- npm run typecheck 
- npm run test:ci
- npm run build 

I also did manual visual check by taking screenshots of before/after states. To do this, first, the welcome page only displays when it is user's first time sign in. I signed in using `student_1` then allocated to `welcome.component.ts` and commented out line 36-38, this would prevent the webpage from automatically transfer to `/home` endpoint, therefore I could observe the welcome page before and after making changes.

- Before/after visual check:
<img width="1800" height="1169" alt="Screenshot 2026-08-25 at 4 17 00 PM" src="https://github.com/user-attachments/assets/cbcf1903-537e-4751-8ea0-25c1266ed5f8" />
<img width="1800" height="1169" alt="Screenshot 2026-08-25 at 4 25 30 PM" src="https://github.com/user-attachments/assets/a22f18cb-a440-4de7-bc3b-c813a310424d" />

## Testing Checklist:

- [ ] Tested in latest Chrome
- [x] Tested in latest Safari
- [ ] Tested in latest Firefox

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have formatted my changes with `npm run format`
- [x] I have run `npm run lint` with no errors
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have requested a review from @macite and @jakerenzella on the Pull Request
