### PR TITLE
refactor: replace flex-layout with tailwindcss in tutor's dashboard f…

### DIFF
--- a/src/app/common/footer/footer.component.html
+++ b/src/app/common/footer/footer.component.html
@@ -124,7 +124,7 @@
   </ng-template>
 
   <div class="flex w-full">
-    <f-user-badge fxFlex fxFlexAlign="start start" [selectedTask]="selectedTask"></f-user-badge>
+    <f-user-badge class="flex-1" [selectedTask]="selectedTask"></f-user-badge>
     <div
       class="flex items-center"
       [ngClass]="hideMainActionButtonsForModeration ? 'w-full justify-center' : 'justify-between'"
@@ -180,7 +180,7 @@
       }
     </div>
 
-    <div fxFlex fxFlexAlign="end start" fxLayout="row" fxLayoutAlign="end center">
+    <div class="flex flex-1 flex-row items-center justify-end">
       <!-- @if (selectedTask?.similaritiesDetected) {
         <div class="relative inline-block">
           <div


### PR DESCRIPTION
# Description

Migrated `src/app/common/footer/footer.component.html` off `ng-flex-layout` directives to native Tailwind utility classes. 

**Changes made:**
 
- Converted `footer.component.html`: replaced bare `fxFlex` on the user badge (line 127) and the right-hand tool cluster (line 183) with `flex-1` — `fxFlex` with no value compiles to `flex: 1 1 0%`, verified against the library's compiled output rather than the mapping table alone
- Replaced `fxLayout="row"` with `flex flex-row`
- Replaced `fxLayoutAlign="end center"` with the equivalent `justify-end` (main axis) and `items-center` (cross axis) Tailwind classes
- Dropped `fxFlexAlign="start start"` / `fxFlexAlign="end start"` rather than mapping to `self-*` — the parent flex container's cross-axis alignment already produces the same result, and the second token is not something `fxFlexAlign` consumes

Part of [doubtfire-lms#1187](https://github.com/doubtfire-lms/doubtfire-web/issues/1187)

## Type of change

- [x] Refactor (non-breaking change which restructures existing code without changing functionality)

# How Has This Been Tested?

**Automated tests from `doubtfire-web/`:**

- npx prettier --check src/app/common/footer/footer.component.html
- npm run lint
- npm run typecheck 
- npm run test:ci
- npm run build 

**Before/after visual check:**
<img width="1800" height="1169" alt="Screenshot 2026-08-19 at 8 55 40 PM" src="https://github.com/user-attachments/assets/e6795385-bec6-4ea3-ad26-42902060ee90" />
<img width="1800" height="1169" alt="Screenshot 2026-08-19 at 8 37 54 PM" src="https://github.com/user-attachments/assets/9f0ff98a-90eb-4e65-a149-84e067377b24" />

## Testing Checklist:

- [ ] Tested in latest Chrome
- [x] Tested in latest Safari
- [ ] Tested in latest Firefox

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have formatted my changes with `npm run format`
- [x] I have run `npm run lint` with no errors
- [x] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have requested a review from @macite and @jakerenzella on the Pull Request
