### PR TITLE
fix: restore bottom padding on task description card

### DIFF
--- a/src/app/projects/states/dashboard/directives/task-dashboard/directives/task-description-card/task-description-card.component.html
+++ b/src/app/projects/states/dashboard/directives/task-dashboard/directives/task-description-card/task-description-card.component.html
@@ -44,26 +44,32 @@
       }
     </ul>
   </mat-card-content>
-  <mat-card-actions
-    class="space-x-1"
-    [hidden]="!(taskDef?.hasTaskSheet || taskDef?.hasTaskResources)"
-  >
-    <!-- <button mat-stroked-button [hidden]="!taskDef?.hasTaskSheet" (click)="viewTaskSheet()">
+  @if (taskDef?.hasTaskSheet || taskDef?.hasTaskResources) {
+    <mat-card-actions class="space-x-1">
+      <!-- <button mat-stroked-button [hidden]="!taskDef?.hasTaskSheet" (click)="viewTaskSheet()">
       <mat-icon style="width: 20px; height: 20px; font-size: 20px" aria-label="View icon"
         >description</mat-icon
       >
       Task Sheet
     </button> -->
-    <button mat-stroked-button [hidden]="!taskDef?.hasTaskSheet" (click)="downloadTaskSheet()">
-      <mat-icon aria-label="Download icon" style="width: 20px; height: 20px; font-size: 20px"
-        >download</mat-icon
+      <button mat-stroked-button [hidden]="!taskDef?.hasTaskSheet" (click)="downloadTaskSheet()">
+        <mat-icon aria-label="Download icon" style="width: 20px; height: 20px; font-size: 20px"
+          >download</mat-icon
+        >
+        Task Sheet
+      </button>
+      <button
+        mat-stroked-button
+        [hidden]="!taskDef?.hasTaskResources"
+        (click)="downloadResources()"
       >
-      Task Sheet
-    </button>
-    <button mat-stroked-button [hidden]="!taskDef?.hasTaskResources" (click)="downloadResources()">
-      <mat-icon aria-label="Download icon" inline style="width: 20px; height: 20px; font-size: 20px"
-        >download</mat-icon
-      ><span>Resources</span>
-    </button>
-  </mat-card-actions>
+        <mat-icon
+          aria-label="Download icon"
+          inline
+          style="width: 20px; height: 20px; font-size: 20px"
+          >download</mat-icon
+        ><span>Resources</span>
+      </button>
+    </mat-card-actions>
+  }
 </mat-card>


### PR DESCRIPTION
# Description

Angular Material only applies bottom padding to mat-card-content when it is the last child of the card. The mat-card-actions row was hidden with [hidden] when a task had no task sheet or resources, but it stayed in the DOM. So mat-card-content was never the last child, and the card content sat almost flush against the bottom edge of the card.

Replace the [hidden] binding with an @if block, so the actions row is not rendered when there is nothing to download. mat-card-content is then the last child and gets its normal bottom padding.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Go to a route like `/projects/19/dashboard/A1` and check the task description card. Ensure that there is no task sheet or resources for the task.

<img width="463" height="249" alt="Screenshot 2026-09-11 at 5 38 31 pm" src="https://github.com/user-attachments/assets/89299eb7-5b37-4cb3-89c6-4598025c7d69" />

## Testing Checklist:

- [ ] Tested in latest Chrome
- [ ] Tested in latest Safari
- [x] Tested in latest Firefox

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have formatted my changes with `npm run format`
- [x] I have run `npm run lint` with no errors
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have requested a review from @macite and @jakerenzella on the Pull Request
