### PR TITLE
refactor: task status chart

### DIFF
--- a/src/app/api/models/calendar-day.ts
+++ b/src/app/api/models/calendar-day.ts
@@ -1,0 +1,31 @@
+/**
+ * Teaching week arithmetic subtracts two dates and divides by a week, so the two
+ * dates have to be a whole number of days apart. Local midnights are not: across a
+ * daylight saving change two of them are 23 or 25 hours apart, which is enough for
+ * `Math.floor(difference / week)` to lose a week and slide every week boundary onto
+ * the wrong day. Pinning each calendar day to midnight UTC keeps the gaps exact.
+ *
+ * The calendar day itself is still read locally, so a date reads as the day the user
+ * sees it, not the day it falls on in UTC.
+ */
+export function startOfDay(date: Date | string | null | undefined): Date | null {
+  if (!date) {
+    return null;
+  }
+
+  const parsed = date instanceof Date ? date : new Date(date);
+  if (Number.isNaN(parsed.valueOf())) {
+    return null;
+  }
+
+  return new Date(Date.UTC(parsed.getFullYear(), parsed.getMonth(), parsed.getDate()));
+}
+
+/**
+ * Add whole days to a day produced by {@link startOfDay}.
+ */
+export function addDays(day: Date, days: number): Date {
+  return new Date(Date.UTC(day.getUTCFullYear(), day.getUTCMonth(), day.getUTCDate() + days));
+}
+
+export const MILLISECONDS_PER_WEEK = 1000 * 60 * 60 * 24 * 7;

--- a/src/app/api/models/task-completion-snapshot.ts
+++ b/src/app/api/models/task-completion-snapshot.ts
@@ -2,6 +2,11 @@ export type TaskCompletionSnapshot = {
   snapshot_date: string;
   snapshot_timestamp: string;
   stats: CampusStats;
+  /**
+   * Set on the filler days the client prepends to pad out week 0. Never sent by the
+   * API - it marks a day that has no real data behind it.
+   */
+  placeholder?: boolean;
 };
 
 export type TaskStatusCounts = {

--- a/src/app/api/models/teaching-period.ts
+++ b/src/app/api/models/teaching-period.ts
@@ -102,18 +102,27 @@ export class TeachingPeriod extends Entity {
   }
 
   public breakAt(date: Date | string): TeachingPeriodBreak | null {
+    return this.findBreakAt(this.breaks, date);
+  }
+
+  /**
+   * The break covering this date that also pauses the week count. Breaks that do
+   * not pause it run alongside a teaching week rather than replacing it.
+   */
+  public weekPausingBreakAt(date: Date | string): TeachingPeriodBreak | null {
+    return this.findBreakAt(this.weekPausingBreaks, date);
+  }
+
+  private findBreakAt(
+    breaks: readonly TeachingPeriodBreak[],
+    date: Date | string,
+  ): TeachingPeriodBreak | null {
     const target = this.normalizeDay(date);
     if (!target) {
       return null;
     }
 
-    return (
-      this.breaks.find((teachingBreak) => {
-        const start = this.normalizeDay(teachingBreak.startDate);
-        const end = this.breakEndDate(teachingBreak);
-        return start !== null && end !== null && target >= start && target < end;
-      }) ?? null
-    );
+    return breaks.find((teachingBreak) => teachingBreak.covers(target)) ?? null;
   }
 
   public get units(): readonly Unit[] {

--- a/src/app/api/models/teaching-period.ts
+++ b/src/app/api/models/teaching-period.ts
@@ -54,6 +54,21 @@ export class TeachingPeriod extends Entity {
     );
   }
 
+  public breakAt(date: Date | string): TeachingPeriodBreak | null {
+    const target = this.normalizeDay(date);
+    if (!target) {
+      return null;
+    }
+
+    return (
+      this.breaks.find((teachingBreak) => {
+        const start = this.normalizeDay(teachingBreak.startDate);
+        const end = this.breakEndDate(teachingBreak);
+        return start !== null && end !== null && target >= start && target < end;
+      }) ?? null
+    );
+  }
+
   public get units(): readonly Unit[] {
     return this.unitsCache.currentValues;
   }

--- a/src/app/api/models/teaching-period.ts
+++ b/src/app/api/models/teaching-period.ts
@@ -1,6 +1,7 @@
 import {Entity, EntityCache, EntityMapping} from 'ngx-entity-service';
 import {Observable} from 'rxjs';
 import {AppInjector} from 'src/app/app-injector';
+import {MILLISECONDS_PER_WEEK, addDays, startOfDay} from './calendar-day';
 import {TeachingPeriodBreakService, TeachingPeriodService, Unit} from './doubtfire-model';
 
 export class TeachingPeriodBreak extends Entity {
@@ -22,30 +23,19 @@ export class TeachingPeriodBreak extends Entity {
    * The day teaching resumes after this break.
    */
   public get endDate(): Date | null {
-    if (!this.startDate || !this.numberOfDays) {
-      return null;
-    }
-
-    const start = this.startDate instanceof Date ? this.startDate : new Date(this.startDate);
-    if (Number.isNaN(start.valueOf())) {
-      return null;
-    }
-
-    return new Date(start.getFullYear(), start.getMonth(), start.getDate() + this.numberOfDays);
+    const start = this.numberOfDays ? startOfDay(this.startDate) : null;
+    return start === null ? null : addDays(start, this.numberOfDays);
   }
 
   /**
    * Is the given date within this break?
    */
-  public covers(date: Date): boolean {
-    const start = this.startDate instanceof Date ? this.startDate : new Date(this.startDate);
+  public covers(date: Date | string): boolean {
+    const day = startOfDay(date);
+    const start = startOfDay(this.startDate);
     const end = this.endDate;
-    if (!end || Number.isNaN(start.valueOf())) {
-      return false;
-    }
 
-    const day = new Date(date.getFullYear(), date.getMonth(), date.getDate());
-    return day >= new Date(start.getFullYear(), start.getMonth(), start.getDate()) && day < end;
+    return day !== null && start !== null && end !== null && day >= start && day < end;
   }
 }
 
@@ -212,8 +202,8 @@ export class TeachingPeriod extends Entity {
       return null;
     }
 
-    const millisecondsPerWeek = 1000 * 60 * 60 * 24 * 7;
-    let result = Math.floor((targetDate.getTime() - startDate.getTime()) / millisecondsPerWeek) + 1;
+    let result =
+      Math.floor((targetDate.getTime() - startDate.getTime()) / MILLISECONDS_PER_WEEK) + 1;
 
     for (const teachingBreak of this.weekPausingBreaks) {
       const breakStart = this.normalizeDay(teachingBreak.startDate);
@@ -233,7 +223,9 @@ export class TeachingPeriod extends Entity {
             result -= 1;
           }
         } else if (targetDate >= firstMonday) {
-          result -= Math.ceil((targetDate.getTime() - firstMonday.getTime()) / millisecondsPerWeek);
+          result -= Math.ceil(
+            (targetDate.getTime() - firstMonday.getTime()) / MILLISECONDS_PER_WEEK,
+          );
         }
 
         if (targetDate >= breakEnd && targetDate < mondayAfterBreak) {
@@ -246,16 +238,7 @@ export class TeachingPeriod extends Entity {
   }
 
   private normalizeDay(date: Date | string | null | undefined): Date | null {
-    if (!date) {
-      return null;
-    }
-
-    const parsed = date instanceof Date ? date : new Date(date);
-    if (Number.isNaN(parsed.valueOf())) {
-      return null;
-    }
-
-    return new Date(parsed.getFullYear(), parsed.getMonth(), parsed.getDate());
+    return startOfDay(date);
   }
 
   private breakEndDate(teachingBreak: TeachingPeriodBreak): Date | null {
@@ -268,18 +251,14 @@ export class TeachingPeriod extends Entity {
       return null;
     }
 
-    if (startDate.getDay() === 1) {
+    if (startDate.getUTCDay() === 1) {
       return startDate;
     }
-    if (startDate.getDay() === 0) {
-      return new Date(startDate.getFullYear(), startDate.getMonth(), startDate.getDate() + 1);
+    if (startDate.getUTCDay() === 0) {
+      return addDays(startDate, 1);
     }
 
-    return new Date(
-      startDate.getFullYear(),
-      startDate.getMonth(),
-      startDate.getDate() + (8 - startDate.getDay()),
-    );
+    return addDays(startDate, 8 - startDate.getUTCDay());
   }
 
   private mondayAfterBreak(teachingBreak: TeachingPeriodBreak): Date | null {
@@ -288,10 +267,6 @@ export class TeachingPeriod extends Entity {
       return null;
     }
 
-    return new Date(
-      firstMonday.getFullYear(),
-      firstMonday.getMonth(),
-      firstMonday.getDate() + teachingBreak.numberOfDays,
-    );
+    return addDays(firstMonday, teachingBreak.numberOfDays);
   }
 }

--- a/src/app/api/models/unit.ts
+++ b/src/app/api/models/unit.ts
@@ -10,6 +10,7 @@ import {MarkingSessionService} from '../services/marking-session.service';
 import {ProjectService} from '../services/project.service';
 import {TaskDefinitionService} from '../services/task-definition.service';
 import {TaskPrerequisiteService} from '../services/task-prerequisite.service';
+import {MILLISECONDS_PER_WEEK, startOfDay} from './calendar-day';
 import {D2lAssessmentMapping} from './d2l/d2l_assessment_mapping';
 import {
   Campus,
@@ -327,26 +328,13 @@ export class Unit extends Entity {
       return this.teachingPeriod.weekNumber(date);
     }
 
-    const targetDate = date instanceof Date ? date : new Date(date);
-    if (Number.isNaN(targetDate.valueOf())) {
+    const targetDate = startOfDay(date);
+    const startDate = startOfDay(this.startDate);
+    if (!targetDate || !startDate) {
       return null;
     }
-    const normalizedTargetDate = new Date(
-      targetDate.getFullYear(),
-      targetDate.getMonth(),
-      targetDate.getDate(),
-    );
-    const normalizedStartDate = new Date(
-      this.startDate.getFullYear(),
-      this.startDate.getMonth(),
-      this.startDate.getDate(),
-    );
-    const millisecondsPerWeek = 1000 * 60 * 60 * 24 * 7;
-    return (
-      Math.floor(
-        (normalizedTargetDate.valueOf() - normalizedStartDate.valueOf()) / millisecondsPerWeek,
-      ) + 1
-    );
+
+    return Math.floor((targetDate.valueOf() - startDate.valueOf()) / MILLISECONDS_PER_WEEK) + 1;
   }
 
   /**

--- a/src/app/units/states/analytics/directives/charts/chart-data-helpers.spec.ts
+++ b/src/app/units/states/analytics/directives/charts/chart-data-helpers.spec.ts
@@ -1,0 +1,90 @@
+import {describe, expect, it} from 'vitest';
+import {TaskCompletionSnapshot} from 'src/app/api/models/doubtfire-model';
+import {Unit} from 'src/app/api/models/unit';
+import {
+  displayWeekNumber,
+  dropLeadingEmptySnapshots,
+  formatSnapshotLabel,
+  isEmptySnapshot,
+} from './chart-data-helpers';
+
+const unitStartingOn = (start: string): Unit =>
+  ({
+    weekNumber: (date: Date | string) => {
+      const target = date instanceof Date ? date : new Date(date);
+      const startDate = new Date(start);
+      return Math.floor((target.valueOf() - startDate.valueOf()) / (1000 * 60 * 60 * 24 * 7)) + 1;
+    },
+  }) as Unit;
+
+const snapshot = (date: string, counts?: Record<string, number>): TaskCompletionSnapshot => ({
+  snapshot_date: date,
+  snapshot_timestamp: String(new Date(date).valueOf()),
+  stats: counts ? {Burwood: {'LA1-01': {T1: counts}}} : {},
+});
+
+describe('displayWeekNumber', () => {
+  const unit = unitStartingOn('2025-03-03');
+
+  it('folds every week before week 1 into week 0', () => {
+    expect(displayWeekNumber(unit, '2025-02-24')).toBe(0); // raw week 0
+    expect(displayWeekNumber(unit, '2025-02-17')).toBe(0); // raw week -1
+    expect(displayWeekNumber(unit, '2025-01-06')).toBe(0); // raw week -6
+  });
+
+  it('leaves teaching weeks untouched', () => {
+    expect(displayWeekNumber(unit, '2025-03-03')).toBe(1);
+    expect(displayWeekNumber(unit, '2025-05-19')).toBe(12);
+  });
+
+  it('passes through a null week number', () => {
+    expect(displayWeekNumber({weekNumber: () => null} as unknown as Unit, '2025-03-03')).toBeNull();
+  });
+
+  it('never labels a snapshot with a negative week', () => {
+    expect(formatSnapshotLabel(unit, '2025-02-17', 'short')).toBe('Week 0');
+    expect(formatSnapshotLabel(unit, '2025-02-17', 'long')).toContain('Week 0');
+  });
+});
+
+describe('isEmptySnapshot', () => {
+  it('treats a snapshot with no campuses as empty', () => {
+    expect(isEmptySnapshot(snapshot('2025-02-17'))).toBe(true);
+  });
+
+  it('treats all-zero counts as empty', () => {
+    expect(isEmptySnapshot(snapshot('2025-02-17', {not_started: 0, complete: 0}))).toBe(true);
+  });
+
+  it('does not treat an all-not-started cohort as empty', () => {
+    expect(isEmptySnapshot(snapshot('2025-03-03', {not_started: 40}))).toBe(false);
+  });
+});
+
+describe('dropLeadingEmptySnapshots', () => {
+  it('drops only the leading run of empty snapshots', () => {
+    const snapshots = [
+      snapshot('2025-02-17'),
+      snapshot('2025-02-18'),
+      snapshot('2025-03-07', {not_started: 40}),
+      snapshot('2025-03-08'), // empty mid-semester: kept, so week widths stay true
+      snapshot('2025-03-09', {complete: 3, not_started: 37}),
+    ];
+
+    expect(dropLeadingEmptySnapshots(snapshots).map((s) => s.snapshot_date)).toEqual([
+      '2025-03-07',
+      '2025-03-08',
+      '2025-03-09',
+    ]);
+  });
+
+  it('leaves a list that starts with data alone', () => {
+    const snapshots = [snapshot('2025-03-07', {complete: 1}), snapshot('2025-03-08')];
+    expect(dropLeadingEmptySnapshots(snapshots)).toBe(snapshots);
+  });
+
+  it('keeps everything when every snapshot is empty', () => {
+    const snapshots = [snapshot('2025-02-17'), snapshot('2025-02-18')];
+    expect(dropLeadingEmptySnapshots(snapshots)).toBe(snapshots);
+  });
+});

--- a/src/app/units/states/analytics/directives/charts/chart-data-helpers.ts
+++ b/src/app/units/states/analytics/directives/charts/chart-data-helpers.ts
@@ -7,6 +7,12 @@ import {
 } from 'src/app/api/models/doubtfire-model';
 import {Unit} from 'src/app/api/models/unit';
 
+// Snapshots can predate the teaching period; fold those into week 0 rather than showing 'Week -2'.
+export function displayWeekNumber(unit: Unit, date: Date | string): number | null {
+  const weekNumber = unit.weekNumber(date);
+  return weekNumber === null ? null : Math.max(weekNumber, 0);
+}
+
 export function formatSnapshotLabel(unit: Unit, snapshotDate?: string, format?: string): string {
   if (!snapshotDate) {
     return '';
@@ -17,7 +23,7 @@ export function formatSnapshotLabel(unit: Unit, snapshotDate?: string, format?: 
     return snapshotDate;
   }
 
-  const weekNumber = unit.weekNumber(date);
+  const weekNumber = displayWeekNumber(unit, date);
   const dayName = new Intl.DateTimeFormat(undefined, {weekday: 'short'}).format(date);
 
   if (!format) {
@@ -128,4 +134,17 @@ export function hasOnlyNotStartedStatuses(snapshot: TaskCompletionSnapshot): boo
 
 export function shouldIncludeSnapshot(unit: Unit, snapshot: TaskCompletionSnapshot): boolean {
   return !(isPreWeekZeroSnapshot(unit, snapshot) && hasOnlyNotStartedStatuses(snapshot));
+}
+
+export function isEmptySnapshot(snapshot: TaskCompletionSnapshot): boolean {
+  return Object.values(aggregateAllCampuses(snapshot.stats)).every((taskStatusCounts) =>
+    Object.values(taskStatusCounts).every((value) => Number(value) === 0),
+  );
+}
+
+export function dropLeadingEmptySnapshots(
+  snapshots: TaskCompletionSnapshot[],
+): TaskCompletionSnapshot[] {
+  const firstPopulated = snapshots.findIndex((snapshot) => !isEmptySnapshot(snapshot));
+  return firstPopulated <= 0 ? snapshots : snapshots.slice(firstPopulated);
 }

--- a/src/app/units/states/analytics/directives/charts/normalised-task-status-chart/normalised-task-status-chart.component.html
+++ b/src/app/units/states/analytics/directives/charts/normalised-task-status-chart/normalised-task-status-chart.component.html
@@ -56,16 +56,16 @@
       <mat-progress-spinner mode="indeterminate" [diameter]="48"></mat-progress-spinner>
     </div>
   }
-  <div class="flex flex-col items-center px-4 pt-0 pb-4">
-    <div class="-mb-2 flex w-full px-4">
+  <div class="px-4 pt-2 pb-4">
+    <div class="relative w-full">
       <mat-slider
-        class="snapshot-slider w-full"
+        class="snapshot-slider"
         [disabled]="snapshots.length <= 1"
         [discrete]="true"
         [displayWith]="formatSnapshotDate"
         [max]="sliderMax"
         [min]="0"
-        [showTickMarks]="true"
+        [showTickMarks]="showTickMarks"
         [step]="1"
       >
         <input
@@ -74,19 +74,37 @@
           (ngModelChange)="onSnapshotSliderChange($event)"
         />
       </mat-slider>
-    </div>
-    <div class="flex w-full justify-between text-center text-sm text-slate-600">
-      @if (snapshotDates.length < 5) {
-        @for (snapshotDate of snapshotDates; track $index) {
-          <span class="min-w-15">{{ snapshotDate }}</span>
-        }
-      } @else {
-        @for (snapshotWeek of snapshotWeeks; track $index) {
-          <span class="min-w-15">{{ snapshotWeek }}</span>
-        }
+      @if (weekSegments.length > 1) {
+        <div
+          #weekTrack
+          aria-label="Teaching weeks"
+          class="relative -mt-1.5 h-6 w-full select-none"
+          role="group"
+        >
+          @for (segment of weekSegments; track segment.key) {
+            <button
+              class="absolute inset-y-0 flex cursor-pointer items-center justify-center overflow-hidden border-r border-white p-0 text-xs leading-none whitespace-nowrap tabular-nums transition-colors first:rounded-l-sm last:rounded-r-sm last:border-r-0 focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-formatif-blue"
+              type="button"
+              [attr.aria-current]="isActiveWeek(segment) ? 'true' : null"
+              [attr.aria-label]="segment.tooltip"
+              [matTooltip]="segment.tooltip"
+              [ngClass]="
+                isActiveWeek(segment)
+                  ? 'bg-formatif-blue font-semibold text-white'
+                  : 'bg-slate-100 text-slate-600 hover:bg-slate-200'
+              "
+              [style.left]="segment.leftStyle"
+              [style.width]="segment.widthStyle"
+              (click)="selectWeek(segment)"
+            >
+              {{ segment.text }}
+            </button>
+          }
+        </div>
       }
     </div>
   </div>
+
   <!-- <mat-card-header class="text-pretty xl:max-w-[calc(50%)]">
     <mat-card-title>Task Completion Status Over Time</mat-card-title>
     <mat-card-subtitle class="mb-2.5">

--- a/src/app/units/states/analytics/directives/charts/normalised-task-status-chart/normalised-task-status-chart.component.html
+++ b/src/app/units/states/analytics/directives/charts/normalised-task-status-chart/normalised-task-status-chart.component.html
@@ -56,7 +56,7 @@
       <mat-progress-spinner mode="indeterminate" [diameter]="48"></mat-progress-spinner>
     </div>
   }
-  <div class="px-4 pt-2 pb-4">
+  <div class="px-4 pt-2 pb-8">
     <div class="relative w-full">
       <mat-slider
         class="snapshot-slider"
@@ -74,11 +74,32 @@
           (ngModelChange)="onSnapshotSliderChange($event)"
         />
       </mat-slider>
+      @if (breakSegments.length) {
+        <div
+          aria-label="Teaching period breaks"
+          class="relative mt-1 w-full select-none"
+          role="group"
+          [style.height]="breakBandHeight"
+        >
+          @for (segment of breakSegments; track segment.key) {
+            <div
+              class="break-pill absolute flex h-5 items-center overflow-hidden rounded px-1 text-[10px] leading-none text-slate-600"
+              [attr.aria-label]="segment.tooltip"
+              [matTooltip]="segment.tooltip"
+              [style.left]="segment.leftStyle"
+              [style.top]="breakLaneStyle(segment)"
+              [style.width]="segment.widthStyle"
+            >
+              <span class="min-w-0 flex-1 truncate">{{ segment.text }}</span>
+            </div>
+          }
+        </div>
+      }
       @if (weekSegments.length > 1) {
         <div
           #weekTrack
           aria-label="Teaching weeks"
-          class="relative -mt-1.5 h-6 w-full select-none"
+          class="relative -mt-1.5 h-7 w-full select-none"
           role="group"
         >
           @for (segment of weekSegments; track segment.key) {

--- a/src/app/units/states/analytics/directives/charts/normalised-task-status-chart/normalised-task-status-chart.component.html
+++ b/src/app/units/states/analytics/directives/charts/normalised-task-status-chart/normalised-task-status-chart.component.html
@@ -88,11 +88,7 @@
               [attr.aria-current]="isActiveWeek(segment) ? 'true' : null"
               [attr.aria-label]="segment.tooltip"
               [matTooltip]="segment.tooltip"
-              [ngClass]="
-                isActiveWeek(segment)
-                  ? 'bg-formatif-blue font-semibold text-white'
-                  : 'bg-slate-100 text-slate-600 hover:bg-slate-200'
-              "
+              [ngClass]="segmentClasses(segment)"
               [style.left]="segment.leftStyle"
               [style.width]="segment.widthStyle"
               (click)="selectWeek(segment)"

--- a/src/app/units/states/analytics/directives/charts/normalised-task-status-chart/normalised-task-status-chart.component.html
+++ b/src/app/units/states/analytics/directives/charts/normalised-task-status-chart/normalised-task-status-chart.component.html
@@ -11,7 +11,7 @@
     </mat-card-header>
     <div class="flex items-center gap-2 p-4">
       <mat-form-field appearance="outline" subscriptSizing="dynamic">
-        <mat-select [(ngModel)]="campusFilter" (selectionChange)="refreshData()">
+        <mat-select [(ngModel)]="campusFilter" (selectionChange)="onCampusFilterChange()">
           <mat-option value="all">All</mat-option>
           @for (campus of campuses; track campus) {
             <mat-option [value]="campus">{{ campus }}</mat-option>

--- a/src/app/units/states/analytics/directives/charts/normalised-task-status-chart/normalised-task-status-chart.component.scss
+++ b/src/app/units/states/analytics/directives/charts/normalised-task-status-chart/normalised-task-status-chart.component.scss
@@ -15,3 +15,10 @@
 :host ::ng-deep .snapshot-slider .mdc-slider__value-indicator-text {
   white-space: nowrap;
 }
+
+// The slider's own 8px side margins would put its track out of step with the week band below it.
+:host ::ng-deep .snapshot-slider.mat-mdc-slider {
+  display: block;
+  margin-inline: 0;
+  width: 100%;
+}

--- a/src/app/units/states/analytics/directives/charts/normalised-task-status-chart/normalised-task-status-chart.component.scss
+++ b/src/app/units/states/analytics/directives/charts/normalised-task-status-chart/normalised-task-status-chart.component.scss
@@ -22,3 +22,15 @@
   margin-inline: 0;
   width: 100%;
 }
+
+// Break pills are hatched so a break reads as 'no teaching' rather than as another
+// week, whether it sits above its own break segment or over the weeks it runs through.
+.break-pill {
+  background-color: var(--color-slate-50, #f8fafc);
+  background-image: repeating-linear-gradient(
+    -45deg,
+    var(--color-slate-200, #e2e8f0) 0 4px,
+    transparent 4px 8px
+  );
+  border: 1px solid var(--color-slate-200, #e2e8f0);
+}

--- a/src/app/units/states/analytics/directives/charts/normalised-task-status-chart/normalised-task-status-chart.component.ts
+++ b/src/app/units/states/analytics/directives/charts/normalised-task-status-chart/normalised-task-status-chart.component.ts
@@ -45,6 +45,21 @@ export interface SnapshotWeekSegment {
   widthStyle: string;
 }
 
+export interface SnapshotBreakSegment {
+  key: string;
+  label: string;
+  text: string;
+  tooltip: string;
+  lane: number;
+  pausesWeekCount: boolean;
+  startIndex: number;
+  endIndex: number;
+  startFraction: number;
+  endFraction: number;
+  leftStyle: string;
+  widthStyle: string;
+}
+
 // The Material slider centres its thumb between this inset and `width - inset`.
 const TICK_MARK_OFFSET = 3;
 const FULL_LABEL_MIN_WIDTH = 56;
@@ -53,6 +68,10 @@ const SHORT_LABEL_MIN_WIDTH = 28;
 const MAX_TICK_MARKS = 40;
 // Week 0 starts mid-week and the current week is only days old, so both are widened to stay readable.
 const MIN_EDGE_SEGMENT_WIDTH = 60;
+// A one week break is only a few dozen pixels wide, so its name is truncated rather
+// than hidden. Below this even an ellipsis is noise, and the tooltip has to carry it.
+const BREAK_LABEL_MIN_WIDTH = 24;
+const BREAK_LANE_HEIGHT = 24;
 
 const offsetStyle = (fraction: number) =>
   `calc(${TICK_MARK_OFFSET}px + ${fraction} * (100% - ${TICK_MARK_OFFSET * 2}px))`;
@@ -74,7 +93,10 @@ export class NormalisedTaskStatusChartComponent implements OnInit, OnDestroy {
   snapshots: TaskCompletionSnapshot[] = [];
   campuses: string[] = [];
   weekSegments: SnapshotWeekSegment[] = [];
+  breakSegments: SnapshotBreakSegment[] = [];
+  breakLaneCount: number = 0;
 
+  private weekBoundaries: number[] = [];
   private trackWidth: number = 0;
   private resizeObserver?: ResizeObserver;
 
@@ -211,6 +233,7 @@ export class NormalisedTaskStatusChartComponent implements OnInit, OnDestroy {
   private updateWeekBand(): void {
     if (this.trackWidth === 0) {
       this.weekSegments.forEach((segment) => (segment.text = segment.label));
+      this.breakSegments.forEach((segment) => (segment.text = segment.label));
       return;
     }
 
@@ -232,6 +255,55 @@ export class NormalisedTaskStatusChartComponent implements OnInit, OnDestroy {
       segment.text =
         widths[index] < requiredWidth ? '' : useFullLabels ? segment.label : segment.shortLabel;
     });
+
+    this.updateBreakBand();
+  }
+
+  /**
+   * Break pills are laid out against the week band's final geometry rather than
+   * the raw fractions, so a widened edge week cannot push them out of step.
+   */
+  private updateBreakBand(): void {
+    this.breakSegments.forEach((segment) => {
+      const left = this.pixelForFraction(segment.startFraction);
+      const right = this.pixelForFraction(segment.endFraction);
+
+      if (left === null || right === null) {
+        segment.leftStyle = offsetStyle(segment.startFraction);
+        segment.widthStyle = spanStyle(segment.endFraction - segment.startFraction);
+        segment.text = segment.label;
+        return;
+      }
+
+      const width = Math.max(right - left, 0);
+      segment.leftStyle = `${left}px`;
+      segment.widthStyle = `${width}px`;
+      // Anything wider keeps the name and lets CSS truncate it.
+      segment.text = width < BREAK_LABEL_MIN_WIDTH ? '' : segment.label;
+    });
+  }
+
+  /**
+   * Map a track fraction onto the pixel position the week band settled on, so both
+   * bands share the same boundaries.
+   */
+  private pixelForFraction(fraction: number): number | null {
+    if (this.weekBoundaries.length !== this.weekSegments.length + 1) {
+      return null;
+    }
+
+    let index = this.weekSegments.findIndex((segment) => fraction <= segment.endFraction);
+    if (index < 0) {
+      index = this.weekSegments.length - 1;
+    }
+
+    const segment = this.weekSegments[index];
+    const span = segment.endFraction - segment.startFraction;
+    const ratio = span <= 0 ? 0 : (fraction - segment.startFraction) / span;
+    const left = this.weekBoundaries[index];
+    const right = this.weekBoundaries[index + 1];
+
+    return left + Math.min(Math.max(ratio, 0), 1) * (right - left);
   }
 
   private widenEdgeSegments(widths: number[], usableWidth: number, requiredWidth: number): void {
@@ -239,6 +311,14 @@ export class NormalisedTaskStatusChartComponent implements OnInit, OnDestroy {
       segment.leftStyle = offsetStyle(segment.startFraction);
       segment.widthStyle = spanStyle(segment.endFraction - segment.startFraction);
     });
+
+    const boundaries = this.weekSegments.map(
+      (segment) => TICK_MARK_OFFSET + segment.startFraction * usableWidth,
+    );
+    boundaries.push(TICK_MARK_OFFSET + usableWidth);
+    // Widening below adjusts this same array in place, so the break band always
+    // reads the final geometry.
+    this.weekBoundaries = boundaries;
 
     const lastIndex = this.weekSegments.length - 1;
     if (lastIndex < 0) {
@@ -251,11 +331,6 @@ export class NormalisedTaskStatusChartComponent implements OnInit, OnDestroy {
     if (!widenLeading && !widenTrailing) {
       return;
     }
-
-    const boundaries = this.weekSegments.map(
-      (segment) => TICK_MARK_OFFSET + segment.startFraction * usableWidth,
-    );
-    boundaries.push(TICK_MARK_OFFSET + usableWidth);
 
     const spareOf = (index: number) => Math.max((widths[index] ?? 0) - requiredWidth, 0);
 
@@ -319,6 +394,8 @@ export class NormalisedTaskStatusChartComponent implements OnInit, OnDestroy {
     const total = this.snapshots.length;
     if (total === 0) {
       this.weekSegments = [];
+      this.breakSegments = [];
+      this.breakLaneCount = 0;
       return;
     }
 
@@ -332,8 +409,9 @@ export class NormalisedTaskStatusChartComponent implements OnInit, OnDestroy {
 
     this.snapshots.forEach((snapshot, index) => {
       const date = new Date(snapshot.snapshot_date);
-      // Break days are their own segment, otherwise a break reads as one very long week.
-      const teachingBreak = this.unit.teachingPeriod?.breakAt(date) ?? null;
+      // Only a break that pauses the week count has no week of its own. Breaks that
+      // leave the count running are drawn in the band above, alongside their week.
+      const teachingBreak = this.unit.teachingPeriod?.weekPausingBreakAt(date) ?? null;
       const weekNumber = teachingBreak ? null : displayWeekNumber(this.unit, date);
       // Nulls merge too, so a unit with no start date collapses to one suppressed segment.
       const key = teachingBreak ? `break-${teachingBreak.id}` : `week-${weekNumber}`;
@@ -363,12 +441,7 @@ export class NormalisedTaskStatusChartComponent implements OnInit, OnDestroy {
         : group.weekNumber === null
           ? '–'
           : `W${group.weekNumber}`;
-      const startDate = formatSnapshotLabel(
-        this.unit,
-        this.snapshots[group.startIndex]?.snapshot_date,
-      );
-      const endDate = formatSnapshotLabel(this.unit, this.snapshots[group.endIndex]?.snapshot_date);
-      const range = startDate === endDate ? startDate : `${startDate} – ${endDate}`;
+      const range = this.snapshotRangeLabel(group.startIndex, group.endIndex);
       const tooltip = group.teachingBreak
         ? [group.teachingBreak.label || 'Break', range, this.breakCampuses(group.teachingBreak)]
             .filter((part) => part)
@@ -391,7 +464,97 @@ export class NormalisedTaskStatusChartComponent implements OnInit, OnDestroy {
       };
     });
 
+    this.buildBreakSegments();
     this.updateWeekBand();
+  }
+
+  /**
+   * Every break that overlaps the snapshot range, drawn over the weeks it spans.
+   * A break that pauses the week count sits above its own 'Break' week segment; one
+   * that does not runs alongside the teaching weeks it overlaps, which is why the
+   * breaks need a band of their own.
+   */
+  private buildBreakSegments(): void {
+    const total = this.snapshots.length;
+    const breaks = this.unit.teachingPeriod?.breaks ?? [];
+
+    if (total === 0 || breaks.length === 0) {
+      this.breakSegments = [];
+      this.breakLaneCount = 0;
+      return;
+    }
+
+    const denominator = Math.max(total - 1, 1);
+    const snapshotDates = this.snapshots.map((snapshot) => new Date(snapshot.snapshot_date));
+
+    const spans = breaks
+      .map((teachingBreak) => {
+        const covered = snapshotDates.reduce<number[]>((acc, date, index) => {
+          if (teachingBreak.covers(date)) {
+            acc.push(index);
+          }
+          return acc;
+        }, []);
+
+        return covered.length === 0
+          ? null
+          : {
+              teachingBreak,
+              startIndex: covered[0],
+              endIndex: covered[covered.length - 1],
+            };
+      })
+      .filter((span) => span !== null)
+      .sort((left, right) => left.startIndex - right.startIndex);
+
+    // Campus specific breaks can run at the same time, so overlapping pills stack.
+    const laneEnds: number[] = [];
+
+    this.breakSegments = spans.map((span) => {
+      let lane = laneEnds.findIndex((end) => end < span.startIndex);
+      if (lane === -1) {
+        lane = laneEnds.length;
+      }
+      laneEnds[lane] = span.endIndex;
+
+      const startFraction = span.startIndex === 0 ? 0 : (span.startIndex - 0.5) / denominator;
+      const endFraction = span.endIndex === total - 1 ? 1 : (span.endIndex + 0.5) / denominator;
+      const label = span.teachingBreak.label || 'Break';
+      const range = this.snapshotRangeLabel(span.startIndex, span.endIndex);
+
+      return {
+        key: `break-${span.teachingBreak.id}`,
+        label,
+        text: label,
+        tooltip: [label, range, this.breakCampuses(span.teachingBreak)]
+          .filter((part) => part)
+          .join(' · '),
+        lane,
+        pausesWeekCount: span.teachingBreak.pauseWeekCount,
+        startIndex: span.startIndex,
+        endIndex: span.endIndex,
+        startFraction,
+        endFraction,
+        leftStyle: offsetStyle(startFraction),
+        widthStyle: spanStyle(endFraction - startFraction),
+      };
+    });
+
+    this.breakLaneCount = laneEnds.length;
+  }
+
+  get breakBandHeight(): string {
+    return `${this.breakLaneCount * BREAK_LANE_HEIGHT}px`;
+  }
+
+  breakLaneStyle(segment: SnapshotBreakSegment): string {
+    return `${segment.lane * BREAK_LANE_HEIGHT}px`;
+  }
+
+  private snapshotRangeLabel(startIndex: number, endIndex: number): string {
+    const start = formatSnapshotLabel(this.unit, this.snapshots[startIndex]?.snapshot_date);
+    const end = formatSnapshotLabel(this.unit, this.snapshots[endIndex]?.snapshot_date);
+    return start === end ? start : `${start} – ${end}`;
   }
 
   private buildChartData(taskStats: TaskCodeStats): MultiSeries {

--- a/src/app/units/states/analytics/directives/charts/normalised-task-status-chart/normalised-task-status-chart.component.ts
+++ b/src/app/units/states/analytics/directives/charts/normalised-task-status-chart/normalised-task-status-chart.component.ts
@@ -2,9 +2,13 @@ import {MultiSeries, TooltipService} from '@glitchtip/ng-charts';
 import {
   ChangeDetectorRef,
   Component,
+  ElementRef,
   Injector,
   Input,
+  NgZone,
+  OnDestroy,
   OnInit,
+  ViewChild,
   ViewContainerRef,
 } from '@angular/core';
 import {filter, map, take} from 'rxjs/operators';
@@ -17,11 +21,40 @@ import {SidekiqProgressModalService} from 'src/app/common/modals/sidekiq-progres
 import {AlertService} from 'src/app/common/services/alert.service';
 import {
   countStudentsFromSnapshot,
+  displayWeekNumber,
+  dropLeadingEmptySnapshots,
   formatSnapshotLabel,
   getTaskStats,
   shouldIncludeSnapshot,
   statusMapping,
 } from '../chart-data-helpers';
+
+export interface SnapshotWeekSegment {
+  key: string;
+  label: string;
+  shortLabel: string;
+  text: string;
+  tooltip: string;
+  startIndex: number;
+  endIndex: number;
+  startFraction: number;
+  endFraction: number;
+  leftStyle: string;
+  widthStyle: string;
+}
+
+// The Material slider centres its thumb between this inset and `width - inset`.
+const TICK_MARK_OFFSET = 3;
+const FULL_LABEL_MIN_WIDTH = 56;
+const SHORT_LABEL_MIN_WIDTH = 28;
+// Beyond this many snapshots the slider's tick marks merge into a solid line, so they are hidden.
+const MAX_TICK_MARKS = 40;
+// Week 0 starts mid-week and the current week is only days old, so both are widened to stay readable.
+const MIN_EDGE_SEGMENT_WIDTH = 60;
+
+const offsetStyle = (fraction: number) =>
+  `calc(${TICK_MARK_OFFSET}px + ${fraction} * (100% - ${TICK_MARK_OFFSET * 2}px))`;
+const spanStyle = (fraction: number) => `calc(${fraction} * (100% - ${TICK_MARK_OFFSET * 2}px))`;
 
 @Component({
   selector: 'f-normalised-task-status-chart',
@@ -29,7 +62,7 @@ import {
   styleUrl: './normalised-task-status-chart.component.scss',
   standalone: false,
 })
-export class NormalisedTaskStatusChartComponent implements OnInit {
+export class NormalisedTaskStatusChartComponent implements OnInit, OnDestroy {
   @Input() unit: Unit;
 
   data: MultiSeries = [];
@@ -38,6 +71,30 @@ export class NormalisedTaskStatusChartComponent implements OnInit {
   sliderSelect: number = 0;
   snapshots: TaskCompletionSnapshot[] = [];
   campuses: string[] = [];
+  weekSegments: SnapshotWeekSegment[] = [];
+
+  private trackWidth: number = 0;
+  private resizeObserver?: ResizeObserver;
+
+  @ViewChild('weekTrack')
+  set weekTrack(ref: ElementRef<HTMLElement> | undefined) {
+    this.resizeObserver?.disconnect();
+    this.resizeObserver = undefined;
+
+    if (!ref) {
+      return;
+    }
+
+    // observe() fires the first measurement; assigning here would mutate a value already read.
+    this.resizeObserver = new ResizeObserver((entries) => {
+      this.ngZone.run(() => {
+        this.trackWidth = entries[0]?.contentRect.width ?? 0;
+        this.updateWeekBand();
+        this.changeDetectorRef.markForCheck();
+      });
+    });
+    this.resizeObserver.observe(ref.nativeElement);
+  }
 
   // options
   normalisedCompletionSnapshotXLabel: string = 'Task';
@@ -60,33 +117,15 @@ export class NormalisedTaskStatusChartComponent implements OnInit {
   }
 
   get firstSnapshotDate(): string {
-    return formatSnapshotLabel(this.unit, this.snapshots[0]?.snapshot_date, 'long');
+    return formatSnapshotLabel(this.unit, this.snapshots[0]?.snapshot_date);
   }
 
   get lastSnapshotDate(): string {
-    return formatSnapshotLabel(
-      this.unit,
-      this.snapshots[this.snapshots.length - 1]?.snapshot_date,
-      'long',
-    );
+    return formatSnapshotLabel(this.unit, this.snapshots[this.snapshots.length - 1]?.snapshot_date);
   }
 
-  get snapshotDates(): string[] {
-    return this.snapshots.map((snapshot) => formatSnapshotLabel(this.unit, snapshot.snapshot_date));
-  }
-
-  get snapshotWeeks(): string[] {
-    const weeks = this.snapshots.map((snapshot) =>
-      formatSnapshotLabel(this.unit, snapshot.snapshot_date, 'short'),
-    );
-    return weeks.reduce((acc: string[], week: string) => {
-      if (!acc.includes(week)) {
-        acc.push(week);
-      } else {
-        acc.push('');
-      }
-      return acc;
-    }, []);
+  get showTickMarks(): boolean {
+    return this.snapshots.length <= MAX_TICK_MARKS;
   }
 
   get snapshotStudentCount(): number {
@@ -122,6 +161,7 @@ export class NormalisedTaskStatusChartComponent implements OnInit {
     private viewContainerRef: ViewContainerRef,
     private injectorObj: Injector,
     private changeDetectorRef: ChangeDetectorRef,
+    private ngZone: NgZone,
   ) {
     // https://github.com/swimlane/ngx-charts/issues/1428#issuecomment-659237562
     this.chartToolTipService = this.injectorObj.get(TooltipService);
@@ -137,6 +177,10 @@ export class NormalisedTaskStatusChartComponent implements OnInit {
       (labels) => this.taskService.statusColors.get(labels) || '#000000',
     );
     this.loadRecentSnapshot();
+  }
+
+  ngOnDestroy(): void {
+    this.resizeObserver?.disconnect();
   }
 
   refreshData() {
@@ -160,6 +204,140 @@ export class NormalisedTaskStatusChartComponent implements OnInit {
   onSnapshotSliderChange(value: number): void {
     this.sliderSelect = Math.min(Math.max(Math.round(Number(value)), 0), this.sliderMax);
     this.refreshData();
+  }
+
+  private updateWeekBand(): void {
+    if (this.trackWidth === 0) {
+      this.weekSegments.forEach((segment) => (segment.text = segment.label));
+      return;
+    }
+
+    const usableWidth = Math.max(this.trackWidth - TICK_MARK_OFFSET * 2, 0);
+    const widths = this.weekSegments.map(
+      (segment) => (segment.endFraction - segment.startFraction) * usableWidth,
+    );
+    // Format comes from the natural widths, so widening an edge week cannot flip the whole band.
+    const sorted = [...widths].sort((left, right) => left - right);
+    const medianWidth = sorted[Math.floor(sorted.length / 2)];
+    const narrowestSegment = Math.min(...sorted.filter((width) => width >= medianWidth / 2));
+
+    const useFullLabels = narrowestSegment >= FULL_LABEL_MIN_WIDTH;
+    const requiredWidth = useFullLabels ? FULL_LABEL_MIN_WIDTH : SHORT_LABEL_MIN_WIDTH;
+
+    this.widenEdgeSegments(widths, usableWidth, requiredWidth);
+
+    this.weekSegments.forEach((segment, index) => {
+      segment.text =
+        widths[index] < requiredWidth ? '' : useFullLabels ? segment.label : segment.shortLabel;
+    });
+  }
+
+  private widenEdgeSegments(widths: number[], usableWidth: number, requiredWidth: number): void {
+    this.weekSegments.forEach((segment) => {
+      segment.leftStyle = offsetStyle(segment.startFraction);
+      segment.widthStyle = spanStyle(segment.endFraction - segment.startFraction);
+    });
+
+    const lastIndex = this.weekSegments.length - 1;
+    if (lastIndex < 0) {
+      return;
+    }
+
+    const minimum = Math.min(MIN_EDGE_SEGMENT_WIDTH, usableWidth);
+    const widenLeading = widths[0] < minimum;
+    const widenTrailing = lastIndex > 0 && widths[lastIndex] < minimum;
+    if (!widenLeading && !widenTrailing) {
+      return;
+    }
+
+    const boundaries = this.weekSegments.map(
+      (segment) => TICK_MARK_OFFSET + segment.startFraction * usableWidth,
+    );
+    boundaries.push(TICK_MARK_OFFSET + usableWidth);
+
+    const spareOf = (index: number) => Math.max((widths[index] ?? 0) - requiredWidth, 0);
+
+    if (widenLeading) {
+      boundaries[1] = boundaries[0] + Math.min(minimum, widths[0] + spareOf(1));
+    }
+    if (widenTrailing) {
+      boundaries[lastIndex] =
+        boundaries[lastIndex + 1] - Math.min(minimum, widths[lastIndex] + spareOf(lastIndex - 1));
+    }
+
+    for (let index = 1; index <= lastIndex; index += 1) {
+      boundaries[index] = Math.min(
+        Math.max(boundaries[index], boundaries[index - 1]),
+        boundaries[lastIndex + 1],
+      );
+    }
+
+    this.weekSegments.forEach((segment, index) => {
+      const width = boundaries[index + 1] - boundaries[index];
+      segment.leftStyle = `${boundaries[index]}px`;
+      segment.widthStyle = `${width}px`;
+      widths[index] = width;
+    });
+  }
+
+  isActiveWeek(segment: SnapshotWeekSegment): boolean {
+    return this.sliderSelect >= segment.startIndex && this.sliderSelect <= segment.endIndex;
+  }
+
+  selectWeek(segment: SnapshotWeekSegment): void {
+    this.onSnapshotSliderChange(segment.endIndex);
+  }
+
+  private buildWeekSegments(): void {
+    const total = this.snapshots.length;
+    if (total === 0) {
+      this.weekSegments = [];
+      return;
+    }
+
+    const groups: {weekNumber: number | null; startIndex: number; endIndex: number}[] = [];
+    this.snapshots.forEach((snapshot, index) => {
+      const weekNumber = displayWeekNumber(this.unit, new Date(snapshot.snapshot_date));
+      const current = groups[groups.length - 1];
+
+      // Nulls merge too, so a unit with no start date collapses to one suppressed segment.
+      if (current && current.weekNumber === weekNumber) {
+        current.endIndex = index;
+      } else {
+        groups.push({weekNumber, startIndex: index, endIndex: index});
+      }
+    });
+
+    const denominator = Math.max(total - 1, 1);
+
+    this.weekSegments = groups.map((group) => {
+      const startFraction = group.startIndex === 0 ? 0 : (group.startIndex - 0.5) / denominator;
+      const endFraction = group.endIndex === total - 1 ? 1 : (group.endIndex + 0.5) / denominator;
+      const label = group.weekNumber === null ? 'Unscheduled' : `Week ${group.weekNumber}`;
+      const shortLabel = group.weekNumber === null ? '–' : `W${group.weekNumber}`;
+      const startDate = formatSnapshotLabel(
+        this.unit,
+        this.snapshots[group.startIndex]?.snapshot_date,
+      );
+      const endDate = formatSnapshotLabel(this.unit, this.snapshots[group.endIndex]?.snapshot_date);
+      const range = startDate === endDate ? startDate : `${startDate} – ${endDate}`;
+
+      return {
+        key: `${label}-${group.startIndex}`,
+        label,
+        shortLabel,
+        text: label,
+        tooltip: `${label} · ${range}`,
+        startIndex: group.startIndex,
+        endIndex: group.endIndex,
+        startFraction,
+        endFraction,
+        leftStyle: offsetStyle(startFraction),
+        widthStyle: spanStyle(endFraction - startFraction),
+      };
+    });
+
+    this.updateWeekBand();
   }
 
   private buildChartData(taskStats: TaskCodeStats): MultiSeries {
@@ -230,8 +408,9 @@ export class NormalisedTaskStatusChartComponent implements OnInit {
             return acc;
           }, [] as TaskCompletionSnapshot[])
           .filter((snapshot) => shouldIncludeSnapshot(this.unit, snapshot));
-        this.snapshots = [...this.snapshots].reverse();
+        this.snapshots = dropLeadingEmptySnapshots([...this.snapshots].reverse());
         this.sliderSelect = Math.max(this.snapshots.length - 1, 0);
+        this.buildWeekSegments();
         this.refreshData();
         this.changeDetectorRef.detectChanges();
 

--- a/src/app/units/states/analytics/directives/charts/normalised-task-status-chart/normalised-task-status-chart.component.ts
+++ b/src/app/units/states/analytics/directives/charts/normalised-task-status-chart/normalised-task-status-chart.component.ts
@@ -14,6 +14,7 @@ import {
 import {filter, map, take} from 'rxjs/operators';
 import {TaskCodeStats, TaskCompletionSnapshot} from 'src/app/api/models/doubtfire-model';
 import {SidekiqJob} from 'src/app/api/models/sidekiq-job';
+import {TeachingPeriodBreak} from 'src/app/api/models/teaching-period';
 import {Unit} from 'src/app/api/models/unit';
 import {SidekiqJobService} from 'src/app/api/services/sidekiq-job.service';
 import {TaskService} from 'src/app/api/services/task.service';
@@ -31,6 +32,7 @@ import {
 
 export interface SnapshotWeekSegment {
   key: string;
+  isBreak: boolean;
   label: string;
   shortLabel: string;
   text: string;
@@ -280,6 +282,31 @@ export class NormalisedTaskStatusChartComponent implements OnInit, OnDestroy {
     });
   }
 
+  segmentClasses(segment: SnapshotWeekSegment): string {
+    if (segment.isBreak) {
+      return this.isActiveWeek(segment)
+        ? 'bg-slate-300 font-semibold text-slate-700'
+        : 'bg-slate-50 text-slate-400 hover:bg-slate-100';
+    }
+
+    return this.isActiveWeek(segment)
+      ? 'bg-formatif-blue font-semibold text-white'
+      : 'bg-slate-100 text-slate-600 hover:bg-slate-200';
+  }
+
+  private breakCampuses(teachingBreak: TeachingPeriodBreak): string {
+    if (teachingBreak.campusIds.length === 0) {
+      return 'All campuses';
+    }
+
+    const names = this.unit.tutorials
+      .map((tutorial) => tutorial.campus)
+      .filter((campus) => campus && teachingBreak.campusIds.includes(campus.id))
+      .map((campus) => campus.name);
+
+    return [...new Set(names)].join(', ');
+  }
+
   isActiveWeek(segment: SnapshotWeekSegment): boolean {
     return this.sliderSelect >= segment.startIndex && this.sliderSelect <= segment.endIndex;
   }
@@ -295,16 +322,27 @@ export class NormalisedTaskStatusChartComponent implements OnInit, OnDestroy {
       return;
     }
 
-    const groups: {weekNumber: number | null; startIndex: number; endIndex: number}[] = [];
+    const groups: {
+      key: string;
+      weekNumber: number | null;
+      teachingBreak: TeachingPeriodBreak | null;
+      startIndex: number;
+      endIndex: number;
+    }[] = [];
+
     this.snapshots.forEach((snapshot, index) => {
-      const weekNumber = displayWeekNumber(this.unit, new Date(snapshot.snapshot_date));
+      const date = new Date(snapshot.snapshot_date);
+      // Break days are their own segment, otherwise a break reads as one very long week.
+      const teachingBreak = this.unit.teachingPeriod?.breakAt(date) ?? null;
+      const weekNumber = teachingBreak ? null : displayWeekNumber(this.unit, date);
+      // Nulls merge too, so a unit with no start date collapses to one suppressed segment.
+      const key = teachingBreak ? `break-${teachingBreak.id}` : `week-${weekNumber}`;
       const current = groups[groups.length - 1];
 
-      // Nulls merge too, so a unit with no start date collapses to one suppressed segment.
-      if (current && current.weekNumber === weekNumber) {
+      if (current && current.key === key) {
         current.endIndex = index;
       } else {
-        groups.push({weekNumber, startIndex: index, endIndex: index});
+        groups.push({key, weekNumber, teachingBreak, startIndex: index, endIndex: index});
       }
     });
 
@@ -313,21 +351,37 @@ export class NormalisedTaskStatusChartComponent implements OnInit, OnDestroy {
     this.weekSegments = groups.map((group) => {
       const startFraction = group.startIndex === 0 ? 0 : (group.startIndex - 0.5) / denominator;
       const endFraction = group.endIndex === total - 1 ? 1 : (group.endIndex + 0.5) / denominator;
-      const label = group.weekNumber === null ? 'Unscheduled' : `Week ${group.weekNumber}`;
-      const shortLabel = group.weekNumber === null ? '–' : `W${group.weekNumber}`;
+      // A break's own label can be any length, so the band always says 'Break' and the tooltip
+      // carries the real name.
+      const label = group.teachingBreak
+        ? 'Break'
+        : group.weekNumber === null
+          ? 'Unscheduled'
+          : `Week ${group.weekNumber}`;
+      const shortLabel = group.teachingBreak
+        ? 'Break'
+        : group.weekNumber === null
+          ? '–'
+          : `W${group.weekNumber}`;
       const startDate = formatSnapshotLabel(
         this.unit,
         this.snapshots[group.startIndex]?.snapshot_date,
       );
       const endDate = formatSnapshotLabel(this.unit, this.snapshots[group.endIndex]?.snapshot_date);
       const range = startDate === endDate ? startDate : `${startDate} – ${endDate}`;
+      const tooltip = group.teachingBreak
+        ? [group.teachingBreak.label || 'Break', range, this.breakCampuses(group.teachingBreak)]
+            .filter((part) => part)
+            .join(' · ')
+        : `${label} · ${range}`;
 
       return {
-        key: `${label}-${group.startIndex}`,
+        key: `${group.key}-${group.startIndex}`,
+        isBreak: group.teachingBreak !== null,
         label,
         shortLabel,
         text: label,
-        tooltip: `${label} · ${range}`,
+        tooltip,
         startIndex: group.startIndex,
         endIndex: group.endIndex,
         startFraction,

--- a/src/app/units/states/analytics/directives/charts/normalised-task-status-chart/normalised-task-status-chart.component.ts
+++ b/src/app/units/states/analytics/directives/charts/normalised-task-status-chart/normalised-task-status-chart.component.ts
@@ -12,7 +12,12 @@ import {
   ViewContainerRef,
 } from '@angular/core';
 import {filter, map, take} from 'rxjs/operators';
-import {TaskCodeStats, TaskCompletionSnapshot} from 'src/app/api/models/doubtfire-model';
+import {addDays, startOfDay} from 'src/app/api/models/calendar-day';
+import {
+  CampusStats,
+  TaskCodeStats,
+  TaskCompletionSnapshot,
+} from 'src/app/api/models/doubtfire-model';
 import {SidekiqJob} from 'src/app/api/models/sidekiq-job';
 import {TeachingPeriodBreak} from 'src/app/api/models/teaching-period';
 import {Unit} from 'src/app/api/models/unit';
@@ -66,8 +71,7 @@ const FULL_LABEL_MIN_WIDTH = 56;
 const SHORT_LABEL_MIN_WIDTH = 28;
 // Beyond this many snapshots the slider's tick marks merge into a solid line, so they are hidden.
 const MAX_TICK_MARKS = 40;
-// Week 0 starts mid-week and the current week is only days old, so both are widened to stay readable.
-const MIN_EDGE_SEGMENT_WIDTH = 60;
+const DAYS_PER_WEEK = 7;
 // A one week break is only a few dozen pixels wide, so its name is truncated rather
 // than hidden. Below this even an ellipsis is noise, and the tooltip has to carry it.
 const BREAK_LABEL_MIN_WIDTH = 24;
@@ -153,7 +157,7 @@ export class NormalisedTaskStatusChartComponent implements OnInit, OnDestroy {
   }
 
   get snapshotStudentCount(): number {
-    if (!this.selectedSnapshot) {
+    if (!this.selectedSnapshot || this.selectedSnapshot.placeholder) {
       return 0;
     }
 
@@ -224,7 +228,9 @@ export class NormalisedTaskStatusChartComponent implements OnInit, OnDestroy {
     this.campuses = Object.keys(selectedSnapshot.stats);
 
     this.data = this.buildChartData(getTaskStats(selectedSnapshot, this.campusFilter));
-    this.hasChartData = this.data.length > 0;
+    // Padded week 0 days carry no stats - show the chart empty rather than falling back
+    // to the loading spinner.
+    this.hasChartData = this.snapshots.length > 0;
   }
 
   /**
@@ -256,7 +262,9 @@ export class NormalisedTaskStatusChartComponent implements OnInit, OnDestroy {
     const widths = this.weekSegments.map(
       (segment) => (segment.endFraction - segment.startFraction) * usableWidth,
     );
-    // Format comes from the natural widths, so widening an edge week cannot flip the whole band.
+
+    // Every segment is sized by the days it covers, so a full week is always the same
+    // width as any other. Label format comes from the narrowest of them.
     const sorted = [...widths].sort((left, right) => left - right);
     const medianWidth = sorted[Math.floor(sorted.length / 2)];
     const narrowestSegment = Math.min(...sorted.filter((width) => width >= medianWidth / 2));
@@ -264,9 +272,14 @@ export class NormalisedTaskStatusChartComponent implements OnInit, OnDestroy {
     const useFullLabels = narrowestSegment >= FULL_LABEL_MIN_WIDTH;
     const requiredWidth = useFullLabels ? FULL_LABEL_MIN_WIDTH : SHORT_LABEL_MIN_WIDTH;
 
-    this.widenEdgeSegments(widths, usableWidth, requiredWidth);
+    this.weekBoundaries = this.weekSegments.map(
+      (segment) => TICK_MARK_OFFSET + segment.startFraction * usableWidth,
+    );
+    this.weekBoundaries.push(TICK_MARK_OFFSET + usableWidth);
 
     this.weekSegments.forEach((segment, index) => {
+      segment.leftStyle = offsetStyle(segment.startFraction);
+      segment.widthStyle = spanStyle(segment.endFraction - segment.startFraction);
       segment.text =
         widths[index] < requiredWidth ? '' : useFullLabels ? segment.label : segment.shortLabel;
     });
@@ -275,8 +288,8 @@ export class NormalisedTaskStatusChartComponent implements OnInit, OnDestroy {
   }
 
   /**
-   * Break pills are laid out against the week band's final geometry rather than
-   * the raw fractions, so a widened edge week cannot push them out of step.
+   * Break pills are laid out against the week band's own geometry, so the two bands
+   * always share boundaries.
    */
   private updateBreakBand(): void {
     this.breakSegments.forEach((segment) => {
@@ -319,57 +332,6 @@ export class NormalisedTaskStatusChartComponent implements OnInit, OnDestroy {
     const right = this.weekBoundaries[index + 1];
 
     return left + Math.min(Math.max(ratio, 0), 1) * (right - left);
-  }
-
-  private widenEdgeSegments(widths: number[], usableWidth: number, requiredWidth: number): void {
-    this.weekSegments.forEach((segment) => {
-      segment.leftStyle = offsetStyle(segment.startFraction);
-      segment.widthStyle = spanStyle(segment.endFraction - segment.startFraction);
-    });
-
-    const boundaries = this.weekSegments.map(
-      (segment) => TICK_MARK_OFFSET + segment.startFraction * usableWidth,
-    );
-    boundaries.push(TICK_MARK_OFFSET + usableWidth);
-    // Widening below adjusts this same array in place, so the break band always
-    // reads the final geometry.
-    this.weekBoundaries = boundaries;
-
-    const lastIndex = this.weekSegments.length - 1;
-    if (lastIndex < 0) {
-      return;
-    }
-
-    const minimum = Math.min(MIN_EDGE_SEGMENT_WIDTH, usableWidth);
-    const widenLeading = widths[0] < minimum;
-    const widenTrailing = lastIndex > 0 && widths[lastIndex] < minimum;
-    if (!widenLeading && !widenTrailing) {
-      return;
-    }
-
-    const spareOf = (index: number) => Math.max((widths[index] ?? 0) - requiredWidth, 0);
-
-    if (widenLeading) {
-      boundaries[1] = boundaries[0] + Math.min(minimum, widths[0] + spareOf(1));
-    }
-    if (widenTrailing) {
-      boundaries[lastIndex] =
-        boundaries[lastIndex + 1] - Math.min(minimum, widths[lastIndex] + spareOf(lastIndex - 1));
-    }
-
-    for (let index = 1; index <= lastIndex; index += 1) {
-      boundaries[index] = Math.min(
-        Math.max(boundaries[index], boundaries[index - 1]),
-        boundaries[lastIndex + 1],
-      );
-    }
-
-    this.weekSegments.forEach((segment, index) => {
-      const width = boundaries[index + 1] - boundaries[index];
-      segment.leftStyle = `${boundaries[index]}px`;
-      segment.widthStyle = `${width}px`;
-      widths[index] = width;
-    });
   }
 
   segmentClasses(segment: SnapshotWeekSegment): string {
@@ -572,6 +534,75 @@ export class NormalisedTaskStatusChartComponent implements OnInit, OnDestroy {
     return start === end ? start : `${start} – ${end}`;
   }
 
+  /**
+   * Week 0 holds whatever came before the teaching period started, so it is usually a
+   * few days rather than a full week and renders as a stub beside the other segments.
+   * Pad the front with blank days so it takes a full week's width, and always leave at
+   * least one blank day at the very start so the beginning of the data is visible.
+   *
+   * Only applies when there is a week 0 to begin with - a unit whose stats start on or
+   * after week 1 is left alone.
+   */
+  private padWeekZero(snapshots: TaskCompletionSnapshot[]): TaskCompletionSnapshot[] {
+    const firstDay = startOfDay(snapshots[0]?.snapshot_date);
+    if (!firstDay) {
+      return snapshots;
+    }
+
+    const weekZeroDays = snapshots.filter(
+      (snapshot) => displayWeekNumber(this.unit, new Date(snapshot.snapshot_date)) === 0,
+    ).length;
+
+    if (weekZeroDays === 0) {
+      return snapshots;
+    }
+
+    const blankDays = Math.max(DAYS_PER_WEEK - weekZeroDays, 1);
+    const stats = this.notStartedStats(snapshots[0]);
+    const padding: TaskCompletionSnapshot[] = [];
+
+    for (let offset = blankDays; offset > 0; offset -= 1) {
+      const day = addDays(firstDay, -offset);
+      padding.push({
+        snapshot_date: day.toISOString().slice(0, 10),
+        snapshot_timestamp: `${Math.floor(day.getTime() / 1000)}`,
+        stats,
+        placeholder: true,
+      });
+    }
+
+    return [...padding, ...snapshots];
+  }
+
+  /**
+   * Stats for a filler day: every task sitting at not started, so the bars read as a
+   * full column of 'not started' rather than the chart blanking out.
+   *
+   * The campus keys are copied from a real snapshot, because the campus filter is built
+   * from whichever snapshot is selected - a filler day has to offer the same choices.
+   */
+  private notStartedStats(reference: TaskCompletionSnapshot): CampusStats {
+    const taskCodes: Set<string> = new Set();
+    Object.values(reference.stats).forEach((tutorials) =>
+      Object.values(tutorials).forEach((taskStats) =>
+        Object.keys(taskStats).forEach((taskCode) => taskCodes.add(taskCode)),
+      ),
+    );
+
+    const notStarted: TaskCodeStats = {};
+    taskCodes.forEach((taskCode) => (notStarted[taskCode] = {not_started: 1}));
+
+    const stats: CampusStats = {};
+    Object.entries(reference.stats).forEach(([campus, tutorials]) => {
+      const tutorialCode = Object.keys(tutorials)[0];
+      if (tutorialCode) {
+        stats[campus] = {[tutorialCode]: notStarted};
+      }
+    });
+
+    return stats;
+  }
+
   private buildChartData(taskStats: TaskCodeStats): MultiSeries {
     const taskSeqByCode = new Map(
       this.unit.taskDefinitions.map((taskDefinition) => [
@@ -640,7 +671,7 @@ export class NormalisedTaskStatusChartComponent implements OnInit, OnDestroy {
             return acc;
           }, [] as TaskCompletionSnapshot[])
           .filter((snapshot) => shouldIncludeSnapshot(this.unit, snapshot));
-        this.snapshots = dropLeadingEmptySnapshots([...this.snapshots].reverse());
+        this.snapshots = this.padWeekZero(dropLeadingEmptySnapshots([...this.snapshots].reverse()));
         this.sliderSelect = Math.max(this.snapshots.length - 1, 0);
         this.buildWeekSegments();
         this.refreshData();

--- a/src/app/units/states/analytics/directives/charts/normalised-task-status-chart/normalised-task-status-chart.component.ts
+++ b/src/app/units/states/analytics/directives/charts/normalised-task-status-chart/normalised-task-status-chart.component.ts
@@ -207,12 +207,15 @@ export class NormalisedTaskStatusChartComponent implements OnInit, OnDestroy {
     this.resizeObserver?.disconnect();
   }
 
+  /**
+   * Rebuild the bars for the selected snapshot. This runs on every slider tick, so
+   * it must only touch the one snapshot the slider is pointing at.
+   */
   refreshData() {
     const selectedSnapshot = this.selectedSnapshot;
 
     if (!selectedSnapshot) {
       this.data = [];
-      this.weeklyData = [];
       this.campuses = [];
       this.hasChartData = false;
       return;
@@ -221,8 +224,20 @@ export class NormalisedTaskStatusChartComponent implements OnInit, OnDestroy {
     this.campuses = Object.keys(selectedSnapshot.stats);
 
     this.data = this.buildChartData(getTaskStats(selectedSnapshot, this.campusFilter));
-    this.weeklyData = this.buildWeeklyChartData(this.snapshots);
     this.hasChartData = this.data.length > 0;
+  }
+
+  /**
+   * The weekly series covers every snapshot, so it only changes when the snapshots or
+   * the campus filter do - never when the slider moves.
+   */
+  private refreshWeeklyData(): void {
+    this.weeklyData = this.selectedSnapshot ? this.buildWeeklyChartData(this.snapshots) : [];
+  }
+
+  onCampusFilterChange(): void {
+    this.refreshData();
+    this.refreshWeeklyData();
   }
 
   onSnapshotSliderChange(value: number): void {
@@ -589,21 +604,21 @@ export class NormalisedTaskStatusChartComponent implements OnInit, OnDestroy {
       }
     });
 
-    const snapshotsByWeek = [...lastSnapshotByWeek.values()];
+    // Aggregate each week's snapshot once, rather than once per status series.
+    const weeks = [...lastSnapshotByWeek.entries()].map(([name, snapshot]) => ({
+      name,
+      taskStats: getTaskStats(snapshot, this.campusFilter),
+    }));
+
     return statusMapping.map((status) => ({
       name: this.taskService.statusLabels.get(status) || status,
-      series: snapshotsByWeek.map((snapshot) => {
-        const taskStats = getTaskStats(snapshot, this.campusFilter);
-        const value = Object.values(taskStats).reduce(
+      series: weeks.map((week) => ({
+        name: week.name,
+        value: Object.values(week.taskStats).reduce(
           (total, taskCounts) => total + (taskCounts[status] || 0),
           0,
-        );
-
-        return {
-          name: formatSnapshotLabel(this.unit, snapshot.snapshot_date, 'short'),
-          value,
-        };
-      }),
+        ),
+      })),
     }));
   }
 
@@ -629,6 +644,7 @@ export class NormalisedTaskStatusChartComponent implements OnInit, OnDestroy {
         this.sliderSelect = Math.max(this.snapshots.length - 1, 0);
         this.buildWeekSegments();
         this.refreshData();
+        this.refreshWeeklyData();
         this.changeDetectorRef.detectChanges();
 
         if (this.snapshots.length === 0 && !this.autoCaptureAttempted) {

--- a/src/app/units/states/analytics/directives/charts/normalised-task-status-chart/normalised-task-status-chart.component.ts
+++ b/src/app/units/states/analytics/directives/charts/normalised-task-status-chart/normalised-task-status-chart.component.ts
@@ -604,17 +604,23 @@ export class NormalisedTaskStatusChartComponent implements OnInit, OnDestroy {
   }
 
   private buildChartData(taskStats: TaskCodeStats): MultiSeries {
-    const taskSeqByCode = new Map(
+    const orderByCode = new Map(
       this.unit.taskDefinitions.map((taskDefinition) => [
         taskDefinition.abbreviation,
-        taskDefinition.seq,
+        {
+          target: taskDefinition.targetDate?.valueOf() ?? Number.MAX_SAFE_INTEGER,
+          seq: taskDefinition.seq,
+        },
       ]),
     );
+    // A task definition that has since been removed still shows up in older snapshots.
+    const unknown = {target: Number.MAX_SAFE_INTEGER, seq: Number.MAX_SAFE_INTEGER};
+
     return Object.entries(taskStats)
       .sort(([taskCodeA], [taskCodeB]) => {
-        const seqA = taskSeqByCode.get(taskCodeA) ?? Number.MAX_SAFE_INTEGER;
-        const seqB = taskSeqByCode.get(taskCodeB) ?? Number.MAX_SAFE_INTEGER;
-        return seqA - seqB;
+        const a = orderByCode.get(taskCodeA) ?? unknown;
+        const b = orderByCode.get(taskCodeB) ?? unknown;
+        return a.target - b.target || a.seq - b.seq;
       })
       .map(([taskDef, counts]) => ({
         name: taskDef,


### PR DESCRIPTION
- Highlights the week currently being viewed
- Trims off empty snapshots from the start

todo:
- API: aggregate the json after capturing the latest snapshots so we're not crunching the numbers on every fetch